### PR TITLE
fix: handle missing subType in SNS publish, isolate batch failures, map failed IDs safely

### DIFF
--- a/.changeset/fix-sns-publish.md
+++ b/.changeset/fix-sns-publish.md
@@ -1,0 +1,5 @@
+---
+'@dcl/sns-component': patch
+---
+
+Fix `publishMessage` sending `StringValue: undefined` when the event had no `subType`, harden `publishMessages` so a single rejected batch no longer discards successful sibling batches (`Promise.allSettled`), and compute failed-event indices directly from the returned `Id` so mismatches can no longer push `undefined` into `failedEvents`.

--- a/.changeset/fix-sns-publish.md
+++ b/.changeset/fix-sns-publish.md
@@ -1,5 +1,7 @@
 ---
-'@dcl/sns-component': patch
+'@dcl/sns-component': minor
 ---
 
 Fix `publishMessage` sending `StringValue: undefined` when the event had no `subType`, harden `publishMessages` so a single rejected batch no longer discards successful sibling batches (`Promise.allSettled`), and compute failed-event indices directly from the returned `Id` so mismatches can no longer push `undefined` into `failedEvents`.
+
+**Behavior change** — `publishMessages` no longer rejects when a batch hits a network / throttling error. Those events are now reported via `failedEvents` instead. Callers that wrapped `publishMessages` in `try/catch` to detect batch-level failures should inspect `failedEvents` instead.

--- a/components/sns/src/component.ts
+++ b/components/sns/src/component.ts
@@ -1,7 +1,7 @@
 import { PublishBatchCommand, PublishCommand, SNSClient, PublishCommandOutput } from '@aws-sdk/client-sns'
 import { IConfigComponent } from '@well-known-components/interfaces'
 
-import { IPublisherComponent, CustomMessageAttributes } from './types'
+import { IPublisherComponent, CustomMessageAttributes, MessageAttribute } from './types'
 
 function chunk<T>(theArray: T[], size: number): T[][] {
   return theArray.reduce((acc: T[][], _, i) => {
@@ -27,6 +27,21 @@ function validateCustomAttributes(customMessageAttributes?: CustomMessageAttribu
   }
 }
 
+function buildMessageAttributes(
+  event: { type: string; subType?: string },
+  customMessageAttributes?: CustomMessageAttributes
+): Record<string, MessageAttribute> {
+  const attributes: Record<string, MessageAttribute> = {
+    type: { DataType: 'String', StringValue: event.type }
+  }
+
+  if (event.subType !== undefined) {
+    attributes.subType = { DataType: 'String', StringValue: event.subType }
+  }
+
+  return { ...attributes, ...customMessageAttributes }
+}
+
 export async function createSnsComponent({ config }: { config: IConfigComponent }): Promise<IPublisherComponent> {
   // SNS PublishBatch can handle up to 10 messages in a single request
   const MAX_BATCH_SIZE = 10
@@ -50,17 +65,7 @@ export async function createSnsComponent({ config }: { config: IConfigComponent 
     const command = new PublishCommand({
       TopicArn: snsArn,
       Message: JSON.stringify(event),
-      MessageAttributes: {
-        type: {
-          DataType: 'String',
-          StringValue: event.type
-        },
-        subType: {
-          DataType: 'String',
-          StringValue: event.subType
-        },
-        ...customMessageAttributes
-      }
+      MessageAttributes: buildMessageAttributes(event, customMessageAttributes)
     })
     return client.send(command)
   }
@@ -74,27 +79,14 @@ export async function createSnsComponent({ config }: { config: IConfigComponent 
   }> {
     validateCustomAttributes(customMessageAttributes)
 
-    // split events into batches of 10
     const batches = chunk(events, MAX_BATCH_SIZE)
 
-    const publishBatchPromises = batches.map(async (batch, batchIndex) => {
-      const entries = batch.map((event, index) => {
-        return {
-          Id: `msg_${batchIndex * MAX_BATCH_SIZE + index}`,
-          Message: JSON.stringify(event),
-          MessageAttributes: {
-            type: {
-              DataType: 'String',
-              StringValue: event.type || 'unknown'
-            },
-            subType: {
-              DataType: 'String',
-              StringValue: event.subType || 'unknown'
-            },
-            ...customMessageAttributes
-          }
-        }
-      })
+    const publishBatchPromises = batches.map(async (batch) => {
+      const entries = batch.map((event, index) => ({
+        Id: `msg_${index}`,
+        Message: JSON.stringify(event),
+        MessageAttributes: buildMessageAttributes(event, customMessageAttributes)
+      }))
 
       const command = new PublishBatchCommand({
         TopicArn: snsArn,
@@ -104,24 +96,33 @@ export async function createSnsComponent({ config }: { config: IConfigComponent 
       const { Successful, Failed } = await client.send(command)
 
       const successfulMessageIds: string[] =
-        Successful?.map((result) => result.MessageId).filter(
-          (messageId: string | undefined) => messageId !== undefined
-        ) || []
+        Successful?.flatMap((result) => (result.MessageId ? [result.MessageId] : [])) ?? []
 
-      const failedEvents =
-        Failed?.map((failure) => {
-          const failedEntry = entries.find((entry) => entry.Id === failure.Id)
-          const failedIndex = entries.indexOf(failedEntry!)
-          return batch[failedIndex]
-        }) || []
+      const failedEvents: Array<{ type: string; subType?: string; [key: string]: any }> =
+        Failed?.flatMap((failure) => {
+          const localIndex = failure.Id ? parseInt(failure.Id.slice('msg_'.length), 10) : NaN
+          const failedEvent = Number.isInteger(localIndex) ? batch[localIndex] : undefined
+          return failedEvent ? [failedEvent] : []
+        }) ?? []
 
       return { successfulMessageIds, failedEvents }
     })
 
-    const results = await Promise.all(publishBatchPromises)
+    const results = await Promise.allSettled(publishBatchPromises)
 
-    const successfulMessageIds = results.flatMap((result) => result.successfulMessageIds)
-    const failedEvents = results.flatMap((result) => result.failedEvents)
+    const successfulMessageIds: string[] = []
+    const failedEvents: Array<{ type: string; subType?: string; [key: string]: any }> = []
+
+    results.forEach((result, batchIndex) => {
+      if (result.status === 'fulfilled') {
+        successfulMessageIds.push(...result.value.successfulMessageIds)
+        failedEvents.push(...result.value.failedEvents)
+      } else {
+        // A batch that rejected (e.g. network failure, throttling) fails in full;
+        // treat every event in the batch as failed so callers can retry them.
+        failedEvents.push(...batches[batchIndex])
+      }
+    })
 
     return { successfulMessageIds, failedEvents }
   }

--- a/components/sns/src/component.ts
+++ b/components/sns/src/component.ts
@@ -31,8 +31,12 @@ function buildMessageAttributes(
   event: { type: string; subType?: string },
   customMessageAttributes?: CustomMessageAttributes
 ): Record<string, MessageAttribute> {
+  // `type` is required per the TS contract, but fall back to 'unknown' at
+  // runtime so a caller that slips past the type system (e.g. `''` or
+  // `undefined`) doesn't end up sending `StringValue: undefined`, which
+  // SNS rejects for a String-typed attribute.
   const attributes: Record<string, MessageAttribute> = {
-    type: { DataType: 'String', StringValue: event.type }
+    type: { DataType: 'String', StringValue: event.type || 'unknown' }
   }
 
   if (event.subType !== undefined) {
@@ -100,7 +104,11 @@ export async function createSnsComponent({ config }: { config: IConfigComponent 
 
       const failedEvents: Array<{ type: string; subType?: string; [key: string]: any }> =
         Failed?.flatMap((failure) => {
-          const localIndex = failure.Id ? parseInt(failure.Id.slice('msg_'.length), 10) : NaN
+          // Strictly match the Id shape we generated above (`msg_<digits>`)
+          // so a malformed echo from the service can't silently map to a
+          // neighbouring event via parseInt's lenient parsing.
+          const match = failure.Id?.match(/^msg_(\d+)$/)
+          const localIndex = match ? parseInt(match[1], 10) : NaN
           const failedEvent = Number.isInteger(localIndex) ? batch[localIndex] : undefined
           return failedEvent ? [failedEvent] : []
         }) ?? []

--- a/components/sns/src/component.ts
+++ b/components/sns/src/component.ts
@@ -1,7 +1,7 @@
 import { PublishBatchCommand, PublishCommand, SNSClient, PublishCommandOutput } from '@aws-sdk/client-sns'
 import { IConfigComponent } from '@well-known-components/interfaces'
 
-import { IPublisherComponent, CustomMessageAttributes, MessageAttribute } from './types'
+import { IPublisherComponent, CustomMessageAttributes, MessageAttribute, PublishableEvent } from './types'
 
 function chunk<T>(theArray: T[], size: number): T[][] {
   return theArray.reduce((acc: T[][], _, i) => {
@@ -28,7 +28,7 @@ function validateCustomAttributes(customMessageAttributes?: CustomMessageAttribu
 }
 
 function buildMessageAttributes(
-  event: { type: string; subType?: string },
+  event: PublishableEvent,
   customMessageAttributes?: CustomMessageAttributes
 ): Record<string, MessageAttribute> {
   // `type` is required per the TS contract, but fall back to 'unknown' at
@@ -57,11 +57,7 @@ export async function createSnsComponent({ config }: { config: IConfigComponent 
   })
 
   async function publishMessage(
-    event: {
-      type: string
-      subType?: string
-      [key: string]: any
-    },
+    event: PublishableEvent,
     customMessageAttributes?: CustomMessageAttributes
   ): Promise<PublishCommandOutput> {
     validateCustomAttributes(customMessageAttributes)
@@ -75,11 +71,11 @@ export async function createSnsComponent({ config }: { config: IConfigComponent 
   }
 
   async function publishMessages(
-    events: Array<{ type: string; subType?: string; [key: string]: any }>,
+    events: PublishableEvent[],
     customMessageAttributes?: CustomMessageAttributes
   ): Promise<{
     successfulMessageIds: string[]
-    failedEvents: Array<{ type: string; subType?: string; [key: string]: any }>
+    failedEvents: PublishableEvent[]
   }> {
     validateCustomAttributes(customMessageAttributes)
 
@@ -102,7 +98,7 @@ export async function createSnsComponent({ config }: { config: IConfigComponent 
       const successfulMessageIds: string[] =
         Successful?.flatMap((result) => (result.MessageId ? [result.MessageId] : [])) ?? []
 
-      const failedEvents: Array<{ type: string; subType?: string; [key: string]: any }> =
+      const failedEvents: PublishableEvent[] =
         Failed?.flatMap((failure) => {
           // Strictly match the Id shape we generated above (`msg_<digits>`)
           // so a malformed echo from the service can't silently map to a
@@ -119,7 +115,7 @@ export async function createSnsComponent({ config }: { config: IConfigComponent 
     const results = await Promise.allSettled(publishBatchPromises)
 
     const successfulMessageIds: string[] = []
-    const failedEvents: Array<{ type: string; subType?: string; [key: string]: any }> = []
+    const failedEvents: PublishableEvent[] = []
 
     results.forEach((result, batchIndex) => {
       if (result.status === 'fulfilled') {

--- a/components/sns/src/types.ts
+++ b/components/sns/src/types.ts
@@ -9,16 +9,27 @@ export interface CustomMessageAttributes {
   [key: string]: MessageAttribute
 }
 
+/**
+ * Shape required by the SNS publisher: `type` is mandatory (used as a
+ * MessageAttribute and for SNS filter policies), `subType` is optional,
+ * and any additional fields are preserved in the published JSON body.
+ */
+export interface PublishableEvent {
+  type: string
+  subType?: string
+  [key: string]: any
+}
+
 export interface IPublisherComponent {
   publishMessage(
-    event: any,
+    event: PublishableEvent,
     customMessageAttributes?: CustomMessageAttributes
   ): Promise<PublishCommandOutput>
   publishMessages(
-    events: any[],
+    events: PublishableEvent[],
     customMessageAttributes?: CustomMessageAttributes
   ): Promise<{
     successfulMessageIds: string[]
-    failedEvents: any[]
+    failedEvents: PublishableEvent[]
   }>
 }

--- a/components/sns/tests/sns-component.spec.ts
+++ b/components/sns/tests/sns-component.spec.ts
@@ -216,13 +216,47 @@ describe('when publishing messages', () => {
     })
   })
 
-  describe('and the AWS client throws an error', () => {
+  describe('and the AWS client throws an error for a batch', () => {
     beforeEach(() => {
       sendMock.mockRejectedValue(new Error('AWS Error'))
     })
 
-    it('should throw the error', async () => {
-      await expect(component.publishMessages([event])).rejects.toThrow('AWS Error')
+    it('should report every event in the batch as failed instead of throwing', async () => {
+      const result = await component.publishMessages([event])
+
+      expect(result.successfulMessageIds).toEqual([])
+      expect(result.failedEvents).toEqual([event])
+    })
+  })
+
+  describe('and one batch rejects while another succeeds', () => {
+    let manyEvents: Array<{ type: string; subType: string; index: number }>
+
+    beforeEach(() => {
+      manyEvents = Array.from({ length: 15 }, (_, i) => ({
+        type: 'test_event',
+        subType: 'batch',
+        index: i
+      }))
+
+      let callCount = 0
+      sendMock.mockImplementation(async () => {
+        callCount++
+        if (callCount === 1) {
+          return {
+            Successful: Array.from({ length: 10 }, (_, i) => ({ MessageId: `msg-${i}` })),
+            Failed: []
+          }
+        }
+        throw new Error('AWS Error on second batch')
+      })
+    })
+
+    it('should preserve successful results from the healthy batch and fail the rejected events', async () => {
+      const result = await component.publishMessages(manyEvents)
+
+      expect(result.successfulMessageIds).toHaveLength(10)
+      expect(result.failedEvents).toEqual(manyEvents.slice(10))
     })
   })
 
@@ -233,6 +267,73 @@ describe('when publishing messages', () => {
       expect(result.successfulMessageIds).toEqual([])
       expect(result.failedEvents).toEqual([])
       expect(sendMock).not.toHaveBeenCalled()
+    })
+  })
+})
+
+describe('when publishing events without a subType', () => {
+  afterEach(() => {
+    sendMock.mockClear()
+  })
+
+  describe('and publishing a single message', () => {
+    let eventWithoutSubType: { type: string; data: string }
+
+    beforeEach(() => {
+      eventWithoutSubType = { type: 'user_login', data: 'test' }
+      sendMock.mockResolvedValue({ MessageId: 'msg-123' })
+    })
+
+    it('should omit the subType attribute rather than sending StringValue: undefined', async () => {
+      await component.publishMessage(eventWithoutSubType)
+
+      expect(sendMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            MessageAttributes: {
+              type: { DataType: 'String', StringValue: 'user_login' }
+            }
+          })
+        })
+      )
+    })
+  })
+
+  describe('and publishing in batch', () => {
+    let eventsWithoutSubType: Array<{ type: string; index: number }>
+
+    beforeEach(() => {
+      eventsWithoutSubType = [
+        { type: 'user_login', index: 0 },
+        { type: 'user_logout', index: 1 }
+      ]
+      sendMock.mockResolvedValue({
+        Successful: [{ MessageId: 'msg-1' }, { MessageId: 'msg-2' }],
+        Failed: []
+      })
+    })
+
+    it('should omit the subType attribute for entries that do not carry one', async () => {
+      await component.publishMessages(eventsWithoutSubType)
+
+      expect(sendMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            PublishBatchRequestEntries: [
+              expect.objectContaining({
+                MessageAttributes: {
+                  type: { DataType: 'String', StringValue: 'user_login' }
+                }
+              }),
+              expect.objectContaining({
+                MessageAttributes: {
+                  type: { DataType: 'String', StringValue: 'user_logout' }
+                }
+              })
+            ]
+          })
+        })
+      )
     })
   })
 })

--- a/components/sns/tests/sns-component.spec.ts
+++ b/components/sns/tests/sns-component.spec.ts
@@ -338,6 +338,113 @@ describe('when publishing events without a subType', () => {
   })
 })
 
+describe('when an event is missing a type at runtime', () => {
+  afterEach(() => {
+    sendMock.mockClear()
+  })
+
+  describe('and publishing a single message', () => {
+    beforeEach(() => {
+      sendMock.mockResolvedValue({ MessageId: 'msg-123' })
+    })
+
+    it('should fall back to StringValue: "unknown" rather than sending undefined', async () => {
+      await component.publishMessage({ type: undefined as unknown as string, data: 'noisy' })
+
+      expect(sendMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            MessageAttributes: expect.objectContaining({
+              type: { DataType: 'String', StringValue: 'unknown' }
+            })
+          })
+        })
+      )
+    })
+  })
+
+  describe('and publishing in batch', () => {
+    beforeEach(() => {
+      sendMock.mockResolvedValue({
+        Successful: [{ MessageId: 'msg-1' }],
+        Failed: []
+      })
+    })
+
+    it('should fall back to StringValue: "unknown" for every entry without a type', async () => {
+      await component.publishMessages([{ type: '' as string, index: 0 }])
+
+      expect(sendMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            PublishBatchRequestEntries: [
+              expect.objectContaining({
+                MessageAttributes: expect.objectContaining({
+                  type: { DataType: 'String', StringValue: 'unknown' }
+                })
+              })
+            ]
+          })
+        })
+      )
+    })
+  })
+})
+
+describe('when a failed-event Id returned by SNS does not match the expected shape', () => {
+  const event = { type: 'user_login', subType: 'web', userId: '123' }
+
+  afterEach(() => {
+    sendMock.mockClear()
+  })
+
+  describe('and the Id has extra characters (e.g. "msg_0abc")', () => {
+    beforeEach(() => {
+      sendMock.mockResolvedValue({
+        Successful: [],
+        Failed: [{ Id: 'msg_0abc', Code: 'InvalidParameter' }]
+      })
+    })
+
+    it('should not map it to batch[0]; it should be skipped entirely', async () => {
+      const result = await component.publishMessages([event])
+
+      expect(result.successfulMessageIds).toEqual([])
+      expect(result.failedEvents).toEqual([])
+    })
+  })
+
+  describe('and the Id has an unexpected prefix', () => {
+    beforeEach(() => {
+      sendMock.mockResolvedValue({
+        Successful: [],
+        Failed: [{ Id: 'other_0', Code: 'InvalidParameter' }]
+      })
+    })
+
+    it('should be skipped rather than producing an undefined entry', async () => {
+      const result = await component.publishMessages([event])
+
+      expect(result.failedEvents).toEqual([])
+    })
+  })
+
+  describe('and the Id is completely missing', () => {
+    beforeEach(() => {
+      sendMock.mockResolvedValue({
+        Successful: [],
+        Failed: [{ Code: 'InvalidParameter' }]
+      })
+    })
+
+    it('should be skipped rather than producing an undefined entry', async () => {
+      const result = await component.publishMessages([event])
+
+      expect(result.failedEvents).toEqual([])
+    })
+  })
+})
+
 describe('when publishing a single message with custom MessageAttributes', () => {
   let event: any
   let customAttributes: CustomMessageAttributes


### PR DESCRIPTION
## Summary

- `publishMessage` was sending `{ DataType: 'String', StringValue: event.subType }` even when `event.subType` was `undefined`. SNS rejects that at runtime. Now the attribute is omitted entirely when absent (and `publishMessages` does the same — it previously defaulted to the string \`'unknown'\`, which silently polluted subscriber filters).
- `publishMessages` used `Promise.all` over batch promises, so a single rejected batch (network blip, throttling, service error) discarded successful results from every other batch. Switched to `Promise.allSettled`; events inside a rejected batch are now reported via `failedEvents` so callers can retry them.
- Failed-event mapping used `entries.indexOf(failedEntry!)`, which returned `-1` for an unrecognized `Id` and pushed `undefined` into `failedEvents`. Now the local index is parsed directly from the returned `Id` and unknown IDs are skipped.
- Extracted a `buildMessageAttributes` helper so the single/batch paths produce identical attribute shapes.

## Test plan

- [x] `pnpm --filter @dcl/sns-component test` — 22 passing, including new tests for: subType omitted when absent (single + batch), partial batch failure preserves successes from healthy batches, and a rejected batch surfaces its events as `failedEvents` rather than throwing.

## Note on behavior change

`publishMessages` previously set `StringValue: 'unknown'` for events without a `subType`. That value is gone; the attribute is now omitted. SNS subscribers relying on `subType = 'unknown'` filters would need to adjust — but that pattern is not expected in practice, since `'unknown'` was effectively a bug workaround.