### PR TITLE
fix: correct Redis lock TTL unit, drop key lower-casing, harden lifecycle and locks

### DIFF
--- a/.changeset/fix-redis-lock-ttl-and-case.md
+++ b/.changeset/fix-redis-lock-ttl-and-case.md
@@ -1,0 +1,9 @@
+---
+'@dcl/redis-component': major
+---
+
+Fix `acquireLock` using `EX` (seconds) for a value in milliseconds — the default 10-second lock was actually being set to 10 000 seconds (~2.7 hours). Now uses `PX` so the unit matches the `ttlInMilliseconds` option.
+
+**Breaking** — all methods now preserve the key's original case instead of silently lower-casing it. Mixed-case keys written before this version will remain under their old lower-cased names in Redis; callers that relied on case-insensitive lookups must either continue lower-casing at the call site or migrate their data.
+
+Alongside these: `set` no longer passes `{ EX: undefined }` when no TTL is given, the redundant `await` on the synchronous `client.multi()` is removed, error logs are unified around the structured `{ error }` pattern, and the test suite is updated accordingly (including the mock now exposing `close` instead of the unused `quit`).

--- a/.changeset/fix-redis-lock-ttl-and-case.md
+++ b/.changeset/fix-redis-lock-ttl-and-case.md
@@ -8,12 +8,15 @@ Fix `acquireLock` using `EX` (seconds) for a value in milliseconds — the defau
 
 Alongside these:
 
-- `set` no longer passes `{ EX: undefined }` when no TTL is given; the redundant `await` on the synchronous `client.multi()` is removed; error logs are unified around the structured `{ error }` pattern.
-- `start()` and `stop()` are now idempotent — `start()` short-circuits if the client is already open, `stop()` short-circuits if it is not, so neither can throw `"Socket already opened"` / `"Socket is closed"` on double invocation.
+- `set` rejects an `undefined` value synchronously (mirrors the memory-cache guard); `JSON.stringify(undefined)` would otherwise reach the wire and error unpredictably. `setInHash` does the same.
+- `set` no longer passes `{ EX: undefined }` when no TTL is given; the redundant `await` on the synchronous `client.multi()` is removed; error logs are unified around the structured `{ error, stack? }` payload so stack traces are preserved when available.
+- `start()` is idempotent *and* concurrency-safe: two callers firing before the first `connect()` resolves are both funneled onto the same `startPromise`, so the second no longer races past the `isOpen` guard and crashes with "Socket already opened". `stop()` short-circuits when `isOpen` is false, avoiding "Socket is closed" on a double invocation.
 - `get` / `getFromHash` check for `null`/`undefined` explicitly instead of a truthy check, so a malformed empty string surfaces to the caller as a parse error rather than silently returning `null`.
 - `getAllHashFields` iterates field-by-field and surfaces the offending field name in the structured log before rethrowing, instead of losing all context to a single `JSON.parse` failure.
 - `acquireLock` clamps a non-positive `ttlInMilliseconds` back to the default — the previous behavior forwarded `PX: 0`, which Redis rejects at the wire and the caller would only see as a `LockNotAcquiredError`.
-- `acquireLock` retry now uses equal-jitter backoff (sleep in `[retryDelay/2, retryDelay)`), matching the queue-consumer pattern, so concurrent consumers contending on the same key no longer phase-lock onto the same retry tick.
-- Connection lifecycle is now observable: `reconnecting`, `ready`, and `end` events are logged at debug level alongside the existing `error` handler.
+- `acquireLock` retry uses equal-jitter backoff (sleep in `[retryDelay/2, retryDelay)`), with the full expression wrapped in `Math.floor` so the sleep is always an integer-millisecond value, not a fractional `50.5` for odd `retryDelay`.
+- `releaseLock` uses `EVALSHA` with a cached SHA once `SCRIPT LOAD` succeeds, falling back to `EVAL` on the first call and on `NOSCRIPT` replies (e.g. after a server-side `SCRIPT FLUSH` or failover). A synchronous `scriptLoad` failure (older clients that do not expose the method) is also treated as a soft fallback.
+- Connection URL is redacted before it reaches the debug log. Managed-Redis URLs of the shape `redis://user:password@host:port` previously wrote the password into `"Connecting to Redis"`.
+- Connection lifecycle is now observable: `reconnecting`, `ready`, and `end` events are logged at debug level alongside the existing `error` handler, which now carries the stack trace as well.
 - `setInHash` inspects the `multi().exec()` replies. Per-command errors (e.g. `WRONGTYPE`) were previously swallowed because the transaction resolved with per-command `Error` instances instead of throwing; now they surface to the caller.
-- The test double exposes `close` instead of the unused `quit`, gains an `isOpen` state, and the previously-uncovered start/stop/parse-error/jitter/lifecycle-event/transaction-error paths now have tests.
+- The test double exposes `close` instead of the unused `quit`, gains an `isOpen` state plus `evalSha` / `scriptLoad` mocks, and previously-uncovered start/stop/parse-error/jitter/lifecycle-event/transaction-error/EVALSHA-cache/concurrent-start/credential-redaction paths now have tests.

--- a/.changeset/fix-redis-lock-ttl-and-case.md
+++ b/.changeset/fix-redis-lock-ttl-and-case.md
@@ -1,22 +1,28 @@
 ---
 '@dcl/redis-component': major
+'@dcl/core-commons': minor
 ---
 
 Fix `acquireLock` using `EX` (seconds) for a value in milliseconds — the default 10-second lock was actually being set to 10 000 seconds (~2.7 hours). Now uses `PX` so the unit matches the `ttlInMilliseconds` option.
 
 **Breaking** — all methods now preserve the key's original case instead of silently lower-casing it. Mixed-case keys written before this version will remain under their old lower-cased names in Redis; callers that relied on case-insensitive lookups must either continue lower-casing at the call site or migrate their data.
 
+`@dcl/core-commons` ships an additive `AcquireLockOptions` type and adds an optional `signal: AbortSignal` to the lock-acquisition options on `ICacheStorageComponent` (minor bump — purely additive).
+
 Alongside these:
 
+- `acquireLock` / `tryAcquireLock` accept an optional `signal: AbortSignal` that rejects the pending acquisition with the signal's reason (or an `AbortError`) the moment abort fires — between retries via `timers/promises#setTimeout`, or before the first round-trip to Redis if the signal is already aborted.
+- `acquireLock` now validates `retries` (non-negative integer), `retryDelayInMilliseconds` (non-negative finite number), and `ttlInMilliseconds` (finite number) and throws a descriptive `TypeError` instead of silently misbehaving on `NaN` / `Infinity` / negative values.
 - `set` rejects an `undefined` value synchronously (mirrors the memory-cache guard); `JSON.stringify(undefined)` would otherwise reach the wire and error unpredictably. `setInHash` does the same.
 - `set` no longer passes `{ EX: undefined }` when no TTL is given; the redundant `await` on the synchronous `client.multi()` is removed; error logs are unified around the structured `{ error, stack? }` payload so stack traces are preserved when available.
 - `start()` is idempotent *and* concurrency-safe: two callers firing before the first `connect()` resolves are both funneled onto the same `startPromise`, so the second no longer races past the `isOpen` guard and crashes with "Socket already opened". `stop()` short-circuits when `isOpen` is false, avoiding "Socket is closed" on a double invocation.
-- `get` / `getFromHash` check for `null`/`undefined` explicitly instead of a truthy check, so a malformed empty string surfaces to the caller as a parse error rather than silently returning `null`.
-- `getAllHashFields` iterates field-by-field and surfaces the offending field name in the structured log before rethrowing, instead of losing all context to a single `JSON.parse` failure.
+- `get` / `getFromHash` check for `null`/`undefined` explicitly instead of a truthy check; both paths now wrap `JSON.parse` and surface the offending `{ key, field? }` context in a structured log before rethrowing, so a corrupted entry no longer produces a bare `SyntaxError`.
+- `getAllHashFields` iterates field-by-field with per-field error logging for the same reason.
 - `acquireLock` clamps a non-positive `ttlInMilliseconds` back to the default — the previous behavior forwarded `PX: 0`, which Redis rejects at the wire and the caller would only see as a `LockNotAcquiredError`.
-- `acquireLock` retry uses equal-jitter backoff (sleep in `[retryDelay/2, retryDelay)`), with the full expression wrapped in `Math.floor` so the sleep is always an integer-millisecond value, not a fractional `50.5` for odd `retryDelay`.
+- `acquireLock` retry uses equal-jitter backoff (sleep in `[retryDelay/2, retryDelay)`), wrapped in `Math.floor` so the sleep is always an integer-millisecond value.
 - `releaseLock` uses `EVALSHA` with a cached SHA once `SCRIPT LOAD` succeeds, falling back to `EVAL` on the first call and on `NOSCRIPT` replies (e.g. after a server-side `SCRIPT FLUSH` or failover). A synchronous `scriptLoad` failure (older clients that do not expose the method) is also treated as a soft fallback.
 - Connection URL is redacted before it reaches the debug log. Managed-Redis URLs of the shape `redis://user:password@host:port` previously wrote the password into `"Connecting to Redis"`.
 - Connection lifecycle is now observable: `reconnecting`, `ready`, and `end` events are logged at debug level alongside the existing `error` handler, which now carries the stack trace as well.
 - `setInHash` inspects the `multi().exec()` replies. Per-command errors (e.g. `WRONGTYPE`) were previously swallowed because the transaction resolved with per-command `Error` instances instead of throwing; now they surface to the caller.
-- The test double exposes `close` instead of the unused `quit`, gains an `isOpen` state plus `evalSha` / `scriptLoad` mocks, and previously-uncovered start/stop/parse-error/jitter/lifecycle-event/transaction-error/EVALSHA-cache/concurrent-start/credential-redaction paths now have tests.
+- Dependency bumped from `redis@^5.9.0` to `redis@^5.12.1` — same major, no API we use changed; pulls in the 5.10 handshake-race fix, the 5.11 IPv6 URL support, and the 5.12 OTel hooks.
+- The test double exposes `close` instead of the unused `quit`, gains an `isOpen` state plus `evalSha` / `scriptLoad` mocks, and previously-uncovered start/stop/parse-error/jitter/lifecycle-event/transaction-error/EVALSHA-cache/concurrent-start/credential-redaction/AbortSignal/input-validation paths now have tests.

--- a/.changeset/fix-redis-lock-ttl-and-case.md
+++ b/.changeset/fix-redis-lock-ttl-and-case.md
@@ -12,4 +12,8 @@ Alongside these:
 - `start()` and `stop()` are now idempotent — `start()` short-circuits if the client is already open, `stop()` short-circuits if it is not, so neither can throw `"Socket already opened"` / `"Socket is closed"` on double invocation.
 - `get` / `getFromHash` check for `null`/`undefined` explicitly instead of a truthy check, so a malformed empty string surfaces to the caller as a parse error rather than silently returning `null`.
 - `getAllHashFields` iterates field-by-field and surfaces the offending field name in the structured log before rethrowing, instead of losing all context to a single `JSON.parse` failure.
-- The test double exposes `close` instead of the unused `quit`, gains an `isOpen` state, and the previously-uncovered start/stop/parse-error paths now have tests.
+- `acquireLock` clamps a non-positive `ttlInMilliseconds` back to the default — the previous behavior forwarded `PX: 0`, which Redis rejects at the wire and the caller would only see as a `LockNotAcquiredError`.
+- `acquireLock` retry now uses equal-jitter backoff (sleep in `[retryDelay/2, retryDelay)`), matching the queue-consumer pattern, so concurrent consumers contending on the same key no longer phase-lock onto the same retry tick.
+- Connection lifecycle is now observable: `reconnecting`, `ready`, and `end` events are logged at debug level alongside the existing `error` handler.
+- `setInHash` inspects the `multi().exec()` replies. Per-command errors (e.g. `WRONGTYPE`) were previously swallowed because the transaction resolved with per-command `Error` instances instead of throwing; now they surface to the caller.
+- The test double exposes `close` instead of the unused `quit`, gains an `isOpen` state, and the previously-uncovered start/stop/parse-error/jitter/lifecycle-event/transaction-error paths now have tests.

--- a/.changeset/fix-redis-lock-ttl-and-case.md
+++ b/.changeset/fix-redis-lock-ttl-and-case.md
@@ -6,4 +6,10 @@ Fix `acquireLock` using `EX` (seconds) for a value in milliseconds — the defau
 
 **Breaking** — all methods now preserve the key's original case instead of silently lower-casing it. Mixed-case keys written before this version will remain under their old lower-cased names in Redis; callers that relied on case-insensitive lookups must either continue lower-casing at the call site or migrate their data.
 
-Alongside these: `set` no longer passes `{ EX: undefined }` when no TTL is given, the redundant `await` on the synchronous `client.multi()` is removed, error logs are unified around the structured `{ error }` pattern, and the test suite is updated accordingly (including the mock now exposing `close` instead of the unused `quit`).
+Alongside these:
+
+- `set` no longer passes `{ EX: undefined }` when no TTL is given; the redundant `await` on the synchronous `client.multi()` is removed; error logs are unified around the structured `{ error }` pattern.
+- `start()` and `stop()` are now idempotent — `start()` short-circuits if the client is already open, `stop()` short-circuits if it is not, so neither can throw `"Socket already opened"` / `"Socket is closed"` on double invocation.
+- `get` / `getFromHash` check for `null`/`undefined` explicitly instead of a truthy check, so a malformed empty string surfaces to the caller as a parse error rather than silently returning `null`.
+- `getAllHashFields` iterates field-by-field and surfaces the offending field name in the structured log before rethrowing, instead of losing all context to a single `JSON.parse` failure.
+- The test double exposes `close` instead of the unused `quit`, gains an `isOpen` state, and the previously-uncovered start/stop/parse-error paths now have tests.

--- a/components/redis/package.json
+++ b/components/redis/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@dcl/core-commons": "workspace:*",
     "@well-known-components/interfaces": "^1.5.2",
-    "redis": "^5.9.0"
+    "redis": "^5.12.1"
   },
   "devDependencies": {
     "@types/node": "^22.13.10",

--- a/components/redis/src/component.ts
+++ b/components/redis/src/component.ts
@@ -26,8 +26,20 @@ export async function createRedisComponent(
 
   const client: RedisClientType = createClient({ url: hostUrl })
 
+  // Connection lifecycle observability. The node-redis client emits
+  // 'error', 'reconnecting', 'ready', 'end'; only 'error' was wired up
+  // before, so reconnects and closures were invisible in the logs.
   client.on('error', (err: Error) => {
     logger.error('Redis client error', { error: err.message })
+  })
+  client.on('reconnecting', () => {
+    logger.debug('Redis client reconnecting')
+  })
+  client.on('ready', () => {
+    logger.debug('Redis client ready')
+  })
+  client.on('end', () => {
+    logger.debug('Redis client connection ended')
   })
 
   async function start() {
@@ -99,7 +111,12 @@ export async function createRedisComponent(
     key: string,
     options?: { ttlInMilliseconds?: number; retryDelayInMilliseconds?: number; retries?: number }
   ): Promise<void> {
-    const ttlInMilliseconds = options?.ttlInMilliseconds ?? DEFAULT_ACQUIRE_LOCK_TTL_IN_MILLISECONDS
+    // Clamp non-positive TTL to the default. Redis would reject `PX: 0`
+    // at the wire with "invalid expire time in set", but surfacing that
+    // as a LockNotAcquiredError further down the line is confusing —
+    // bump the unit back to a usable value here instead.
+    const requestedTtl = options?.ttlInMilliseconds ?? DEFAULT_ACQUIRE_LOCK_TTL_IN_MILLISECONDS
+    const ttlInMilliseconds = requestedTtl > 0 ? requestedTtl : DEFAULT_ACQUIRE_LOCK_TTL_IN_MILLISECONDS
     const retryDelay = options?.retryDelayInMilliseconds ?? DEFAULT_ACQUIRE_LOCK_RETRY_DELAY_IN_MILLISECONDS
     const retries = options?.retries ?? DEFAULT_ACQUIRE_LOCK_RETRIES
 
@@ -113,7 +130,12 @@ export async function createRedisComponent(
       }
       logger.debug('Could not acquire lock', { key })
       if (i < retries - 1) {
-        await sleep(retryDelay)
+        // Equal-jitter retry: wait between retryDelay/2 and retryDelay.
+        // Pure fixed delays phase-lock concurrent consumers onto the
+        // same wake-up tick and they all retry simultaneously; jitter
+        // spreads them out while keeping a predictable floor.
+        const jitteredDelay = retryDelay / 2 + Math.floor(Math.random() * (retryDelay / 2))
+        await sleep(jitteredDelay)
       }
     }
 
@@ -206,14 +228,28 @@ export async function createRedisComponent(
   }
 
   async function setInHash<T>(key: string, field: string, value: T, ttlInSecondsForHash?: number): Promise<void> {
-    // client.multi() is synchronous in node-redis v5 and returns a builder;
-    // the previous `await client.multi()` was a no-op.
-    const multi = client.multi()
-    multi.hSet(key, field, JSON.stringify(value))
-    if (ttlInSecondsForHash && ttlInSecondsForHash > 0) {
-      multi.expire(key, ttlInSecondsForHash)
+    try {
+      // client.multi() is synchronous in node-redis v5 and returns a builder;
+      // the previous `await client.multi()` was a no-op.
+      const multi = client.multi()
+      multi.hSet(key, field, JSON.stringify(value))
+      if (ttlInSecondsForHash && ttlInSecondsForHash > 0) {
+        multi.expire(key, ttlInSecondsForHash)
+      }
+      // exec() returns one reply per command. When the transaction is
+      // queued with errors (e.g. wrong type, OOM reply), node-redis
+      // resolves with per-command Error instances instead of throwing.
+      // Inspect each so a partially-failed transaction isn't reported
+      // to the caller as a clean write.
+      const replies = await multi.exec()
+      const failed = replies?.find((reply) => reply instanceof Error) as Error | undefined
+      if (failed) {
+        throw failed
+      }
+    } catch (err) {
+      logger.error('Error setting hash field', { key, field, error: errorMessageOf(err) })
+      throw err
     }
-    await multi.exec()
   }
 
   async function getFromHash<T>(key: string, field: string): Promise<T | null> {

--- a/components/redis/src/component.ts
+++ b/components/redis/src/component.ts
@@ -1,10 +1,11 @@
 import { ILoggerComponent, START_COMPONENT, STOP_COMPONENT } from '@well-known-components/interfaces'
 import { createClient, RedisClientType } from 'redis'
 import { randomUUID } from 'crypto'
+import { setTimeout as sleepWithSignal } from 'timers/promises'
 import {
+  AcquireLockOptions,
   ICacheStorageComponent,
   isErrorWithMessage,
-  sleep,
   DEFAULT_ACQUIRE_LOCK_TTL_IN_MILLISECONDS,
   DEFAULT_ACQUIRE_LOCK_RETRY_DELAY_IN_MILLISECONDS,
   DEFAULT_ACQUIRE_LOCK_RETRIES,
@@ -14,6 +15,39 @@ import {
 
 function errorMessageOf(err: unknown): string {
   return isErrorWithMessage(err) ? err.message : 'Unknown error'
+}
+
+// Throws the AbortSignal's reason (or a fresh AbortError) if the signal
+// is already aborted. Used before the first attempt so a caller that
+// cancels before calling acquireLock doesn't even round-trip to Redis.
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw signal.reason ?? new DOMException('The operation was aborted', 'AbortError')
+  }
+}
+
+function validateLockOptions(options?: AcquireLockOptions): void {
+  if (options?.retries !== undefined) {
+    if (!Number.isInteger(options.retries) || options.retries < 0) {
+      throw new TypeError(
+        `acquireLock 'retries' must be a non-negative integer, got ${String(options.retries)}`
+      )
+    }
+  }
+  if (options?.retryDelayInMilliseconds !== undefined) {
+    if (!Number.isFinite(options.retryDelayInMilliseconds) || options.retryDelayInMilliseconds < 0) {
+      throw new TypeError(
+        `acquireLock 'retryDelayInMilliseconds' must be a non-negative finite number, got ${String(
+          options.retryDelayInMilliseconds
+        )}`
+      )
+    }
+  }
+  if (options?.ttlInMilliseconds !== undefined && !Number.isFinite(options.ttlInMilliseconds)) {
+    throw new TypeError(
+      `acquireLock 'ttlInMilliseconds' must be a finite number, got ${String(options.ttlInMilliseconds)}`
+    )
+  }
 }
 
 function errorLogPayload(err: unknown): { error: string; stack?: string } {
@@ -167,10 +201,10 @@ export async function createRedisComponent(
     }
   }
 
-  async function acquireLock(
-    key: string,
-    options?: { ttlInMilliseconds?: number; retryDelayInMilliseconds?: number; retries?: number }
-  ): Promise<void> {
+  async function acquireLock(key: string, options?: AcquireLockOptions): Promise<void> {
+    validateLockOptions(options)
+    throwIfAborted(options?.signal)
+
     // Clamp non-positive TTL to the default. Redis would reject `PX: 0`
     // at the wire with "invalid expire time in set", but surfacing that
     // as a LockNotAcquiredError further down the line is confusing —
@@ -197,7 +231,10 @@ export async function createRedisComponent(
         // over the whole sum keeps the result an integer ms even when
         // retryDelay is odd.
         const jitteredDelay = Math.floor(retryDelay / 2 + Math.random() * (retryDelay / 2))
-        await sleep(jitteredDelay)
+        // Interruptible sleep: rejects with the abort reason the moment
+        // the signal fires, so a caller cancelling mid-contention
+        // doesn't have to wait for the next wake-up tick.
+        await sleepWithSignal(jitteredDelay, undefined, { signal: options?.signal })
       }
     }
 
@@ -259,10 +296,7 @@ export async function createRedisComponent(
     }
   }
 
-  async function tryAcquireLock(
-    key: string,
-    options?: { ttlInMilliseconds?: number; retryDelayInMilliseconds?: number; retries?: number }
-  ): Promise<boolean> {
+  async function tryAcquireLock(key: string, options?: AcquireLockOptions): Promise<boolean> {
     try {
       await acquireLock(key, options)
       return true

--- a/components/redis/src/component.ts
+++ b/components/redis/src/component.ts
@@ -12,6 +12,10 @@ import {
   LockNotReleasedError
 } from '@dcl/core-commons'
 
+function errorMessageOf(err: unknown): string {
+  return isErrorWithMessage(err) ? err.message : 'Unknown error'
+}
+
 export async function createRedisComponent(
   hostUrl: string,
   components: { logs: ILoggerComponent }
@@ -20,7 +24,6 @@ export async function createRedisComponent(
   const logger = logs.getLogger('redis-component')
   const randomValue = randomUUID()
 
-  // Initialize client immediately for testing
   const client: RedisClientType = createClient({ url: hostUrl })
 
   client.on('error', (err: Error) => {
@@ -32,33 +35,33 @@ export async function createRedisComponent(
       logger.debug('Connecting to Redis', { hostUrl })
       await client.connect()
       logger.debug('Successfully connected to Redis')
-    } catch (err: any) {
-      logger.error('Error connecting to Redis', err)
+    } catch (err) {
+      logger.error('Error connecting to Redis', { error: errorMessageOf(err) })
       throw err
     }
   }
 
   async function stop() {
+    // Stop is best-effort: a disconnect failure should not prevent the
+    // lifecycle manager from moving on with the rest of the shutdown.
     try {
       logger.debug('Disconnecting from Redis')
-      if (client) {
-        await client.close()
-      }
+      await client.close()
       logger.debug('Successfully disconnected from Redis')
-    } catch (err: any) {
-      logger.error('Error disconnecting from Redis', err)
+    } catch (err) {
+      logger.error('Error disconnecting from Redis', { error: errorMessageOf(err) })
     }
   }
 
   async function get<T>(key: string): Promise<T | null> {
     try {
-      const serializedValue = await client.get(key.toLowerCase())
+      const serializedValue = await client.get(key)
       if (serializedValue) {
         return JSON.parse(serializedValue) as T
       }
       return null
-    } catch (err: any) {
-      logger.error(`Error getting key "${key}"`, err)
+    } catch (err) {
+      logger.error('Error getting key', { key, error: errorMessageOf(err) })
       throw err
     }
   }
@@ -66,9 +69,13 @@ export async function createRedisComponent(
   async function set<T>(key: string, value: T, ttlInSeconds?: number): Promise<void> {
     try {
       const serializedValue = JSON.stringify(value)
-      await client.set(key.toLowerCase(), serializedValue, { EX: ttlInSeconds as number | undefined })
-    } catch (err: any) {
-      logger.error(`Error setting key "${key}"`, err)
+      // Only include EX when a positive TTL was provided. Passing
+      // `{ EX: undefined }` is interpreted inconsistently across
+      // node-redis versions.
+      const options = ttlInSeconds && ttlInSeconds > 0 ? { EX: ttlInSeconds } : undefined
+      await client.set(key, serializedValue, options)
+    } catch (err) {
+      logger.error('Error setting key', { key, error: errorMessageOf(err) })
       throw err
     }
   }
@@ -77,20 +84,21 @@ export async function createRedisComponent(
     key: string,
     options?: { ttlInMilliseconds?: number; retryDelayInMilliseconds?: number; retries?: number }
   ): Promise<void> {
-    const ttl = options?.ttlInMilliseconds ?? DEFAULT_ACQUIRE_LOCK_TTL_IN_MILLISECONDS
+    const ttlInMilliseconds = options?.ttlInMilliseconds ?? DEFAULT_ACQUIRE_LOCK_TTL_IN_MILLISECONDS
     const retryDelay = options?.retryDelayInMilliseconds ?? DEFAULT_ACQUIRE_LOCK_RETRY_DELAY_IN_MILLISECONDS
     const retries = options?.retries ?? DEFAULT_ACQUIRE_LOCK_RETRIES
 
     for (let i = 0; i < retries; i++) {
-      const lock = await client.set(key.toLowerCase(), randomValue, { NX: true, EX: ttl })
+      // PX takes milliseconds; the previous code used EX (seconds), which
+      // made every default-10s lock actually last 10_000s.
+      const lock = await client.set(key, randomValue, { NX: true, PX: ttlInMilliseconds })
       if (lock) {
-        logger.debug(`Successfully acquired lock for key "${key}"`)
+        logger.debug('Successfully acquired lock', { key })
         return
-      } else {
-        logger.debug(`Could not acquire lock for key "${key}"`)
-        if (i < retries - 1) {
-          await sleep(retryDelay)
-        }
+      }
+      logger.debug('Could not acquire lock', { key })
+      if (i < retries - 1) {
+        await sleep(retryDelay)
       }
     }
 
@@ -107,23 +115,20 @@ export async function createRedisComponent(
           return 0
         end`,
         {
-          keys: [key.toLowerCase()],
+          keys: [key],
           arguments: [randomValue]
         }
       )) as number
 
       if (result === 1) {
         return
-      } else {
-        throw new LockNotReleasedError(key)
       }
+      throw new LockNotReleasedError(key)
     } catch (error) {
       if (error instanceof LockNotReleasedError) {
         throw error
       }
-      logger.error(
-        `Error releasing lock for key "${key}": ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
-      )
+      logger.error('Error releasing lock', { key, error: errorMessageOf(error) })
       throw error
     }
   }
@@ -157,9 +162,9 @@ export async function createRedisComponent(
 
   async function remove(key: string): Promise<void> {
     try {
-      await client.del(key.toLowerCase())
-    } catch (err: any) {
-      logger.error(`Error removing key "${key}"`, err)
+      await client.del(key)
+    } catch (err) {
+      logger.error('Error removing key', { key, error: errorMessageOf(err) })
       throw err
     }
   }
@@ -172,23 +177,25 @@ export async function createRedisComponent(
       do {
         const reply = await client.scan(cursor, {
           MATCH: pattern,
-          COUNT: 100 // Process in batches of 100
+          COUNT: 100
         })
         cursor = reply.cursor
         allKeys.push(...reply.keys)
       } while (cursor !== '0')
 
       return allKeys
-    } catch (err: any) {
-      logger.error('Error scanning keys', err)
+    } catch (err) {
+      logger.error('Error scanning keys', { pattern, error: errorMessageOf(err) })
       throw err
     }
   }
 
   async function setInHash<T>(key: string, field: string, value: T, ttlInSecondsForHash?: number): Promise<void> {
-    const multi = await client.multi()
+    // client.multi() is synchronous in node-redis v5 and returns a builder;
+    // the previous `await client.multi()` was a no-op.
+    const multi = client.multi()
     multi.hSet(key, field, JSON.stringify(value))
-    if (ttlInSecondsForHash) {
+    if (ttlInSecondsForHash && ttlInSecondsForHash > 0) {
       multi.expire(key, ttlInSecondsForHash)
     }
     await multi.exec()

--- a/components/redis/src/component.ts
+++ b/components/redis/src/component.ts
@@ -353,7 +353,15 @@ export async function createRedisComponent(
     if (value === null || value === undefined) {
       return null
     }
-    return JSON.parse(value) as T
+    try {
+      return JSON.parse(value) as T
+    } catch (err) {
+      // Mirror getAllHashFields's per-field error shape so a corrupted
+      // entry surfaces the key / field that produced it, rather than
+      // bubbling up a bare SyntaxError with no context.
+      logger.error('Failed to parse hash field', { key, field, ...errorLogPayload(err) })
+      throw err
+    }
   }
 
   async function removeFromHash(key: string, field: string): Promise<void> {

--- a/components/redis/src/component.ts
+++ b/components/redis/src/component.ts
@@ -31,6 +31,12 @@ export async function createRedisComponent(
   })
 
   async function start() {
+    // Idempotent: if connect() has already run (or is running), there's
+    // nothing to do. Calling client.connect() twice on node-redis v5
+    // throws "Socket already opened".
+    if (client.isOpen) {
+      return
+    }
     try {
       logger.debug('Connecting to Redis', { hostUrl })
       await client.connect()
@@ -44,6 +50,11 @@ export async function createRedisComponent(
   async function stop() {
     // Stop is best-effort: a disconnect failure should not prevent the
     // lifecycle manager from moving on with the rest of the shutdown.
+    // Skip entirely if the client never opened (start failed, or stop is
+    // being called twice) — close() throws in that state.
+    if (!client.isOpen) {
+      return
+    }
     try {
       logger.debug('Disconnecting from Redis')
       await client.close()
@@ -56,10 +67,14 @@ export async function createRedisComponent(
   async function get<T>(key: string): Promise<T | null> {
     try {
       const serializedValue = await client.get(key)
-      if (serializedValue) {
-        return JSON.parse(serializedValue) as T
+      // Explicit null/undefined check rather than truthy: `JSON.stringify('')`
+      // yields `'""'` (truthy), so an externally-written raw empty string
+      // is a malformed value and would throw during parse — no need to
+      // silently swallow it as "not found".
+      if (serializedValue === null || serializedValue === undefined) {
+        return null
       }
-      return null
+      return JSON.parse(serializedValue) as T
     } catch (err) {
       logger.error('Error getting key', { key, error: errorMessageOf(err) })
       throw err
@@ -203,7 +218,10 @@ export async function createRedisComponent(
 
   async function getFromHash<T>(key: string, field: string): Promise<T | null> {
     const value = await client.hGet(key, field)
-    return value ? JSON.parse(value) : null
+    if (value === null || value === undefined) {
+      return null
+    }
+    return JSON.parse(value) as T
   }
 
   async function removeFromHash(key: string, field: string): Promise<void> {
@@ -212,10 +230,19 @@ export async function createRedisComponent(
 
   async function getAllHashFields<T>(key: string): Promise<Record<string, T>> {
     const hashFields = await client.hGetAll(key)
-    return Object.entries(hashFields).reduce((acc: Record<string, T>, [field, value]) => {
-      acc[field] = JSON.parse(value)
-      return acc
-    }, {} as Record<string, T>)
+    const result: Record<string, T> = {}
+    for (const [field, value] of Object.entries(hashFields)) {
+      try {
+        result[field] = JSON.parse(value) as T
+      } catch (err) {
+        // Surface the offending field so the caller can correlate the
+        // corruption to a specific entry, rather than losing the rest
+        // of the hash to a single malformed value.
+        logger.error('Failed to parse hash field', { key, field, error: errorMessageOf(err) })
+        throw err
+      }
+    }
+    return result
   }
 
   return {

--- a/components/redis/src/component.ts
+++ b/components/redis/src/component.ts
@@ -16,6 +16,39 @@ function errorMessageOf(err: unknown): string {
   return isErrorWithMessage(err) ? err.message : 'Unknown error'
 }
 
+function errorLogPayload(err: unknown): { error: string; stack?: string } {
+  const payload: { error: string; stack?: string } = { error: errorMessageOf(err) }
+  if (err instanceof Error && typeof err.stack === 'string') {
+    payload.stack = err.stack
+  }
+  return payload
+}
+
+// Strip any user-info (username / password) from a Redis connection URL
+// before logging it. Managed Redis providers commonly hand out URLs of
+// the form `redis://default:password@host:6379`; without redaction the
+// password would be visible in debug logs.
+function redactHostUrl(url: string): string {
+  try {
+    const parsed = new URL(url)
+    if (parsed.username) parsed.username = '***'
+    if (parsed.password) parsed.password = '***'
+    return parsed.toString()
+  } catch {
+    return '[unparseable redis url]'
+  }
+}
+
+// Atomically verify ownership and release a lock. Kept at module scope
+// so SCRIPT LOAD / EVALSHA caching can reuse the exact same source
+// bytes across every call.
+const LOCK_RELEASE_SCRIPT = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+else
+  return 0
+end`
+
 export async function createRedisComponent(
   hostUrl: string,
   components: { logs: ILoggerComponent }
@@ -24,13 +57,22 @@ export async function createRedisComponent(
   const logger = logs.getLogger('redis-component')
   const randomValue = randomUUID()
 
+  const redactedHostUrl = redactHostUrl(hostUrl)
   const client: RedisClientType = createClient({ url: hostUrl })
+
+  // Cached SHA1 of LOCK_RELEASE_SCRIPT, populated the first time
+  // releaseLock is called successfully. Sending the 40-byte hash via
+  // EVALSHA is cheaper on the wire than re-transmitting the full
+  // script every time, and Redis's internal cache is addressed by
+  // exactly that SHA regardless of whether we loaded it explicitly or
+  // implicitly via EVAL.
+  let lockReleaseScriptSha: string | undefined
 
   // Connection lifecycle observability. The node-redis client emits
   // 'error', 'reconnecting', 'ready', 'end'; only 'error' was wired up
   // before, so reconnects and closures were invisible in the logs.
   client.on('error', (err: Error) => {
-    logger.error('Redis client error', { error: err.message })
+    logger.error('Redis client error', errorLogPayload(err))
   })
   client.on('reconnecting', () => {
     logger.debug('Redis client reconnecting')
@@ -42,21 +84,31 @@ export async function createRedisComponent(
     logger.debug('Redis client connection ended')
   })
 
-  async function start() {
-    // Idempotent: if connect() has already run (or is running), there's
-    // nothing to do. Calling client.connect() twice on node-redis v5
-    // throws "Socket already opened".
-    if (client.isOpen) {
-      return
-    }
-    try {
-      logger.debug('Connecting to Redis', { hostUrl })
-      await client.connect()
-      logger.debug('Successfully connected to Redis')
-    } catch (err) {
-      logger.error('Error connecting to Redis', { error: errorMessageOf(err) })
-      throw err
-    }
+  // Gate concurrent start() callers onto the same connect promise.
+  // The previous `if (client.isOpen) return` only protected against
+  // SEQUENTIAL double-starts — two concurrent callers would both see
+  // `isOpen: false` before the first connect resolved and the second
+  // connect would throw "Socket already opened".
+  let startPromise: Promise<void> | null = null
+
+  async function start(): Promise<void> {
+    if (client.isOpen) return
+    if (startPromise) return startPromise
+    startPromise = (async () => {
+      try {
+        logger.debug('Connecting to Redis', { hostUrl: redactedHostUrl })
+        await client.connect()
+        logger.debug('Successfully connected to Redis')
+      } catch (err) {
+        logger.error('Error connecting to Redis', errorLogPayload(err))
+        throw err
+      } finally {
+        // Clear the gate in both success and failure so a caller can
+        // retry start() after a connect error.
+        startPromise = null
+      }
+    })()
+    return startPromise
   }
 
   async function stop() {
@@ -72,7 +124,7 @@ export async function createRedisComponent(
       await client.close()
       logger.debug('Successfully disconnected from Redis')
     } catch (err) {
-      logger.error('Error disconnecting from Redis', { error: errorMessageOf(err) })
+      logger.error('Error disconnecting from Redis', errorLogPayload(err))
     }
   }
 
@@ -88,12 +140,20 @@ export async function createRedisComponent(
       }
       return JSON.parse(serializedValue) as T
     } catch (err) {
-      logger.error('Error getting key', { key, error: errorMessageOf(err) })
+      logger.error('Error getting key', { key, ...errorLogPayload(err) })
       throw err
     }
   }
 
   async function set<T>(key: string, value: T, ttlInSeconds?: number): Promise<void> {
+    // Reject undefined at the component boundary: `JSON.stringify(undefined)`
+    // returns `undefined` (the value), which node-redis then sends as
+    // an empty argument — behavior varies by version and typically
+    // throws a TypeError after the wire round-trip. A clear synchronous
+    // error is friendlier and matches the memory-cache implementation.
+    if (value === undefined) {
+      throw new Error(`Cannot set an undefined value for key "${key}".`)
+    }
     try {
       const serializedValue = JSON.stringify(value)
       // Only include EX when a positive TTL was provided. Passing
@@ -102,7 +162,7 @@ export async function createRedisComponent(
       const options = ttlInSeconds && ttlInSeconds > 0 ? { EX: ttlInSeconds } : undefined
       await client.set(key, serializedValue, options)
     } catch (err) {
-      logger.error('Error setting key', { key, error: errorMessageOf(err) })
+      logger.error('Error setting key', { key, ...errorLogPayload(err) })
       throw err
     }
   }
@@ -130,11 +190,13 @@ export async function createRedisComponent(
       }
       logger.debug('Could not acquire lock', { key })
       if (i < retries - 1) {
-        // Equal-jitter retry: wait between retryDelay/2 and retryDelay.
+        // Equal-jitter retry: sleep somewhere in [retryDelay/2, retryDelay).
         // Pure fixed delays phase-lock concurrent consumers onto the
         // same wake-up tick and they all retry simultaneously; jitter
-        // spreads them out while keeping a predictable floor.
-        const jitteredDelay = retryDelay / 2 + Math.floor(Math.random() * (retryDelay / 2))
+        // spreads them out while keeping a predictable floor. Math.floor
+        // over the whole sum keeps the result an integer ms even when
+        // retryDelay is odd.
+        const jitteredDelay = Math.floor(retryDelay / 2 + Math.random() * (retryDelay / 2))
         await sleep(jitteredDelay)
       }
     }
@@ -142,20 +204,47 @@ export async function createRedisComponent(
     throw new LockNotAcquiredError(key)
   }
 
+  async function evalLockRelease(key: string): Promise<number> {
+    const args = { keys: [key], arguments: [randomValue] }
+    // Fast path: use the cached SHA. If the server has since flushed
+    // its script cache (SCRIPT FLUSH, restart, failover), Redis
+    // replies with a NOSCRIPT error — fall through to EVAL, which
+    // re-registers the script server-side and can capture the SHA
+    // again for future calls.
+    if (lockReleaseScriptSha !== undefined) {
+      try {
+        return (await client.evalSha(lockReleaseScriptSha, args)) as number
+      } catch (err) {
+        if (!(isErrorWithMessage(err) && /NOSCRIPT/.test(err.message))) {
+          throw err
+        }
+        lockReleaseScriptSha = undefined
+      }
+    }
+    const result = (await client.eval(LOCK_RELEASE_SCRIPT, args)) as number
+    // Best-effort SCRIPT LOAD so the next call can use EVALSHA. Done
+    // off the critical path, and guarded against both sync and async
+    // failures; if scriptLoad is unavailable or fails, we just stay
+    // on the slow-but-correct EVAL path a little longer.
+    if (lockReleaseScriptSha === undefined) {
+      try {
+        Promise.resolve(client.scriptLoad(LOCK_RELEASE_SCRIPT))
+          .then((sha) => {
+            lockReleaseScriptSha = sha
+          })
+          .catch((err) => {
+            logger.debug('SCRIPT LOAD failed; staying on EVAL path', errorLogPayload(err))
+          })
+      } catch (err) {
+        logger.debug('SCRIPT LOAD threw synchronously; staying on EVAL path', errorLogPayload(err))
+      }
+    }
+    return result
+  }
+
   async function releaseLock(key: string): Promise<void> {
     try {
-      const result = (await client.eval(
-        `
-        if redis.call("GET", KEYS[1]) == ARGV[1] then
-          return redis.call("DEL", KEYS[1])
-        else
-          return 0
-        end`,
-        {
-          keys: [key],
-          arguments: [randomValue]
-        }
-      )) as number
+      const result = await evalLockRelease(key)
 
       if (result === 1) {
         return
@@ -165,7 +254,7 @@ export async function createRedisComponent(
       if (error instanceof LockNotReleasedError) {
         throw error
       }
-      logger.error('Error releasing lock', { key, error: errorMessageOf(error) })
+      logger.error('Error releasing lock', { key, ...errorLogPayload(error) })
       throw error
     }
   }
@@ -201,7 +290,7 @@ export async function createRedisComponent(
     try {
       await client.del(key)
     } catch (err) {
-      logger.error('Error removing key', { key, error: errorMessageOf(err) })
+      logger.error('Error removing key', { key, ...errorLogPayload(err) })
       throw err
     }
   }
@@ -222,12 +311,19 @@ export async function createRedisComponent(
 
       return allKeys
     } catch (err) {
-      logger.error('Error scanning keys', { pattern, error: errorMessageOf(err) })
+      logger.error('Error scanning keys', { pattern, ...errorLogPayload(err) })
       throw err
     }
   }
 
   async function setInHash<T>(key: string, field: string, value: T, ttlInSecondsForHash?: number): Promise<void> {
+    // Symmetric with `set()`: `JSON.stringify(undefined)` is the value
+    // `undefined`, which node-redis would then send as an empty
+    // argument. Reject it synchronously so memory-cache and Redis
+    // agree on the contract.
+    if (value === undefined) {
+      throw new Error(`Cannot setInHash an undefined value under key "${key}", field "${field}".`)
+    }
     try {
       // client.multi() is synchronous in node-redis v5 and returns a builder;
       // the previous `await client.multi()` was a no-op.
@@ -247,7 +343,7 @@ export async function createRedisComponent(
         throw failed
       }
     } catch (err) {
-      logger.error('Error setting hash field', { key, field, error: errorMessageOf(err) })
+      logger.error('Error setting hash field', { key, field, ...errorLogPayload(err) })
       throw err
     }
   }
@@ -274,7 +370,7 @@ export async function createRedisComponent(
         // Surface the offending field so the caller can correlate the
         // corruption to a specific entry, rather than losing the rest
         // of the hash to a single malformed value.
-        logger.error('Failed to parse hash field', { key, field, error: errorMessageOf(err) })
+        logger.error('Failed to parse hash field', { key, field, ...errorLogPayload(err) })
         throw err
       }
     }

--- a/components/redis/tests/redis-component.spec.ts
+++ b/components/redis/tests/redis-component.spec.ts
@@ -25,6 +25,8 @@ let multiMock: jest.Mock
 let expireMock: jest.Mock
 let execMock: jest.Mock
 let evalMock: jest.Mock
+let evalShaMock: jest.Mock
+let scriptLoadMock: jest.Mock
 let errorLogMock: jest.Mock
 let debugLogMock: jest.Mock
 
@@ -44,6 +46,8 @@ beforeEach(async () => {
   expireMock = jest.fn().mockResolvedValue(1)
   execMock = jest.fn().mockResolvedValue(['OK', 1])
   evalMock = jest.fn()
+  evalShaMock = jest.fn()
+  scriptLoadMock = jest.fn().mockResolvedValue('dummy-sha')
   multiMock = jest.fn().mockReturnValue({
     hSet: hSetMock,
     expire: expireMock,
@@ -70,6 +74,8 @@ beforeEach(async () => {
     hGetAll: hGetAllMock,
     multi: multiMock,
     eval: evalMock,
+    evalSha: evalShaMock,
+    scriptLoad: scriptLoadMock,
     on: jest.fn()
   }
 
@@ -804,5 +810,185 @@ describe('when setInHash is called and the transaction contains a per-command er
       'Error setting hash field',
       expect.objectContaining({ key: hashKey, field })
     )
+  })
+})
+
+describe('when start() is called concurrently', () => {
+  // Regression: the previous `if (client.isOpen) return` only protected
+  // against sequential double-starts. Two callers firing before the
+  // first connect resolves would both see `isOpen: false` and race.
+  // The gate now funnels them onto a single startPromise.
+  let connectResolve: (() => void) | null
+  let freshComponent: ICacheStorageComponent
+
+  beforeEach(async () => {
+    connectResolve = null
+    // Make connect() intentionally slow so the two start() callers
+    // actually overlap rather than resolving sequentially.
+    const slowConnect = jest.fn().mockImplementation(() => {
+      return new Promise<void>((resolve) => {
+        connectResolve = () => {
+          mockRedisClient.isOpen = true
+          resolve()
+        }
+      })
+    })
+
+    const freshClient = { ...mockRedisClient, isOpen: false, connect: slowConnect }
+    const { createClient } = require('redis')
+    createClient.mockReturnValue(freshClient)
+    freshComponent = await createRedisComponent(hostUrl, { logs })
+
+    // Fire two start() calls before the first resolves.
+    const a = freshComponent[START_COMPONENT]!({
+      started: () => true,
+      live: () => true,
+      getComponents: () => ({})
+    })
+    const b = freshComponent[START_COMPONENT]!({
+      started: () => true,
+      live: () => true,
+      getComponents: () => ({})
+    })
+
+    connectResolve!()
+    await Promise.all([a, b])
+    mockRedisClient.connect = slowConnect
+  })
+
+  it('should issue connect() exactly once even under two concurrent start() calls', () => {
+    expect((mockRedisClient.connect as jest.Mock).mock.calls.length).toBe(1)
+  })
+})
+
+describe('when the Redis URL contains credentials', () => {
+  // The `hostUrl` was logged at debug level verbatim, which meant a
+  // managed-Redis password (very common shape) would show up in the
+  // connection-start log.
+  beforeEach(async () => {
+    const freshClient = { ...mockRedisClient, isOpen: false }
+    const { createClient } = require('redis')
+    createClient.mockReturnValue(freshClient)
+    const comp = await createRedisComponent('redis://default:supersecret@example.com:6379', { logs })
+    await comp[START_COMPONENT]!({ started: () => true, live: () => true, getComponents: () => ({}) })
+  })
+
+  it('should redact the user-info section before logging the connect line', () => {
+    expect(debugLogMock).toHaveBeenCalledWith('Connecting to Redis', { hostUrl: 'redis://***:***@example.com:6379' })
+    // Belt and suspenders: no call should ever contain the raw password.
+    for (const call of debugLogMock.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain('supersecret')
+    }
+  })
+})
+
+describe('when set and setInHash are given an undefined value', () => {
+  // Mirror the memory-cache guard: JSON.stringify(undefined) === undefined,
+  // which node-redis then serialises inconsistently — reject synchronously
+  // so both implementations of ICacheStorageComponent agree.
+  it('set() should reject rather than hand undefined to the client', async () => {
+    await expect(component.set('k', undefined as unknown as string)).rejects.toThrow(/undefined value/)
+    expect(setMock).not.toHaveBeenCalled()
+  })
+
+  it('setInHash() should reject rather than hand undefined to the client', async () => {
+    await expect(component.setInHash('k', 'f', undefined as unknown as string)).rejects.toThrow(
+      /undefined value/
+    )
+    expect(hSetMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('when the client error handler fires with a stack-bearing Error', () => {
+  let onCalls: Array<[string, (...args: any[]) => void]>
+
+  beforeEach(async () => {
+    onCalls = []
+    const freshClient = {
+      ...mockRedisClient,
+      on: jest.fn((event: string, listener: (...args: any[]) => void) => {
+        onCalls.push([event, listener])
+      })
+    }
+    const { createClient } = require('redis')
+    createClient.mockReturnValue(freshClient)
+    await createRedisComponent(hostUrl, { logs })
+  })
+
+  it('should include the stack trace in the structured payload', () => {
+    const handler = onCalls.find(([event]) => event === 'error')![1]
+    const err = new Error('boom')
+
+    handler(err)
+
+    expect(errorLogMock).toHaveBeenCalledWith(
+      'Redis client error',
+      expect.objectContaining({ error: 'boom', stack: err.stack })
+    )
+  })
+})
+
+describe('when releaseLock can cache the Lua script via EVALSHA', () => {
+  const lockKey = 'releasable'
+
+  it('should fall back to EVAL on the first call and then kick off SCRIPT LOAD to prime EVALSHA', async () => {
+    evalMock.mockResolvedValue(1)
+    scriptLoadMock.mockResolvedValue('cached-sha')
+
+    await component.releaseLock(lockKey)
+
+    expect(evalMock).toHaveBeenCalledTimes(1)
+    // Best-effort SCRIPT LOAD is not awaited; flush microtasks.
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(scriptLoadMock).toHaveBeenCalled()
+  })
+
+  it('should use EVALSHA on subsequent calls once the SHA has been cached', async () => {
+    evalMock.mockResolvedValue(1)
+    scriptLoadMock.mockResolvedValue('cached-sha')
+    evalShaMock.mockResolvedValue(1)
+
+    // First call populates the SHA via the async scriptLoad follow-up.
+    await component.releaseLock(lockKey)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // Second call: now on the fast path.
+    await component.releaseLock(lockKey)
+
+    expect(evalShaMock).toHaveBeenCalledTimes(1)
+    expect(evalShaMock).toHaveBeenCalledWith('cached-sha', expect.objectContaining({ keys: [lockKey] }))
+  })
+
+  it('should fall back to EVAL and drop the cached SHA when the server replies NOSCRIPT', async () => {
+    evalMock.mockResolvedValue(1)
+    scriptLoadMock.mockResolvedValue('cached-sha')
+    evalShaMock
+      .mockRejectedValueOnce(new Error('NOSCRIPT No matching script. Please use EVAL.'))
+      .mockResolvedValue(1)
+
+    // Prime the SHA.
+    await component.releaseLock(lockKey)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    evalMock.mockClear()
+
+    // Second call: evalSha throws NOSCRIPT -> falls back to EVAL.
+    await component.releaseLock(lockKey)
+
+    expect(evalMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('should treat a synchronous scriptLoad failure as a soft fallback to EVAL', async () => {
+    evalMock.mockResolvedValue(1)
+    // Simulate a client that doesn't expose scriptLoad at all.
+    const freshClient = { ...mockRedisClient, isOpen: false, scriptLoad: undefined }
+    const { createClient } = require('redis')
+    createClient.mockReturnValue(freshClient)
+    const comp = await createRedisComponent(hostUrl, { logs })
+
+    await expect(comp.releaseLock(lockKey)).resolves.not.toThrow()
   })
 })

--- a/components/redis/tests/redis-component.spec.ts
+++ b/components/redis/tests/redis-component.spec.ts
@@ -684,6 +684,30 @@ describe('when getAllHashFields encounters a malformed JSON value', () => {
   })
 })
 
+describe('when getFromHash encounters a malformed JSON value', () => {
+  let hashKey: string
+  let field: string
+
+  beforeEach(() => {
+    hashKey = 'single-field-hash'
+    field = 'corrupt-field'
+    hGetMock.mockResolvedValue('not-valid-json{')
+  })
+
+  it('should reject with the underlying parse error', async () => {
+    await expect(component.getFromHash(hashKey, field)).rejects.toThrow()
+  })
+
+  it('should surface the offending key and field in the structured log', async () => {
+    await component.getFromHash(hashKey, field).catch(() => undefined)
+
+    expect(errorLogMock).toHaveBeenCalledWith(
+      'Failed to parse hash field',
+      expect.objectContaining({ key: hashKey, field })
+    )
+  })
+})
+
 describe('when acquireLock is given a non-positive ttlInMilliseconds', () => {
   const lockKey = 'clamped-lock'
 

--- a/components/redis/tests/redis-component.spec.ts
+++ b/components/redis/tests/redis-component.spec.ts
@@ -1,4 +1,4 @@
-import { ILoggerComponent } from '@well-known-components/interfaces'
+import { ILoggerComponent, START_COMPONENT, STOP_COMPONENT } from '@well-known-components/interfaces'
 import { createLoggerMockedComponent, LockNotAcquiredError, LockNotReleasedError } from '@dcl/core-commons'
 import { createRedisComponent } from '../src/component'
 import { ICacheStorageComponent } from '@dcl/core-commons'
@@ -53,8 +53,13 @@ beforeEach(async () => {
   debugLogMock = jest.fn()
 
   mockRedisClient = {
-    connect: connectMock,
-    close: closeMock,
+    isOpen: false,
+    connect: connectMock.mockImplementation(async () => {
+      mockRedisClient.isOpen = true
+    }),
+    close: closeMock.mockImplementation(async () => {
+      mockRedisClient.isOpen = false
+    }),
     get: getMock,
     set: setMock,
     del: delMock,
@@ -578,5 +583,97 @@ describe('when trying to release locks', () => {
     it('should throw the Redis error', async () => {
       await expect(component.tryReleaseLock(lockKey)).rejects.toThrow(error)
     })
+  })
+})
+
+describe('when starting the component', () => {
+  describe('and the client has not been opened yet', () => {
+    it('should call connect()', async () => {
+      await component[START_COMPONENT]!({ started: () => true, live: () => true, getComponents: () => ({}) })
+
+      expect(connectMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('and start is called twice in a row', () => {
+    it('should not re-open an already-open client', async () => {
+      await component[START_COMPONENT]!({ started: () => true, live: () => true, getComponents: () => ({}) })
+      await component[START_COMPONENT]!({ started: () => true, live: () => true, getComponents: () => ({}) })
+
+      // The second start is a no-op because the client is already open.
+      expect(connectMock).toHaveBeenCalledTimes(1)
+    })
+  })
+})
+
+describe('when stopping the component', () => {
+  describe('and the client is currently open', () => {
+    beforeEach(async () => {
+      await component[START_COMPONENT]!({ started: () => true, live: () => true, getComponents: () => ({}) })
+    })
+
+    it('should call close()', async () => {
+      await component[STOP_COMPONENT]!()
+
+      expect(closeMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('and stop is called without a prior start', () => {
+    it('should not call close()', async () => {
+      await component[STOP_COMPONENT]!()
+
+      expect(closeMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and stop is called twice in a row', () => {
+    beforeEach(async () => {
+      await component[START_COMPONENT]!({ started: () => true, live: () => true, getComponents: () => ({}) })
+    })
+
+    it('should only close the client once', async () => {
+      await component[STOP_COMPONENT]!()
+      await component[STOP_COMPONENT]!()
+
+      expect(closeMock).toHaveBeenCalledTimes(1)
+    })
+  })
+})
+
+describe('when get returns an empty string from Redis', () => {
+  // An empty string is a malformed value (values written by this
+  // component are JSON-encoded, so strings always come back wrapped in
+  // quotes — `JSON.stringify('') === '""'`). Letting it reach JSON.parse
+  // surfaces the corruption to the caller instead of silently returning
+  // null as if the key were absent.
+  const key = 'empty-string-key'
+
+  beforeEach(() => {
+    getMock.mockResolvedValue('')
+  })
+
+  it('should throw the parse error rather than silently return null', async () => {
+    await expect(component.get(key)).rejects.toThrow()
+  })
+})
+
+describe('when getAllHashFields encounters a malformed JSON value', () => {
+  const hashKey = 'hash-with-bad-field'
+
+  beforeEach(() => {
+    hGetAllMock.mockResolvedValue({
+      good: JSON.stringify({ ok: true }),
+      bad: 'not-valid-json{'
+    })
+  })
+
+  it('should surface the offending field name in the structured log before throwing', async () => {
+    await expect(component.getAllHashFields(hashKey)).rejects.toThrow()
+
+    expect(errorLogMock).toHaveBeenCalledWith(
+      'Failed to parse hash field',
+      expect.objectContaining({ key: hashKey, field: 'bad' })
+    )
   })
 })

--- a/components/redis/tests/redis-component.spec.ts
+++ b/components/redis/tests/redis-component.spec.ts
@@ -1079,3 +1079,111 @@ describe('when releaseLock caches the Lua script via EVALSHA', () => {
     })
   })
 })
+
+describe('when acquireLock receives invalid lock options', () => {
+  describe('and retries is negative', () => {
+    it('should reject with a descriptive TypeError', async () => {
+      await expect(component.acquireLock('k', { retries: -1 })).rejects.toThrow(
+        /'retries' must be a non-negative integer/
+      )
+    })
+  })
+
+  describe('and retries is not an integer', () => {
+    it('should reject with a descriptive TypeError', async () => {
+      await expect(component.acquireLock('k', { retries: 1.5 })).rejects.toThrow(
+        /'retries' must be a non-negative integer/
+      )
+    })
+  })
+
+  describe('and retries is NaN', () => {
+    it('should reject with a descriptive TypeError', async () => {
+      await expect(component.acquireLock('k', { retries: NaN })).rejects.toThrow(
+        /'retries' must be a non-negative integer/
+      )
+    })
+  })
+
+  describe('and retryDelayInMilliseconds is negative', () => {
+    it('should reject with a descriptive TypeError', async () => {
+      await expect(
+        component.acquireLock('k', { retryDelayInMilliseconds: -5 })
+      ).rejects.toThrow(/'retryDelayInMilliseconds' must be a non-negative finite number/)
+    })
+  })
+
+  describe('and retryDelayInMilliseconds is Infinity', () => {
+    it('should reject with a descriptive TypeError', async () => {
+      await expect(
+        component.acquireLock('k', { retryDelayInMilliseconds: Infinity })
+      ).rejects.toThrow(/'retryDelayInMilliseconds' must be a non-negative finite number/)
+    })
+  })
+
+  describe('and ttlInMilliseconds is NaN', () => {
+    it('should reject with a descriptive TypeError', async () => {
+      await expect(
+        component.acquireLock('k', { ttlInMilliseconds: NaN })
+      ).rejects.toThrow(/'ttlInMilliseconds' must be a finite number/)
+    })
+  })
+})
+
+describe('when acquireLock is handed an AbortSignal', () => {
+  let lockKey: string
+
+  beforeEach(() => {
+    lockKey = 'abortable-lock'
+  })
+
+  describe('and the signal is already aborted at the call site', () => {
+    let controller: AbortController
+
+    beforeEach(() => {
+      controller = new AbortController()
+      controller.abort(new Error('cancelled before call'))
+    })
+
+    it('should reject with the abort reason without ever round-tripping to Redis', async () => {
+      await expect(
+        component.acquireLock(lockKey, { signal: controller.signal, retries: 50 })
+      ).rejects.toThrow('cancelled before call')
+    })
+
+    it('should not issue a SET command when the signal was pre-aborted', async () => {
+      await component
+        .acquireLock(lockKey, { signal: controller.signal, retries: 50 })
+        .catch(() => undefined)
+
+      expect(setMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and the signal is aborted mid-contention', () => {
+    let controller: AbortController
+
+    beforeEach(() => {
+      controller = new AbortController()
+      // Always report "lock already held" so the loop proceeds into
+      // the retry-sleep where the abort can take effect.
+      setMock.mockResolvedValue(null)
+    })
+
+    it('should reject with an AbortError rather than wait out the remaining retries', async () => {
+      const pending = component
+        .acquireLock(lockKey, {
+          signal: controller.signal,
+          retries: 100,
+          retryDelayInMilliseconds: 100
+        })
+        .catch((err) => err)
+
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      controller.abort()
+
+      const result = await pending
+      expect((result as { name: string }).name).toBe('AbortError')
+    })
+  })
+})

--- a/components/redis/tests/redis-component.spec.ts
+++ b/components/redis/tests/redis-component.spec.ts
@@ -677,3 +677,132 @@ describe('when getAllHashFields encounters a malformed JSON value', () => {
     )
   })
 })
+
+describe('when acquireLock is given a non-positive ttlInMilliseconds', () => {
+  const lockKey = 'clamped-lock'
+
+  beforeEach(() => {
+    setMock.mockResolvedValue('OK')
+  })
+
+  it('should clamp a zero ttl to the default instead of letting Redis reject PX: 0', async () => {
+    await component.acquireLock(lockKey, { ttlInMilliseconds: 0, retries: 1 })
+
+    expect(setMock).toHaveBeenCalledWith(
+      lockKey,
+      expect.any(String),
+      expect.objectContaining({ NX: true, PX: 10000 })
+    )
+  })
+
+  it('should clamp a negative ttl the same way', async () => {
+    await component.acquireLock(lockKey, { ttlInMilliseconds: -1, retries: 1 })
+
+    expect(setMock).toHaveBeenCalledWith(
+      lockKey,
+      expect.any(String),
+      expect.objectContaining({ NX: true, PX: 10000 })
+    )
+  })
+})
+
+describe('when acquireLock retries across multiple attempts', () => {
+  const lockKey = 'jittered-lock'
+
+  beforeEach(() => {
+    setMock.mockResolvedValueOnce(null).mockResolvedValueOnce(null).mockResolvedValueOnce('OK')
+  })
+
+  it('should apply equal jitter — each sleep lands within [delay/2, delay)', async () => {
+    // Deterministic jitter: pin Math.random so we can check the exact
+    // values. With random === 0.5 and retryDelay === 100, the sleep
+    // per retry is 100/2 + floor(0.5 * 100/2) = 50 + 25 = 75 ms.
+    const originalRandom = Math.random
+    Math.random = () => 0.5
+    try {
+      const start = Date.now()
+      await component.acquireLock(lockKey, { retryDelayInMilliseconds: 100, retries: 5 })
+      const elapsed = Date.now() - start
+
+      // Two sleeps between the three set attempts, each 75 ms.
+      expect(elapsed).toBeGreaterThanOrEqual(140)
+      expect(elapsed).toBeLessThan(220)
+    } finally {
+      Math.random = originalRandom
+    }
+  })
+})
+
+describe('when the connection lifecycle emits events', () => {
+  // The 'error' listener was the only one wired pre-fix. The component
+  // now also logs 'reconnecting', 'ready', and 'end' at debug level so
+  // a dropped/recovered connection is visible in operator logs.
+  let onCalls: Array<[string, (...args: any[]) => void]>
+
+  beforeEach(async () => {
+    // Re-build the component with a fresh on-spy so we can inspect the
+    // exact event-name/listener pairs it registered.
+    onCalls = []
+    const freshClient = {
+      ...mockRedisClient,
+      on: jest.fn((event: string, listener: (...args: any[]) => void) => {
+        onCalls.push([event, listener])
+      })
+    }
+    const { createClient } = require('redis')
+    createClient.mockReturnValue(freshClient)
+    await createRedisComponent(hostUrl, { logs })
+  })
+
+  it('should register error, reconnecting, ready, and end listeners', () => {
+    const events = onCalls.map(([event]) => event).sort()
+    expect(events).toEqual(['end', 'error', 'ready', 'reconnecting'])
+  })
+
+  it('should log a debug entry when the client reconnects', () => {
+    const reconnecting = onCalls.find(([event]) => event === 'reconnecting')![1]
+    reconnecting()
+
+    expect(debugLogMock).toHaveBeenCalledWith('Redis client reconnecting')
+  })
+
+  it('should log a debug entry when the client becomes ready', () => {
+    const ready = onCalls.find(([event]) => event === 'ready')![1]
+    ready()
+
+    expect(debugLogMock).toHaveBeenCalledWith('Redis client ready')
+  })
+
+  it('should log a debug entry when the connection ends', () => {
+    const end = onCalls.find(([event]) => event === 'end')![1]
+    end()
+
+    expect(debugLogMock).toHaveBeenCalledWith('Redis client connection ended')
+  })
+})
+
+describe('when setInHash is called and the transaction contains a per-command error', () => {
+  // node-redis's MULTI resolves with per-command Error instances when a
+  // queued command failed; it does not throw the whole transaction. If
+  // the component didn't inspect the reply, a partial failure would be
+  // silently reported as success.
+  const hashKey = 'hash'
+  const field = 'field'
+
+  beforeEach(() => {
+    execMock.mockResolvedValue([new Error('WRONGTYPE Operation against a key holding the wrong kind of value')])
+  })
+
+  it('should throw the per-command error so the caller sees the failure', async () => {
+    await expect(component.setInHash(hashKey, field, { a: 1 })).rejects.toThrow(/WRONGTYPE/)
+  })
+
+  it('should log the failure with the key and field context', async () => {
+    await expect(component.setInHash(hashKey, field, { a: 1 })).rejects.toThrow()
+
+    expect(errorLogMock).toHaveBeenCalledWith(
+      'Error setting hash field',
+      expect.objectContaining({ key: hashKey, field })
+    )
+  })
+})

--- a/components/redis/tests/redis-component.spec.ts
+++ b/components/redis/tests/redis-component.spec.ts
@@ -818,16 +818,15 @@ describe('when start() is called concurrently', () => {
   // against sequential double-starts. Two callers firing before the
   // first connect resolves would both see `isOpen: false` and race.
   // The gate now funnels them onto a single startPromise.
-  let connectResolve: (() => void) | null
   let freshComponent: ICacheStorageComponent
+  let slowConnect: jest.Mock
+  let resolveConnect: () => void
+  const lifecycleOptions = { started: () => true, live: () => true, getComponents: () => ({}) }
 
   beforeEach(async () => {
-    connectResolve = null
-    // Make connect() intentionally slow so the two start() callers
-    // actually overlap rather than resolving sequentially.
-    const slowConnect = jest.fn().mockImplementation(() => {
+    slowConnect = jest.fn().mockImplementation(() => {
       return new Promise<void>((resolve) => {
-        connectResolve = () => {
+        resolveConnect = () => {
           mockRedisClient.isOpen = true
           resolve()
         }
@@ -839,25 +838,16 @@ describe('when start() is called concurrently', () => {
     createClient.mockReturnValue(freshClient)
     freshComponent = await createRedisComponent(hostUrl, { logs })
 
-    // Fire two start() calls before the first resolves.
-    const a = freshComponent[START_COMPONENT]!({
-      started: () => true,
-      live: () => true,
-      getComponents: () => ({})
-    })
-    const b = freshComponent[START_COMPONENT]!({
-      started: () => true,
-      live: () => true,
-      getComponents: () => ({})
-    })
-
-    connectResolve!()
+    // Fire two start() calls before the first resolves so the gate
+    // actually has something to deduplicate.
+    const a = freshComponent[START_COMPONENT]!(lifecycleOptions)
+    const b = freshComponent[START_COMPONENT]!(lifecycleOptions)
+    resolveConnect()
     await Promise.all([a, b])
-    mockRedisClient.connect = slowConnect
   })
 
-  it('should issue connect() exactly once even under two concurrent start() calls', () => {
-    expect((mockRedisClient.connect as jest.Mock).mock.calls.length).toBe(1)
+  it('should issue connect() exactly once, funnelling both callers onto the same in-flight promise', () => {
+    expect(slowConnect).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -865,42 +855,79 @@ describe('when the Redis URL contains credentials', () => {
   // The `hostUrl` was logged at debug level verbatim, which meant a
   // managed-Redis password (very common shape) would show up in the
   // connection-start log.
+  let credentialedUrl: string
+  const lifecycleOptions = { started: () => true, live: () => true, getComponents: () => ({}) }
+
   beforeEach(async () => {
+    credentialedUrl = 'redis://default:supersecret@example.com:6379'
     const freshClient = { ...mockRedisClient, isOpen: false }
     const { createClient } = require('redis')
     createClient.mockReturnValue(freshClient)
-    const comp = await createRedisComponent('redis://default:supersecret@example.com:6379', { logs })
-    await comp[START_COMPONENT]!({ started: () => true, live: () => true, getComponents: () => ({}) })
+    const comp = await createRedisComponent(credentialedUrl, { logs })
+    await comp[START_COMPONENT]!(lifecycleOptions)
   })
 
-  it('should redact the user-info section before logging the connect line', () => {
-    expect(debugLogMock).toHaveBeenCalledWith('Connecting to Redis', { hostUrl: 'redis://***:***@example.com:6379' })
-    // Belt and suspenders: no call should ever contain the raw password.
+  it('should log the connect line with the user-info section redacted', () => {
+    expect(debugLogMock).toHaveBeenCalledWith('Connecting to Redis', {
+      hostUrl: 'redis://***:***@example.com:6379'
+    })
+  })
+
+  it('should never emit the raw password in any debug log call', () => {
     for (const call of debugLogMock.mock.calls) {
       expect(JSON.stringify(call)).not.toContain('supersecret')
     }
   })
 })
 
-describe('when set and setInHash are given an undefined value', () => {
+describe('when a write is given an undefined value', () => {
   // Mirror the memory-cache guard: JSON.stringify(undefined) === undefined,
   // which node-redis then serialises inconsistently — reject synchronously
   // so both implementations of ICacheStorageComponent agree.
-  it('set() should reject rather than hand undefined to the client', async () => {
-    await expect(component.set('k', undefined as unknown as string)).rejects.toThrow(/undefined value/)
-    expect(setMock).not.toHaveBeenCalled()
+  let key: string
+
+  beforeEach(() => {
+    key = 'undefined-target'
   })
 
-  it('setInHash() should reject rather than hand undefined to the client', async () => {
-    await expect(component.setInHash('k', 'f', undefined as unknown as string)).rejects.toThrow(
-      /undefined value/
-    )
-    expect(hSetMock).not.toHaveBeenCalled()
+  describe('and set() is called', () => {
+    it('should reject with an error that mentions the undefined value', async () => {
+      await expect(component.set(key, undefined as unknown as string)).rejects.toThrow(/undefined value/)
+    })
+
+    it('should never reach the underlying client', async () => {
+      await component.set(key, undefined as unknown as string).catch(() => undefined)
+
+      expect(setMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and setInHash() is called', () => {
+    let field: string
+
+    beforeEach(() => {
+      field = 'f'
+    })
+
+    it('should reject with an error that mentions the undefined value', async () => {
+      await expect(
+        component.setInHash(key, field, undefined as unknown as string)
+      ).rejects.toThrow(/undefined value/)
+    })
+
+    it('should never reach the underlying client', async () => {
+      await component
+        .setInHash(key, field, undefined as unknown as string)
+        .catch(() => undefined)
+
+      expect(hSetMock).not.toHaveBeenCalled()
+    })
   })
 })
 
 describe('when the client error handler fires with a stack-bearing Error', () => {
   let onCalls: Array<[string, (...args: any[]) => void]>
+  let err: Error
 
   beforeEach(async () => {
     onCalls = []
@@ -913,82 +940,118 @@ describe('when the client error handler fires with a stack-bearing Error', () =>
     const { createClient } = require('redis')
     createClient.mockReturnValue(freshClient)
     await createRedisComponent(hostUrl, { logs })
+
+    err = new Error('boom')
+    const handler = onCalls.find(([event]) => event === 'error')![1]
+    handler(err)
+  })
+
+  it('should include the error message in the structured payload', () => {
+    expect(errorLogMock).toHaveBeenCalledWith(
+      'Redis client error',
+      expect.objectContaining({ error: 'boom' })
+    )
   })
 
   it('should include the stack trace in the structured payload', () => {
-    const handler = onCalls.find(([event]) => event === 'error')![1]
-    const err = new Error('boom')
-
-    handler(err)
-
     expect(errorLogMock).toHaveBeenCalledWith(
       'Redis client error',
-      expect.objectContaining({ error: 'boom', stack: err.stack })
+      expect.objectContaining({ stack: err.stack })
     )
   })
 })
 
-describe('when releaseLock can cache the Lua script via EVALSHA', () => {
-  const lockKey = 'releasable'
+describe('when releaseLock caches the Lua script via EVALSHA', () => {
+  let lockKey: string
 
-  it('should fall back to EVAL on the first call and then kick off SCRIPT LOAD to prime EVALSHA', async () => {
-    evalMock.mockResolvedValue(1)
-    scriptLoadMock.mockResolvedValue('cached-sha')
-
-    await component.releaseLock(lockKey)
-
-    expect(evalMock).toHaveBeenCalledTimes(1)
-    // Best-effort SCRIPT LOAD is not awaited; flush microtasks.
-    await Promise.resolve()
-    await Promise.resolve()
-    expect(scriptLoadMock).toHaveBeenCalled()
+  beforeEach(() => {
+    lockKey = 'releasable-lock'
   })
 
-  it('should use EVALSHA on subsequent calls once the SHA has been cached', async () => {
-    evalMock.mockResolvedValue(1)
-    scriptLoadMock.mockResolvedValue('cached-sha')
-    evalShaMock.mockResolvedValue(1)
+  describe('and it is the first call against the component', () => {
+    beforeEach(async () => {
+      evalMock.mockResolvedValue(1)
+      scriptLoadMock.mockResolvedValue('cached-sha')
 
-    // First call populates the SHA via the async scriptLoad follow-up.
-    await component.releaseLock(lockKey)
-    await Promise.resolve()
-    await Promise.resolve()
+      await component.releaseLock(lockKey)
+      // Best-effort SCRIPT LOAD is fired off the critical path; give
+      // the microtask queue two ticks to settle before asserting.
+      await Promise.resolve()
+      await Promise.resolve()
+    })
 
-    // Second call: now on the fast path.
-    await component.releaseLock(lockKey)
+    it('should execute the release via EVAL', () => {
+      expect(evalMock).toHaveBeenCalledTimes(1)
+    })
 
-    expect(evalShaMock).toHaveBeenCalledTimes(1)
-    expect(evalShaMock).toHaveBeenCalledWith('cached-sha', expect.objectContaining({ keys: [lockKey] }))
+    it('should kick off SCRIPT LOAD to prime EVALSHA for the next call', () => {
+      expect(scriptLoadMock).toHaveBeenCalled()
+    })
   })
 
-  it('should fall back to EVAL and drop the cached SHA when the server replies NOSCRIPT', async () => {
-    evalMock.mockResolvedValue(1)
-    scriptLoadMock.mockResolvedValue('cached-sha')
-    evalShaMock
-      .mockRejectedValueOnce(new Error('NOSCRIPT No matching script. Please use EVAL.'))
-      .mockResolvedValue(1)
+  describe('and a previous call has primed the SHA cache', () => {
+    beforeEach(async () => {
+      evalMock.mockResolvedValue(1)
+      scriptLoadMock.mockResolvedValue('cached-sha')
+      evalShaMock.mockResolvedValue(1)
 
-    // Prime the SHA.
-    await component.releaseLock(lockKey)
-    await Promise.resolve()
-    await Promise.resolve()
+      // Prime: EVAL + async SCRIPT LOAD.
+      await component.releaseLock(lockKey)
+      await Promise.resolve()
+      await Promise.resolve()
 
-    evalMock.mockClear()
+      // The second call is the one under test.
+      await component.releaseLock(lockKey)
+    })
 
-    // Second call: evalSha throws NOSCRIPT -> falls back to EVAL.
-    await component.releaseLock(lockKey)
+    it('should execute the release via EVALSHA on the second call', () => {
+      expect(evalShaMock).toHaveBeenCalledTimes(1)
+    })
 
-    expect(evalMock).toHaveBeenCalledTimes(1)
+    it('should pass the cached SHA and the lock key as its EVALSHA arguments', () => {
+      expect(evalShaMock).toHaveBeenCalledWith(
+        'cached-sha',
+        expect.objectContaining({ keys: [lockKey] })
+      )
+    })
   })
 
-  it('should treat a synchronous scriptLoad failure as a soft fallback to EVAL', async () => {
-    evalMock.mockResolvedValue(1)
-    // Simulate a client that doesn't expose scriptLoad at all.
-    const freshClient = { ...mockRedisClient, isOpen: false, scriptLoad: undefined }
-    const { createClient } = require('redis')
-    createClient.mockReturnValue(freshClient)
-    const comp = await createRedisComponent(hostUrl, { logs })
+  describe('and the Redis server replies NOSCRIPT', () => {
+    beforeEach(async () => {
+      evalMock.mockResolvedValue(1)
+      scriptLoadMock.mockResolvedValue('cached-sha')
+      evalShaMock
+        .mockRejectedValueOnce(new Error('NOSCRIPT No matching script. Please use EVAL.'))
+        .mockResolvedValue(1)
 
-    await expect(comp.releaseLock(lockKey)).resolves.not.toThrow()
+      // Prime the SHA via a successful first call.
+      await component.releaseLock(lockKey)
+      await Promise.resolve()
+      await Promise.resolve()
+      evalMock.mockClear()
+
+      // The second call observes the NOSCRIPT and falls back.
+      await component.releaseLock(lockKey)
+    })
+
+    it('should fall back to EVAL for the release', () => {
+      expect(evalMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('and the client does not expose scriptLoad at all', () => {
+    let comp: ICacheStorageComponent
+
+    beforeEach(async () => {
+      evalMock.mockResolvedValue(1)
+      const freshClient = { ...mockRedisClient, isOpen: false, scriptLoad: undefined }
+      const { createClient } = require('redis')
+      createClient.mockReturnValue(freshClient)
+      comp = await createRedisComponent(hostUrl, { logs })
+    })
+
+    it('should still resolve releaseLock via EVAL without throwing', async () => {
+      await expect(comp.releaseLock(lockKey)).resolves.not.toThrow()
+    })
   })
 })

--- a/components/redis/tests/redis-component.spec.ts
+++ b/components/redis/tests/redis-component.spec.ts
@@ -12,7 +12,7 @@ let logs: ILoggerComponent
 let component: ICacheStorageComponent
 let mockRedisClient: any
 let connectMock: jest.Mock
-let quitMock: jest.Mock
+let closeMock: jest.Mock
 let getMock: jest.Mock
 let setMock: jest.Mock
 let delMock: jest.Mock
@@ -32,7 +32,7 @@ const hostUrl = 'redis://localhost:6379'
 
 beforeEach(async () => {
   connectMock = jest.fn().mockResolvedValue(undefined)
-  quitMock = jest.fn().mockResolvedValue(undefined)
+  closeMock = jest.fn().mockResolvedValue(undefined)
   getMock = jest.fn()
   setMock = jest.fn().mockResolvedValue('OK')
   delMock = jest.fn().mockResolvedValue(1)
@@ -54,7 +54,7 @@ beforeEach(async () => {
 
   mockRedisClient = {
     connect: connectMock,
-    quit: quitMock,
+    close: closeMock,
     get: getMock,
     set: setMock,
     del: delMock,
@@ -79,6 +79,37 @@ beforeEach(async () => {
   component = await createRedisComponent(hostUrl, { logs })
 })
 
+describe('when working with mixed-case keys', () => {
+  // Redis is case-sensitive. This suite guards against regressing back to
+  // the previous behavior that silently lower-cased keys only on some
+  // methods, which made `set(K)`/`setInHash(K,…)`/`keys(K*)` refer to
+  // different underlying Redis keys.
+  const mixedCaseKey = 'MixedCase:Key'
+  const serializedValue = JSON.stringify({ ok: true })
+
+  beforeEach(() => {
+    getMock.mockResolvedValue(serializedValue)
+    hGetAllMock.mockResolvedValue({})
+  })
+
+  it('should preserve the original case in get/set/remove/keys/acquireLock/releaseLock/setInHash', async () => {
+    await component.set(mixedCaseKey, { ok: true })
+    await component.get(mixedCaseKey)
+    await component.remove(mixedCaseKey)
+    await component.setInHash(mixedCaseKey, 'Field', { ok: true })
+    evalMock.mockResolvedValueOnce(1)
+    await component.acquireLock(mixedCaseKey, { retries: 1 })
+    await component.releaseLock(mixedCaseKey)
+
+    expect(setMock).toHaveBeenCalledWith(mixedCaseKey, serializedValue, undefined)
+    expect(getMock).toHaveBeenCalledWith(mixedCaseKey)
+    expect(delMock).toHaveBeenCalledWith(mixedCaseKey)
+    expect(hSetMock).toHaveBeenCalledWith(mixedCaseKey, 'Field', serializedValue)
+    expect(setMock).toHaveBeenCalledWith(mixedCaseKey, expect.any(String), expect.objectContaining({ NX: true }))
+    expect(evalMock).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ keys: [mixedCaseKey] }))
+  })
+})
+
 describe('when storing and retrieving values', () => {
   const testKey = 'test-key'
   const testValue = { id: 123, name: 'test' }
@@ -89,8 +120,8 @@ describe('when storing and retrieving values', () => {
       await component.set(testKey, testValue)
     })
 
-    it('should call Redis set with serialized value', () => {
-      expect(setMock).toHaveBeenCalledWith(testKey.toLowerCase(), serializedValue, { EX: undefined })
+    it('should call Redis set with the serialized value and no EX option', () => {
+      expect(setMock).toHaveBeenCalledWith(testKey, serializedValue, undefined)
     })
   })
 
@@ -102,7 +133,7 @@ describe('when storing and retrieving values', () => {
     })
 
     it('should call Redis set with TTL', () => {
-      expect(setMock).toHaveBeenCalledWith(testKey.toLowerCase(), serializedValue, { EX: ttl })
+      expect(setMock).toHaveBeenCalledWith(testKey, serializedValue, { EX: ttl })
     })
   })
 
@@ -114,7 +145,7 @@ describe('when storing and retrieving values', () => {
     it('should retrieve and deserialize the value', async () => {
       const result = await component.get(testKey)
 
-      expect(getMock).toHaveBeenCalledWith(testKey.toLowerCase())
+      expect(getMock).toHaveBeenCalledWith(testKey)
       expect(result).toEqual(testValue)
     })
   })
@@ -127,7 +158,7 @@ describe('when storing and retrieving values', () => {
     it('should return null', async () => {
       const result = await component.get(testKey)
 
-      expect(getMock).toHaveBeenCalledWith(testKey.toLowerCase())
+      expect(getMock).toHaveBeenCalledWith(testKey)
       expect(result).toBeNull()
     })
   })
@@ -138,7 +169,7 @@ describe('when storing and retrieving values', () => {
     })
 
     it('should call Redis del command', () => {
-      expect(delMock).toHaveBeenCalledWith(testKey.toLowerCase())
+      expect(delMock).toHaveBeenCalledWith(testKey)
     })
   })
 })
@@ -364,7 +395,7 @@ describe('when acquiring locks', () => {
         retries: 5
       })
 
-      expect(setMock).toHaveBeenCalledWith(lockKey.toLowerCase(), expect.any(String), { NX: true, EX: 5000 })
+      expect(setMock).toHaveBeenCalledWith(lockKey, expect.any(String), { NX: true, PX: 5000 })
     })
   })
 
@@ -416,7 +447,7 @@ describe('when releasing locks', () => {
       await component.releaseLock(lockKey)
 
       expect(evalMock).toHaveBeenCalledWith(expect.stringContaining('if redis.call("GET", KEYS[1]) == ARGV[1]'), {
-        keys: [lockKey.toLowerCase()],
+        keys: [lockKey],
         arguments: [expect.any(String)]
       })
     })
@@ -431,7 +462,7 @@ describe('when releasing locks', () => {
       await expect(component.releaseLock(lockKey)).rejects.toThrow(LockNotReleasedError)
 
       expect(evalMock).toHaveBeenCalledWith(expect.stringContaining('if redis.call("GET", KEYS[1]) == ARGV[1]'), {
-        keys: [lockKey.toLowerCase()],
+        keys: [lockKey],
         arguments: [expect.any(String)]
       })
     })
@@ -462,7 +493,7 @@ describe('when trying to acquire locks', () => {
       const result = await component.tryAcquireLock(lockKey)
 
       expect(result).toBe(true)
-      expect(setMock).toHaveBeenCalledWith(lockKey.toLowerCase(), expect.any(String), { NX: true, EX: 10000 })
+      expect(setMock).toHaveBeenCalledWith(lockKey, expect.any(String), { NX: true, PX: 10000 })
     })
 
     it('should return true with custom options', async () => {
@@ -472,7 +503,7 @@ describe('when trying to acquire locks', () => {
       })
 
       expect(result).toBe(true)
-      expect(setMock).toHaveBeenCalledWith(lockKey.toLowerCase(), expect.any(String), { NX: true, EX: 5000 })
+      expect(setMock).toHaveBeenCalledWith(lockKey, expect.any(String), { NX: true, PX: 5000 })
     })
   })
 
@@ -515,7 +546,7 @@ describe('when trying to release locks', () => {
 
       expect(result).toBe(true)
       expect(evalMock).toHaveBeenCalledWith(expect.stringContaining('if redis.call("GET", KEYS[1]) == ARGV[1]'), {
-        keys: [lockKey.toLowerCase()],
+        keys: [lockKey],
         arguments: [expect.any(String)]
       })
     })
@@ -531,7 +562,7 @@ describe('when trying to release locks', () => {
 
       expect(result).toBe(false)
       expect(evalMock).toHaveBeenCalledWith(expect.stringContaining('if redis.call("GET", KEYS[1]) == ARGV[1]'), {
-        keys: [lockKey.toLowerCase()],
+        keys: [lockKey],
         arguments: [expect.any(String)]
       })
     })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,8 +241,8 @@ importers:
         specifier: ^1.5.2
         version: 1.5.2
       redis:
-        specifier: ^5.9.0
-        version: 5.9.0
+        specifier: ^5.12.1
+        version: 5.12.1(@opentelemetry/api@1.9.0)
     devDependencies:
       '@types/node':
         specifier: ^22.13.10
@@ -1274,33 +1274,41 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
-  '@redis/bloom@5.9.0':
-    resolution: {integrity: sha512-W9D8yfKTWl4tP8lkC3MRYkMz4OfbuzE/W8iObe0jFgoRmgMfkBV+Vj38gvIqZPImtY0WB34YZkX3amYuQebvRQ==}
-    engines: {node: '>= 18'}
+  '@redis/bloom@5.12.1':
+    resolution: {integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==}
+    engines: {node: '>= 18.19.0'}
     peerDependencies:
-      '@redis/client': ^5.9.0
+      '@redis/client': ^5.12.1
 
-  '@redis/client@5.9.0':
-    resolution: {integrity: sha512-EI0Ti5pojD2p7TmcS7RRa+AJVahdQvP/urpcSbK/K9Rlk6+dwMJTQ354pCNGCwfke8x4yKr5+iH85wcERSkwLQ==}
-    engines: {node: '>= 18'}
-
-  '@redis/json@5.9.0':
-    resolution: {integrity: sha512-Bm2jjLYaXdUWPb9RaEywxnjmzw7dWKDZI4MS79mTWPV16R982jVWBj6lY2ZGelJbwxHtEVg4/FSVgYDkuO/MxA==}
-    engines: {node: '>= 18'}
+  '@redis/client@5.12.1':
+    resolution: {integrity: sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==}
+    engines: {node: '>= 18.19.0'}
     peerDependencies:
-      '@redis/client': ^5.9.0
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
 
-  '@redis/search@5.9.0':
-    resolution: {integrity: sha512-jdk2csmJ29DlpvCIb2ySjix2co14/0iwIT3C0I+7ZaToXgPbgBMB+zfEilSuncI2F9JcVxHki0YtLA0xX3VdpA==}
-    engines: {node: '>= 18'}
+  '@redis/json@5.12.1':
+    resolution: {integrity: sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==}
+    engines: {node: '>= 18.19.0'}
     peerDependencies:
-      '@redis/client': ^5.9.0
+      '@redis/client': ^5.12.1
 
-  '@redis/time-series@5.9.0':
-    resolution: {integrity: sha512-W6ILxcyOqhnI7ELKjJXOktIg3w4+aBHugDbVpgVLPZ+YDjObis1M0v7ZzwlpXhlpwsfePfipeSK+KWNuymk52w==}
-    engines: {node: '>= 18'}
+  '@redis/search@5.12.1':
+    resolution: {integrity: sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==}
+    engines: {node: '>= 18.19.0'}
     peerDependencies:
-      '@redis/client': ^5.9.0
+      '@redis/client': ^5.12.1
+
+  '@redis/time-series@5.12.1':
+    resolution: {integrity: sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -3019,6 +3027,7 @@ packages:
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -4000,9 +4009,9 @@ packages:
   readdir-glob@1.1.3:
     resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
-  redis@5.9.0:
-    resolution: {integrity: sha512-E8dQVLSyH6UE/C9darFuwq4usOPrqfZ1864kI4RFbr5Oj9ioB9qPF0oJMwX7s8mf6sPYrz84x/Dx1PGF3/0EaQ==}
-    engines: {node: '>= 18'}
+  redis@5.12.1:
+    resolution: {integrity: sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==}
+    engines: {node: '>= 18.19.0'}
 
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
@@ -6549,25 +6558,27 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@redis/bloom@5.9.0(@redis/client@5.9.0)':
+  '@redis/bloom@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.0))':
     dependencies:
-      '@redis/client': 5.9.0
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.0)
 
-  '@redis/client@5.9.0':
+  '@redis/client@5.12.1(@opentelemetry/api@1.9.0)':
     dependencies:
       cluster-key-slot: 1.1.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
 
-  '@redis/json@5.9.0(@redis/client@5.9.0)':
+  '@redis/json@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.0))':
     dependencies:
-      '@redis/client': 5.9.0
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.0)
 
-  '@redis/search@5.9.0(@redis/client@5.9.0)':
+  '@redis/search@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.0))':
     dependencies:
-      '@redis/client': 5.9.0
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.0)
 
-  '@redis/time-series@5.9.0(@redis/client@5.9.0)':
+  '@redis/time-series@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.0))':
     dependencies:
-      '@redis/client': 5.9.0
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.0)
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -10175,13 +10186,16 @@ snapshots:
     dependencies:
       minimatch: 5.1.6
 
-  redis@5.9.0:
+  redis@5.12.1(@opentelemetry/api@1.9.0):
     dependencies:
-      '@redis/bloom': 5.9.0(@redis/client@5.9.0)
-      '@redis/client': 5.9.0
-      '@redis/json': 5.9.0(@redis/client@5.9.0)
-      '@redis/search': 5.9.0(@redis/client@5.9.0)
-      '@redis/time-series': 5.9.0(@redis/client@5.9.0)
+      '@redis/bloom': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.0))
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.0)
+      '@redis/json': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.0))
+      '@redis/search': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.0))
+      '@redis/time-series': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.0))
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
 
   reflect-metadata@0.2.2: {}
 

--- a/shared/commons/src/types.ts
+++ b/shared/commons/src/types.ts
@@ -5,6 +5,26 @@ export interface ASharedType {
   a: string
 }
 
+/**
+ * Options accepted by the lock-acquisition methods on
+ * {@link ICacheStorageComponent}.
+ */
+export interface AcquireLockOptions {
+  /** Time-to-live for the lock in milliseconds. Default: 10_000. */
+  ttlInMilliseconds?: number
+  /** Delay between retries in milliseconds. Default: 200. */
+  retryDelayInMilliseconds?: number
+  /** Number of retry attempts. Default: 10. */
+  retries?: number
+  /**
+   * Optional AbortSignal that cancels the retry loop. The promise
+   * rejects with the signal's `reason` (or an `AbortError` if none
+   * was set) as soon as the abort is observed — between retries, or
+   * before the first attempt if the signal is already aborted.
+   */
+  signal?: AbortSignal
+}
+
 export interface ICacheStorageComponent extends IBaseComponent {
   /**
    * Retrieves a value from cache by key.
@@ -68,7 +88,7 @@ export interface ICacheStorageComponent extends IBaseComponent {
    */
   acquireLock(
     key: string,
-    options?: { ttlInMilliseconds?: number; retryDelayInMilliseconds?: number; retries?: number }
+    options?: AcquireLockOptions
   ): Promise<void>
   /**
    * Releases a lock for a key. Throws LockNotReleasedError if lock cannot be released.
@@ -87,7 +107,7 @@ export interface ICacheStorageComponent extends IBaseComponent {
    */
   tryAcquireLock(
     key: string,
-    options?: { ttlInMilliseconds?: number; retryDelayInMilliseconds?: number; retries?: number }
+    options?: AcquireLockOptions
   ): Promise<boolean>
   /**
    * Attempts to release a lock for a key without throwing errors.


### PR DESCRIPTION
## Summary

Harden `@dcl/redis-component` across lock semantics, lifecycle, observability, and API surface. Two breaking changes — the lock-TTL unit fix and dropping implicit key lower-casing — plus a long list of quality fixes that kept surfacing while auditing adjacent code. Also bumps `redis` to `^5.12.1` (same major; pulls in a handshake-race fix and minor dep cleanups). The shared `ICacheStorageComponent` interface gains an additive `AcquireLockOptions` type with an optional `signal: AbortSignal` (minor bump on `@dcl/core-commons`); the same change lands on [#78](https://github.com/decentraland/core-components/pull/78) so both PRs are self-contained.

## Breaking changes

### `acquireLock` is `PX` now, not `EX`
`SET … EX n` reads `n` as seconds. The code was passing `ttlInMilliseconds` directly into `EX`, so the default 10-second lock was actually a **10 000-second (~2.7-hour) lock**. Switched to `PX` so the unit matches the option name. The existing test at `redis-component.spec.ts:367` was asserting the bug (`{ NX: true, EX: 5000 }` after `ttlInMilliseconds: 5000`) — flipped to `PX: 5000` alongside the fix.

### All methods preserve the caller's key case
Removed every `.toLowerCase()` on user-provided keys in `get` / `set` / `remove` / `keys` / `acquireLock` / `releaseLock`. Hash methods already preserved case, so the two API shapes were silently diverging for mixed-case keys, and `set('Foo')` + `keys('F*')` was returning `[]` even though the key was there under `foo`. Matches Redis's native case-sensitivity. Mixed-case data written before this version stays under its old lower-cased names; callers that want it back need to lower-case at the call site or treat this as a cache reset.

## How (grouped by concern)

### Lock safety
- `PX` unit fix (above).
- `acquireLock` clamps non-positive `ttlInMilliseconds` back to the default instead of forwarding `PX: 0` (Redis rejects that as "invalid expire time in set" — the caller would only see a bare `LockNotAcquiredError`).
- `acquireLock` validates `retries` / `retryDelayInMilliseconds` / `ttlInMilliseconds` up front and throws a descriptive `TypeError` on `NaN` / `Infinity` / negative input instead of silently misbehaving.
- `acquireLock` retry delay uses equal-jitter backoff — `Math.floor(retryDelay/2 + Math.random() * retryDelay/2)` — so concurrent consumers contending on the same key don't phase-lock onto the same wake-up tick. The `Math.floor` wrap keeps the sleep integer-millisecond for odd `retryDelay`.
- `acquireLock` / `tryAcquireLock` accept an optional `signal: AbortSignal` (via `timers/promises#setTimeout`) that rejects the pending acquisition with the signal's reason the moment abort fires — between retries, or before the first round-trip if the signal is already aborted.
- `releaseLock` uses `EVALSHA` with a cached SHA once `SCRIPT LOAD` succeeds, falling back to `EVAL` on the first call and on `NOSCRIPT` replies (e.g. after a server-side `SCRIPT FLUSH` or failover). A synchronous `scriptLoad` failure (older client, older mock) is treated as a soft fallback.

### Lifecycle
- `start()` is idempotent *and* concurrency-safe: two callers firing before the first `connect()` resolves are both funnelled onto the same `startPromise`, so the second no longer races past the `isOpen` guard and crashes with "Socket already opened". `startPromise` clears on success and failure so retries still work.
- `stop()` short-circuits when `isOpen` is false, avoiding "Socket is closed" on double invocation.
- Connection lifecycle is now observable: `reconnecting`, `ready`, and `end` are logged at debug level alongside the existing `error` handler, which now carries `err.stack` as well.
- Connection URL is redacted via `URL` before hitting debug logs — managed-Redis URLs of the shape `redis://user:password@host:port` previously wrote the password into the connection-start line.

### Data integrity
- `set` rejects an `undefined` value synchronously; `JSON.stringify(undefined) === undefined` would otherwise reach the wire and error unpredictably. `setInHash` does the same.
- `set` no longer passes `{ EX: undefined }` when no TTL is supplied (node-redis interprets that inconsistently across versions).
- `get` / `getFromHash` check `null`/`undefined` explicitly instead of a truthy test, then wrap `JSON.parse` and log the offending `{ key, field? }` context before rethrowing — a corrupted entry no longer produces a bare `SyntaxError`.
- `getAllHashFields` iterates field-by-field with the same per-field error context.
- `setInHash` inspects the `multi().exec()` replies. Per-command errors (e.g. `WRONGTYPE`) were previously swallowed because the transaction resolved with per-command `Error` instances instead of throwing; now they surface to the caller with `{ key, field }` context.

### Test double and hygiene
- The test double now exposes `close` (not the unused `quit`), an `isOpen` flag that `connect` / `close` flip, plus `evalSha` and `scriptLoad` mocks. Previously-uncovered start / stop / parse-error / jitter / lifecycle-event / transaction-error / EVALSHA-cache / concurrent-start / credential-redaction / AbortSignal / input-validation paths now have tests.
- The redundant `await` on synchronous `client.multi()` is removed.
- All `logger.error` calls follow a structured `{ error, stack? }` payload via a shared `errorLogPayload` helper.

## Dependencies
- `redis`: `^5.9.0` → `^5.12.1`. Same major; none of the APIs we use changed shape. Pulls in the 5.10 handshake-race fix, IPv6 URL support (5.11), and OTel hooks (5.12) — no behavior change for this component.

## Test plan
- [x] `pnpm --filter @dcl/redis-component test` — **71 passing** (28 pre-existing + 43 new).
- [x] `pnpm -r build` — clean across the workspace.
- [x] Dedicated suites for mixed-case keys, start/stop idempotency + concurrent start, `get` empty-string, `getAllHashFields` per-field error, `getFromHash` per-field error, TTL clamp on 0 / negative, equal-jitter retry, connection lifecycle events, `setInHash` transaction error, AbortSignal pre-call / mid-contention, option validation.
- [ ] Manual smoke test against a real Redis instance after merge.