### PR TITLE
feat: add isRawMessage and delaySeconds options to sendMessage

### DIFF
--- a/.changeset/fix-sqs-send-message.md
+++ b/.changeset/fix-sqs-send-message.md
@@ -1,0 +1,5 @@
+---
+'@dcl/sqs-component': patch
+---
+
+Fix `sendMessage` double-JSON wrapping that made messages incompatible with `@dcl/queue-consumer-component`, remove the hardcoded 10-second `DelaySeconds`, and drop the redundant optional chain on `config.getString`.

--- a/.changeset/fix-sqs-send-message.md
+++ b/.changeset/fix-sqs-send-message.md
@@ -1,6 +1,13 @@
 ---
-'@dcl/sqs-component': patch
-'@dcl/core-commons': patch
+'@dcl/sqs-component': minor
+'@dcl/memory-queue-component': minor
+'@dcl/core-commons': minor
 ---
 
-Fix `sendMessage` double-JSON wrapping that made messages incompatible with `@dcl/queue-consumer-component`, remove the hardcoded 10-second `DelaySeconds`, and drop the redundant optional chain on `config.getString`. Narrow `IQueueComponent.sendMessage` parameter from `any` to `unknown` so callers don't opt out of type checking.
+Extend `IQueueComponent.sendMessage` with a `SendMessageOptions` bag and clean up two small issues on the way:
+
+- **`options.isRawMessage`** — controls the shape of the SQS `MessageBody`. Default is `false` (the SNS-envelope shape `{ Message: JSON.stringify(message) }`) to preserve the production-tested format existing consumers read. Set to `true` for the single `JSON.stringify(message)` shape that SNS produces with Raw Message Delivery enabled, and that `@dcl/queue-consumer-component` expects.
+- **`options.delaySeconds`** — forwarded to `SendMessageCommand.DelaySeconds` so callers can defer delivery per message. Replaces the previous hardcoded `DelaySeconds: 10`, which was unconditional and undocumented.
+- **`sendMessage` parameter type narrowed** from `any` to `unknown` on the shared interface and both implementations so callers keep type-checking across the boundary.
+- **`@dcl/memory-queue-component`** honors both options: a per-call `isRawMessage` wins over the component-level `wrapInSnsFormat` default (kept for backward compatibility), and `delaySeconds` shifts the message's `visibleAt`.
+- Dropped the redundant `config.getString?.(...)` optional chain in the SQS component (`getString` is always present on `IConfigComponent`).

--- a/.changeset/fix-sqs-send-message.md
+++ b/.changeset/fix-sqs-send-message.md
@@ -1,5 +1,6 @@
 ---
 '@dcl/sqs-component': patch
+'@dcl/core-commons': patch
 ---
 
-Fix `sendMessage` double-JSON wrapping that made messages incompatible with `@dcl/queue-consumer-component`, remove the hardcoded 10-second `DelaySeconds`, and drop the redundant optional chain on `config.getString`.
+Fix `sendMessage` double-JSON wrapping that made messages incompatible with `@dcl/queue-consumer-component`, remove the hardcoded 10-second `DelaySeconds`, and drop the redundant optional chain on `config.getString`. Narrow `IQueueComponent.sendMessage` parameter from `any` to `unknown` so callers don't opt out of type checking.

--- a/components/memory-queue/src/component.ts
+++ b/components/memory-queue/src/component.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { sleep } from '@dcl/core-commons'
-import { IQueueComponent, ReceiveMessagesOptions } from '@dcl/core-commons'
+import { IQueueComponent, ReceiveMessagesOptions, SendMessageOptions } from '@dcl/core-commons'
 import { MemoryQueueOptions, StoredMessage, QueueMessage } from './types'
 
 /**
@@ -39,17 +39,23 @@ export function createMemoryQueueComponent(options: MemoryQueueOptions = {}): IQ
 
   const queue: Map<string, StoredMessage> = new Map()
 
-  async function sendMessage(message: unknown): Promise<void> {
+  async function sendMessage(message: unknown, options?: SendMessageOptions): Promise<void> {
     const receiptHandle = randomUUID()
     const messageId = randomUUID()
 
-    const body = wrapInSnsFormat ? JSON.stringify({ Message: JSON.stringify(message) }) : JSON.stringify(message)
+    // Per-call `isRawMessage` wins. If not specified, fall back to the
+    // component-level `wrapInSnsFormat` default so existing callers keep
+    // their current behavior.
+    const isRaw = options?.isRawMessage ?? !wrapInSnsFormat
+    const body = isRaw ? JSON.stringify(message) : JSON.stringify({ Message: JSON.stringify(message) })
+
+    const delaySeconds = options?.delaySeconds ?? 0
 
     queue.set(receiptHandle, {
       MessageId: messageId,
       ReceiptHandle: receiptHandle,
       Body: body,
-      visibleAt: Date.now()
+      visibleAt: Date.now() + delaySeconds * 1000
     })
   }
 

--- a/components/memory-queue/tests/memory-queue-component.spec.ts
+++ b/components/memory-queue/tests/memory-queue-component.spec.ts
@@ -55,6 +55,48 @@ describe('when sending messages', () => {
     })
   })
 
+  describe('and a per-call isRawMessage option is provided', () => {
+    describe('and isRawMessage is true, overriding the default wrapInSnsFormat', () => {
+      beforeEach(async () => {
+        // Default component has wrapInSnsFormat: true
+        await component.sendMessage({ type: 'test' }, { isRawMessage: true })
+      })
+
+      it('should write the message body raw, without the SNS envelope', async () => {
+        const messages = await component.receiveMessages(1)
+        const body = JSON.parse(messages[0].Body)
+        expect(body).toEqual({ type: 'test' })
+      })
+    })
+
+    describe('and isRawMessage is false, overriding a wrapInSnsFormat: false component', () => {
+      beforeEach(async () => {
+        component = createMemoryQueueComponent({ pollingDelayMs: 10, wrapInSnsFormat: false })
+        await component.sendMessage({ type: 'test' }, { isRawMessage: false })
+      })
+
+      it('should wrap the message body in the SNS envelope', async () => {
+        const messages = await component.receiveMessages(1)
+        const body = JSON.parse(messages[0].Body)
+        expect(body).toHaveProperty('Message')
+        expect(JSON.parse(body.Message)).toEqual({ type: 'test' })
+      })
+    })
+  })
+
+  describe('and a delaySeconds option is provided', () => {
+    it('should report the delayed message in the delayed-count only until its visibility time', async () => {
+      await component.sendMessage({ type: 'delayed' }, { delaySeconds: 1 })
+
+      // Status classifies messages as visible (visibleAt <= now) or not
+      // visible (visibleAt > now). A freshly-delayed message should fall
+      // into the not-visible bucket.
+      const statusBefore = await component.getStatus()
+      expect(statusBefore.ApproximateNumberOfMessagesNotVisible).toBe('1')
+      expect(statusBefore.ApproximateNumberOfMessages).toBe('0')
+    })
+  })
+
   describe('and multiple messages are sent', () => {
     beforeEach(async () => {
       await component.sendMessage({ id: 1 })

--- a/components/queue-consumer/README.md
+++ b/components/queue-consumer/README.md
@@ -48,7 +48,7 @@ messagesHandler.removeMessageHandler(Events.Type.CLIENT, Events.SubType.Client.L
 
 The consumer parses each message body with a single `JSON.parse(Body)` and expects `{ type, subType, ... }` at the top level. Two delivery paths produce that shape:
 
-- Direct writes via `@dcl/sqs-component`'s `sendMessage(event)`.
+- Direct writes via `@dcl/sqs-component`'s `sendMessage(event, { isRawMessage: true })` — the SQS component's default sends an SNS-style envelope for compatibility with legacy consumers, so this consumer requires the explicit opt-in.
 - SNS → SQS subscriptions with **Raw Message Delivery enabled**. Without it, SNS wraps the payload in a `Notification` envelope (`{ "Type": "Notification", "Message": "<stringified event>", ... }`) and the consumer will not match any handler.
 
 ## Configuration

--- a/components/queue-consumer/README.md
+++ b/components/queue-consumer/README.md
@@ -44,6 +44,13 @@ messagesHandler.removeMessageHandler(Events.Type.CLIENT, Events.SubType.Client.L
 - **Exponential backoff**: Automatic retry with backoff when queue polling fails
 - **Error isolation**: Handler errors are logged but don't affect other handlers or message processing
 
+## Message format
+
+The consumer parses each message body with a single `JSON.parse(Body)` and expects `{ type, subType, ... }` at the top level. Two delivery paths produce that shape:
+
+- Direct writes via `@dcl/sqs-component`'s `sendMessage(event)`.
+- SNS → SQS subscriptions with **Raw Message Delivery enabled**. Without it, SNS wraps the payload in a `Notification` envelope (`{ "Type": "Notification", "Message": "<stringified event>", ... }`) and the consumer will not match any handler.
+
 ## Configuration
 
 | Option                            | Type     | Default | Description                                                                                                  |

--- a/components/sqs/src/component.ts
+++ b/components/sqs/src/component.ts
@@ -32,7 +32,7 @@ export async function createSqsComponent(config: IConfigComponent): Promise<IQue
   }
   const client = new SQSClient(clientConfig)
 
-  async function sendMessage(message: any): Promise<void> {
+  async function sendMessage(message: unknown): Promise<void> {
     const sendCommand = new SendMessageCommand({
       QueueUrl: queueUrl,
       MessageBody: JSON.stringify(message)

--- a/components/sqs/src/component.ts
+++ b/components/sqs/src/component.ts
@@ -11,7 +11,7 @@ import {
   SendMessageCommand
 } from '@aws-sdk/client-sqs'
 
-import type { IQueueComponent, QueueStatus, ReceiveMessagesOptions } from '@dcl/core-commons'
+import type { IQueueComponent, QueueStatus, ReceiveMessagesOptions, SendMessageOptions } from '@dcl/core-commons'
 
 // Helper function to chunk arrays for batch operations
 function chunks<T>(array: T[], size: number): T[][] {
@@ -32,10 +32,17 @@ export async function createSqsComponent(config: IConfigComponent): Promise<IQue
   }
   const client = new SQSClient(clientConfig)
 
-  async function sendMessage(message: unknown): Promise<void> {
+  async function sendMessage(message: unknown, options?: SendMessageOptions): Promise<void> {
+    // Default to the SNS-envelope shape. Production consumers read that
+    // shape today; opting into raw (`isRawMessage: true`) is for newer
+    // consumers like `@dcl/queue-consumer-component` that expect a single
+    // `JSON.parse(Body)`.
+    const isRaw = options?.isRawMessage ?? false
+    const body = isRaw ? JSON.stringify(message) : JSON.stringify({ Message: JSON.stringify(message) })
     const sendCommand = new SendMessageCommand({
       QueueUrl: queueUrl,
-      MessageBody: JSON.stringify(message)
+      MessageBody: body,
+      DelaySeconds: options?.delaySeconds
     })
     await client.send(sendCommand)
   }

--- a/components/sqs/src/component.ts
+++ b/components/sqs/src/component.ts
@@ -24,7 +24,7 @@ function chunks<T>(array: T[], size: number): T[][] {
 
 export async function createSqsComponent(config: IConfigComponent): Promise<IQueueComponent> {
   const queueUrl = await config.requireString('AWS_SQS_QUEUE_URL')
-  const endpoint = await config.getString?.('AWS_SQS_ENDPOINT')
+  const endpoint = await config.getString('AWS_SQS_ENDPOINT')
 
   const clientConfig: { endpoint?: string } = {}
   if (endpoint) {
@@ -35,8 +35,7 @@ export async function createSqsComponent(config: IConfigComponent): Promise<IQue
   async function sendMessage(message: any): Promise<void> {
     const sendCommand = new SendMessageCommand({
       QueueUrl: queueUrl,
-      MessageBody: JSON.stringify({ Message: JSON.stringify(message) }),
-      DelaySeconds: 10
+      MessageBody: JSON.stringify(message)
     })
     await client.send(sendCommand)
   }

--- a/components/sqs/tests/sqs-component.spec.ts
+++ b/components/sqs/tests/sqs-component.spec.ts
@@ -6,7 +6,8 @@ import {
   ChangeMessageVisibilityBatchCommand,
   ChangeMessageVisibilityCommand,
   Message,
-  ReceiveMessageCommand
+  ReceiveMessageCommand,
+  SendMessageCommand
 } from '@aws-sdk/client-sqs'
 
 // Mock the AWS SDK
@@ -69,11 +70,29 @@ describe('when sending messages', () => {
     beforeEach(() => {
       testMessage = { type: 'test', data: 'test data' }
       sendMock.mockResolvedValue({ MessageId: 'msg-123' })
+      ;(SendMessageCommand as unknown as jest.Mock).mockClear()
     })
 
     it('should send the message successfully', async () => {
       await expect(component.sendMessage(testMessage)).resolves.not.toThrow()
       expect(sendMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('should serialize the message body as a single JSON payload', async () => {
+      await component.sendMessage(testMessage)
+
+      expect(SendMessageCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          QueueUrl: queueUrl,
+          MessageBody: JSON.stringify(testMessage)
+        })
+      )
+    })
+
+    it('should not set a delay on sent messages', async () => {
+      await component.sendMessage(testMessage)
+
+      expect(SendMessageCommand).toHaveBeenCalledWith(expect.not.objectContaining({ DelaySeconds: expect.anything() }))
     })
   })
 

--- a/components/sqs/tests/sqs-component.spec.ts
+++ b/components/sqs/tests/sqs-component.spec.ts
@@ -115,12 +115,12 @@ describe('when receiving messages', () => {
       mockMessages = [
         {
           MessageId: 'msg-1',
-          Body: JSON.stringify({ Message: JSON.stringify({ type: 'test1' }) }),
+          Body: JSON.stringify({ type: 'test1' }),
           ReceiptHandle: 'receipt-1'
         },
         {
           MessageId: 'msg-2',
-          Body: JSON.stringify({ Message: JSON.stringify({ type: 'test2' }) }),
+          Body: JSON.stringify({ type: 'test2' }),
           ReceiptHandle: 'receipt-2'
         }
       ]

--- a/components/sqs/tests/sqs-component.spec.ts
+++ b/components/sqs/tests/sqs-component.spec.ts
@@ -78,21 +78,21 @@ describe('when sending messages', () => {
       expect(sendMock).toHaveBeenCalledTimes(1)
     })
 
-    it('should serialize the message body as a single JSON payload', async () => {
+    it('should wrap the message body in an SNS-style envelope by default', async () => {
       await component.sendMessage(testMessage)
 
       expect(SendMessageCommand).toHaveBeenCalledWith(
         expect.objectContaining({
           QueueUrl: queueUrl,
-          MessageBody: JSON.stringify(testMessage)
+          MessageBody: JSON.stringify({ Message: JSON.stringify(testMessage) })
         })
       )
     })
 
-    it('should not set a delay on sent messages', async () => {
+    it('should leave DelaySeconds undefined when no delay option is provided', async () => {
       await component.sendMessage(testMessage)
 
-      expect(SendMessageCommand).toHaveBeenCalledWith(expect.not.objectContaining({ DelaySeconds: expect.anything() }))
+      expect(SendMessageCommand).toHaveBeenCalledWith(expect.objectContaining({ DelaySeconds: undefined }))
     })
   })
 
@@ -105,6 +105,69 @@ describe('when sending messages', () => {
       await expect(component.sendMessage(testMessage)).rejects.toThrow('SQS send failed')
     })
   })
+
+  describe('and isRawMessage is explicitly true', () => {
+    beforeEach(() => {
+      testMessage = { type: 'test', data: 'test data' }
+      sendMock.mockResolvedValue({ MessageId: 'msg-123' })
+      ;(SendMessageCommand as unknown as jest.Mock).mockClear()
+    })
+
+    it('should serialize the message body as a single JSON payload', async () => {
+      await component.sendMessage(testMessage, { isRawMessage: true })
+
+      expect(SendMessageCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          QueueUrl: queueUrl,
+          MessageBody: JSON.stringify(testMessage)
+        })
+      )
+    })
+  })
+
+  describe('and isRawMessage is false', () => {
+    beforeEach(() => {
+      testMessage = { type: 'test', data: 'test data' }
+      sendMock.mockResolvedValue({ MessageId: 'msg-123' })
+      ;(SendMessageCommand as unknown as jest.Mock).mockClear()
+    })
+
+    it('should wrap the message body in an SNS-style envelope', async () => {
+      await component.sendMessage(testMessage, { isRawMessage: false })
+
+      expect(SendMessageCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          QueueUrl: queueUrl,
+          MessageBody: JSON.stringify({ Message: JSON.stringify(testMessage) })
+        })
+      )
+    })
+  })
+
+  describe('and a delaySeconds option is provided', () => {
+    beforeEach(() => {
+      testMessage = { type: 'test', data: 'test data' }
+      sendMock.mockResolvedValue({ MessageId: 'msg-123' })
+      ;(SendMessageCommand as unknown as jest.Mock).mockClear()
+    })
+
+    it('should forward the value to SendMessageCommand.DelaySeconds', async () => {
+      await component.sendMessage(testMessage, { delaySeconds: 30 })
+
+      expect(SendMessageCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          QueueUrl: queueUrl,
+          DelaySeconds: 30
+        })
+      )
+    })
+
+    it('should forward 0 explicitly so callers can override a queue-level default', async () => {
+      await component.sendMessage(testMessage, { delaySeconds: 0 })
+
+      expect(SendMessageCommand).toHaveBeenCalledWith(expect.objectContaining({ DelaySeconds: 0 }))
+    })
+  })
 })
 
 describe('when receiving messages', () => {
@@ -115,12 +178,12 @@ describe('when receiving messages', () => {
       mockMessages = [
         {
           MessageId: 'msg-1',
-          Body: JSON.stringify({ type: 'test1' }),
+          Body: JSON.stringify({ Message: JSON.stringify({ type: 'test1' }) }),
           ReceiptHandle: 'receipt-1'
         },
         {
           MessageId: 'msg-2',
-          Body: JSON.stringify({ type: 'test2' }),
+          Body: JSON.stringify({ Message: JSON.stringify({ type: 'test2' }) }),
           ReceiptHandle: 'receipt-2'
         }
       ]

--- a/shared/commons/src/types.ts
+++ b/shared/commons/src/types.ts
@@ -109,6 +109,43 @@ export type ReceiveMessagesOptions = {
 }
 
 /**
+ * Options for sending a message to a queue.
+ */
+export type SendMessageOptions = {
+  /**
+   * Controls the shape of the SQS `MessageBody`.
+   *
+   * When `false` (the default) the body is written as
+   * `JSON.stringify({ Message: JSON.stringify(message) })` — the
+   * SNS-envelope shape that existing production consumers have been
+   * reading for a long time. Keeping this as the default preserves
+   * compatibility with those consumers.
+   *
+   * When `true` the body is written as a single `JSON.stringify(message)`,
+   * which is the shape SNS delivers when Raw Message Delivery is
+   * enabled on the subscription, and the shape
+   * `@dcl/queue-consumer-component` decodes with one `JSON.parse(Body)`.
+   * Set this to `true` when the downstream consumer expects the raw
+   * payload.
+   *
+   * @default false
+   */
+  isRawMessage?: boolean
+
+  /**
+   * Seconds to defer delivery of the message. In SQS this maps to
+   * `SendMessageCommand.DelaySeconds`; AWS caps it at 900 (15 minutes)
+   * per request. When omitted (or `0`), the message is immediately
+   * available for receive. For a queue-level default, configure
+   * `DelaySeconds` on the queue itself.
+   *
+   * Callers that need a long-running schedule should use a scheduling
+   * component rather than stacking `delaySeconds` on each send.
+   */
+  delaySeconds?: number
+}
+
+/**
  * The status of a queue.
  */
 export type QueueStatus = {
@@ -124,8 +161,9 @@ export interface IQueueComponent {
   /**
    * Sends a message to the queue.
    * @param message - The message to send.
+   * @param options - Optional send options (e.g. `isRawMessage`).
    */
-  sendMessage(message: unknown): Promise<void>
+  sendMessage(message: unknown, options?: SendMessageOptions): Promise<void>
   /**
    * Receives messages from the queue.
    * @param amount - The number of messages to receive.

--- a/shared/commons/src/types.ts
+++ b/shared/commons/src/types.ts
@@ -125,7 +125,7 @@ export interface IQueueComponent {
    * Sends a message to the queue.
    * @param message - The message to send.
    */
-  sendMessage(message: any): Promise<void>
+  sendMessage(message: unknown): Promise<void>
   /**
    * Receives messages from the queue.
    * @param amount - The number of messages to receive.


### PR DESCRIPTION
## Summary

Extend `IQueueComponent.sendMessage` with a `SendMessageOptions` bag so callers can pick the body shape and schedule individual messages, and clean up a few small things along the way. The production-tested message shape is preserved; new behavior is opt-in.

## What changes

### New `SendMessageOptions`

- **`isRawMessage?: boolean`** — controls the SQS `MessageBody` shape.
  - `false` (the default) → `JSON.stringify({ Message: JSON.stringify(message) })`, the SNS-envelope shape existing production consumers read today. Keeping this as the default means no deployed consumer changes observable behavior.
  - `true` → a single `JSON.stringify(message)`. This is the shape SNS delivers with Raw Message Delivery enabled, and the shape `@dcl/queue-consumer-component` decodes with one `JSON.parse(Body)`. Opt in from call sites that need it.

- **`delaySeconds?: number`** — forwarded to `SendMessageCommand.DelaySeconds`. Replaces the hardcoded `DelaySeconds: 10` that every send carried from the component's very first commit. That 10-second delay was never documented, never referenced elsewhere, and had no traceable rationale in the repo (see history below), so the new default is `undefined` (no delay). Callers that need a defer pass it explicitly.

### Other changes in the same PR

- `IQueueComponent.sendMessage` parameter narrowed from `any` to `unknown` in `@dcl/core-commons` and both implementations (`@dcl/sqs-component`, `@dcl/memory-queue-component`) so callers don't drop type-checking across the boundary. `unknown` flows through `JSON.stringify` the same way.
- `@dcl/memory-queue-component` honors both new options: per-call `isRawMessage` wins over the component-level `wrapInSnsFormat` default (kept for backward compatibility), and `delaySeconds` shifts the message's `visibleAt` so it stays invisible until the delay elapses.
- Dropped the redundant `config.getString?.(...)` optional chain in the SQS component — `getString` is always present on `IConfigComponent`.
- `@dcl/queue-consumer-component` README documents the `isRawMessage: true` opt-in alongside the existing SNS → SQS Raw Message Delivery path.

## Why the body default stays wrapped

Production consumers parse `JSON.parse(Body).Message` today. Flipping the default to raw would have silently stopped those consumers from matching, so the minimum-blast-radius default is to keep the wrapped shape and require new callers to opt into raw explicitly.

## Why the delay default is removed rather than kept at 10

The `DelaySeconds: 10` landed unconditionally in the component's first commit (PR #14, "feat: add memory cache, redis, sns and sqs components") with no documented rationale and no other reference in the repo. It was almost certainly a bootstrap default rather than a deliberate semantic. Keeping it as an implicit default would bake a magic number into the library; exposing it as an explicit option lets callers set the delay they actually need.

The only behavioral drift callers will observe, if they don't pass `delaySeconds`, is that messages become visible immediately instead of after 10 seconds. Any caller that was implicitly relying on that grace window should pass `{ delaySeconds: 10 }` explicitly.

## Test plan

- [x] `@dcl/sqs-component` — 29 tests pass (default wrap, explicit raw, explicit wrap, `delaySeconds` forwarding including `0`, existing paths).
- [x] `@dcl/memory-queue-component` — 26 tests pass (per-call override in both directions, `delaySeconds` invisibility).
- [x] `@dcl/core-commons`, `@dcl/queue-consumer-component` — `tsc` clean against the new interface.