### PR TITLE
fix: pg-component rollback, shutdown and stream-query handling

### DIFF
--- a/.changeset/pg-component-review-fixes.md
+++ b/.changeset/pg-component-review-fixes.md
@@ -1,0 +1,17 @@
+---
+"@dcl/pg-component": minor
+---
+
+Review fixes and configuration improvements:
+
+- Preserve the original transaction error when `ROLLBACK` itself fails in `withTransaction` / `withAsyncContextTransaction`, and release the broken client with `client.release(rollbackError)` so `pg` discards it instead of reusing it.
+- Attach a `pool.on('error')` handler so idle-client errors are logged instead of bubbling up as unhandled Node errors; remove it on `stop()`.
+- Attach a `client.on('error')` handler for the dedicated stream-query client for the same reason.
+- Bound `stop()` with a new `PG_COMPONENT_STOP_TIMEOUT` env var (default 30s) so a stuck query can't block shutdown forever; the drain loop no longer busy-spins when `totalCount` is zero.
+- `streamQuery` no longer clobbers `query_timeout` with `undefined` when `PG_COMPONENT_STREAM_QUERY_TIMEOUT` is unset; it now falls back to `PG_COMPONENT_QUERY_TIMEOUT`.
+- New `PG_COMPONENT_CONNECTION_TIMEOUT` env var wired into `connectionTimeoutMillis` so `pool.connect()` can't hang forever if the DB is unreachable.
+- `PG_COMPONENT_GRACE_PERIODS` fallback now uses `??` instead of `||`, so setting it to `0` actually disables draining.
+- `start()` is now idempotent (guarded by a flag) and logs structured errors.
+- Unified `query` / `measuredQuery` / `defaultQuery` into a single `query` function, removing a non-null assertion on `components.metrics`.
+- Added `durationQueryNameLabel` to the `string` overload of `query` for parity with the `SQLStatement` overload.
+- Documented in JSDoc and README that concurrent queries inside `withAsyncContextTransaction` are unsafe.

--- a/components/pg/README.md
+++ b/components/pg/README.md
@@ -85,6 +85,26 @@ await pg.withAsyncContextTransaction(async () => {
 })
 ```
 
+#### Do not run concurrent queries inside `withAsyncContextTransaction`
+
+All `pg.query()` calls inside the callback share the single `Client` held by the async context. Running them in parallel (e.g. `Promise.all`) will issue concurrent commands on the same connection, which `pg` does not support and will fail or corrupt state:
+
+```typescript
+// ❌ WRONG - concurrent queries on the same transaction client
+await pg.withAsyncContextTransaction(async () => {
+  await Promise.all([
+    pg.query(SQL`INSERT INTO users (name) VALUES ('Alice')`),
+    pg.query(SQL`INSERT INTO users (name) VALUES ('Bob')`)
+  ])
+})
+
+// ✅ CORRECT - await queries sequentially
+await pg.withAsyncContextTransaction(async () => {
+  await pg.query(SQL`INSERT INTO users (name) VALUES ('Alice')`)
+  await pg.query(SQL`INSERT INTO users (name) VALUES ('Bob')`)
+})
+```
+
 #### Nesting transactions creates independent transactions
 
 Calling `withTransaction` or `withAsyncContextTransaction` inside another transaction method will create **independent transactions**, not nested transactions. Each call acquires a new connection from the pool:
@@ -143,10 +163,12 @@ Environment variables read by the component:
 | `PG_COMPONENT_PSQL_DATABASE`          | `string` | Database name                            |
 | `PG_COMPONENT_PSQL_USER`              | `string` | Database user                            |
 | `PG_COMPONENT_PSQL_PASSWORD`          | `string` | Database password                        |
-| `PG_COMPONENT_IDLE_TIMEOUT`           | `number` | Idle connection timeout (ms)             |
-| `PG_COMPONENT_QUERY_TIMEOUT`          | `number` | Query timeout (ms)                       |
-| `PG_COMPONENT_STREAM_QUERY_TIMEOUT`   | `number` | Stream query timeout (ms)                |
-| `PG_COMPONENT_GRACE_PERIODS`          | `number` | Grace periods for shutdown (default: 10) |
+| `PG_COMPONENT_IDLE_TIMEOUT`           | `number` | Idle connection timeout (ms)                                                         |
+| `PG_COMPONENT_QUERY_TIMEOUT`          | `number` | Query timeout (ms)                                                                   |
+| `PG_COMPONENT_STREAM_QUERY_TIMEOUT`   | `number` | Stream query timeout (ms); falls back to `PG_COMPONENT_QUERY_TIMEOUT` when unset     |
+| `PG_COMPONENT_CONNECTION_TIMEOUT`     | `number` | How long `pool.connect()` waits for a TCP connection before failing (ms)             |
+| `PG_COMPONENT_GRACE_PERIODS`          | `number` | Grace periods for shutdown (default: 10)                                             |
+| `PG_COMPONENT_STOP_TIMEOUT`           | `number` | Upper bound (ms) for `stop()` to drain the pool before abandoning it (default: 30000) |
 
 ## Metrics
 

--- a/components/pg/src/component.ts
+++ b/components/pg/src/component.ts
@@ -11,6 +11,9 @@ import { Options, IPgComponent, IMetricsComponent, QueryStreamWithCallback, Quer
 export * from './types'
 export * from './metrics'
 
+/**
+ * @internal
+ */
 export async function runReportingQueryDurationMetric<T>(
   components: { metrics: IMetricsComponent },
   queryNameLabel: string,
@@ -44,7 +47,17 @@ export async function createPgComponent(
   const logger = logs.getLogger('pg-component')
 
   // Environment
-  const [connectionString, port, host, database, user, password, idleTimeoutMillis, query_timeout] = await Promise.all([
+  const [
+    connectionString,
+    port,
+    host,
+    database,
+    user,
+    password,
+    idleTimeoutMillis,
+    query_timeout,
+    connectionTimeoutMillis
+  ] = await Promise.all([
     config.getString('PG_COMPONENT_PSQL_CONNECTION_STRING'),
     config.getNumber('PG_COMPONENT_PSQL_PORT'),
     config.getString('PG_COMPONENT_PSQL_HOST'),
@@ -52,7 +65,8 @@ export async function createPgComponent(
     config.getString('PG_COMPONENT_PSQL_USER'),
     config.getString('PG_COMPONENT_PSQL_PASSWORD'),
     config.getNumber('PG_COMPONENT_IDLE_TIMEOUT'),
-    config.getNumber('PG_COMPONENT_QUERY_TIMEOUT')
+    config.getNumber('PG_COMPONENT_QUERY_TIMEOUT'),
+    config.getNumber('PG_COMPONENT_CONNECTION_TIMEOUT')
   ])
   const defaultOptions: PoolConfig = {
     connectionString,
@@ -62,22 +76,42 @@ export async function createPgComponent(
     user,
     password,
     idleTimeoutMillis,
-    query_timeout
+    query_timeout,
+    connectionTimeoutMillis
   }
 
   const STREAM_QUERY_TIMEOUT = await config.getNumber('PG_COMPONENT_STREAM_QUERY_TIMEOUT')
-  const GRACE_PERIODS = (await config.getNumber('PG_COMPONENT_GRACE_PERIODS')) || 10
+  const GRACE_PERIODS = (await config.getNumber('PG_COMPONENT_GRACE_PERIODS')) ?? 10
+  const STOP_TIMEOUT = (await config.getNumber('PG_COMPONENT_STOP_TIMEOUT')) ?? 30_000
 
   const finalOptions: PoolConfig = { ...defaultOptions, ...options.pool }
 
   // Config
   const pool: Pool = new Pool(finalOptions)
 
+  // Idle-client errors are emitted on the pool and would otherwise become
+  // unhandled Node errors. Surface them through the logger so the process stays up.
+  const onPoolError = (error: Error) => {
+    logger.error('Idle pg client error', {
+      error: error?.message ?? String(error),
+      stack: error?.stack ?? ''
+    })
+  }
+  pool.on('error', onPoolError)
+
   // Async context for transaction client
   const transactionContext = new AsyncLocalStorage<PoolClient>()
 
+  let didStart = false
+
   // Methods
   async function start() {
+    if (didStart) {
+      logger.warn('Start called more than once, ignoring')
+      return
+    }
+    didStart = true
+
     try {
       const db = await pool.connect()
 
@@ -96,20 +130,26 @@ export async function createPgComponent(
           await runner(opt)
         }
       } catch (err: any) {
-        logger.error(err)
+        logger.error('Migration failed', {
+          error: err?.message ?? String(err),
+          stack: err?.stack ?? ''
+        })
         throw err
       } finally {
         db.release()
       }
     } catch (error: any) {
-      logger.warn('Error starting pg-component:')
-      logger.error(error)
+      logger.error('Error starting pg-component', {
+        error: error?.message ?? String(error),
+        stack: error?.stack ?? ''
+      })
       throw error
     }
   }
 
   async function withTransaction<T>(callback: (client: PoolClient) => Promise<T>): Promise<T> {
     const client = await pool.connect()
+    let rollbackError: Error | undefined
 
     try {
       await client.query('BEGIN')
@@ -118,15 +158,21 @@ export async function createPgComponent(
 
       return result
     } catch (error) {
-      await client.query('ROLLBACK')
+      try {
+        await client.query('ROLLBACK')
+      } catch (err: any) {
+        rollbackError = err
+        logger.error('Error rolling back transaction', { error: err?.message ?? String(err) })
+      }
       throw error
     } finally {
-      client.release()
+      client.release(rollbackError)
     }
   }
 
   async function withAsyncContextTransaction<T>(callback: () => Promise<T>): Promise<T> {
     const client = await pool.connect()
+    let rollbackError: Error | undefined
 
     try {
       await client.query('BEGIN')
@@ -136,14 +182,19 @@ export async function createPgComponent(
       await client.query('COMMIT')
       return result
     } catch (error) {
-      await client.query('ROLLBACK')
+      try {
+        await client.query('ROLLBACK')
+      } catch (err: any) {
+        rollbackError = err
+        logger.error('Error rolling back transaction', { error: err?.message ?? String(err) })
+      }
       throw error
     } finally {
-      client.release()
+      client.release(rollbackError)
     }
   }
 
-  async function defaultQuery<T extends Record<string, any>>(sql: string | SQLStatement): Promise<QueryResult<T>> {
+  async function doQuery<T extends Record<string, any>>(sql: string | SQLStatement): Promise<QueryResult<T>> {
     const notices: NoticeMessage[] = []
 
     // Get the transaction's context client or connect a new one
@@ -168,25 +219,44 @@ export async function createPgComponent(
     }
   }
 
-  async function measuredQuery<T extends Record<string, any>>(
+  const metricsComponent = components.metrics
+
+  async function query<T extends Record<string, any>>(
     sql: string | SQLStatement,
     durationQueryNameLabel?: string
   ): Promise<QueryResult<T>> {
-    const result = durationQueryNameLabel
-      ? await runReportingQueryDurationMetric({ metrics: components.metrics! }, durationQueryNameLabel, () =>
-          defaultQuery<T>(sql)
-        )
-      : await defaultQuery<T>(sql)
-
-    return result
+    if (durationQueryNameLabel && metricsComponent) {
+      return runReportingQueryDurationMetric({ metrics: metricsComponent }, durationQueryNameLabel, () =>
+        doQuery<T>(sql)
+      )
+    }
+    return doQuery<T>(sql)
   }
 
   async function* streamQuery<T>(sql: SQLStatement, config?: { batchSize?: number }): AsyncGenerator<T> {
     const client = new Client({
       ...finalOptions,
-      query_timeout: STREAM_QUERY_TIMEOUT
+      // Only override when a stream-specific timeout is configured, otherwise fall back
+      // to `finalOptions.query_timeout` (an explicit `undefined` here would clobber it).
+      ...(STREAM_QUERY_TIMEOUT !== undefined ? { query_timeout: STREAM_QUERY_TIMEOUT } : {})
     })
-    await client.connect()
+
+    // Socket errors on the dedicated stream client would otherwise bubble up as
+    // unhandled 'error' events on the EventEmitter. Surface them through the logger.
+    const onClientError = (error: Error) => {
+      logger.error('Stream pg client error', {
+        error: error?.message ?? String(error),
+        stack: error?.stack ?? ''
+      })
+    }
+    client.on('error', onClientError)
+
+    try {
+      await client.connect()
+    } catch (err) {
+      client.off('error', onClientError)
+      throw err
+    }
 
     // https://github.com/brianc/node-postgres/issues/1860
     // Uncaught TypeError: queryCallback is not a function
@@ -211,6 +281,7 @@ export async function createPgComponent(
       throw err
     } finally {
       stream.destroy()
+      client.off('error', onClientError)
       await client.end()
     }
   }
@@ -223,6 +294,8 @@ export async function createPgComponent(
       return
     }
     didStop = true
+
+    pool.off('error', onPoolError)
 
     let gracePeriods = GRACE_PERIODS
 
@@ -237,23 +310,46 @@ export async function createPgComponent(
 
     const promise = pool.end()
     let finished = false
+    let endError: unknown
 
-    promise.finally(() => {
-      finished = true
-    })
-
-    while (!finished && (pool.totalCount > 0 || pool.idleCount > 0 || pool.waitingCount > 0)) {
-      if (pool.totalCount) {
-        logger.log('Draining connections', {
-          totalCount: pool.totalCount,
-          idleCount: pool.idleCount,
-          waitingCount: pool.waitingCount
-        })
-        await setTimeout(1000)
+    promise.then(
+      () => {
+        finished = true
+      },
+      (err) => {
+        finished = true
+        endError = err
       }
+    )
+
+    const deadline = Date.now() + STOP_TIMEOUT
+
+    while (
+      !finished &&
+      Date.now() < deadline &&
+      (pool.totalCount > 0 || pool.idleCount > 0 || pool.waitingCount > 0)
+    ) {
+      logger.log('Draining connections', {
+        totalCount: pool.totalCount,
+        idleCount: pool.idleCount,
+        waitingCount: pool.waitingCount
+      })
+      await setTimeout(1000)
     }
 
-    await promise
+    if (!finished) {
+      logger.warn('pg-component stop timed out, abandoning remaining connections', {
+        totalCount: pool.totalCount,
+        idleCount: pool.idleCount,
+        waitingCount: pool.waitingCount,
+        timeoutMs: STOP_TIMEOUT
+      })
+      return
+    }
+
+    if (endError) {
+      throw endError
+    }
   }
 
   function getPool(): Pool {
@@ -261,7 +357,7 @@ export async function createPgComponent(
   }
 
   return {
-    query: components.metrics ? measuredQuery : defaultQuery,
+    query,
     withTransaction,
     withAsyncContextTransaction,
     streamQuery,

--- a/components/pg/src/component.ts
+++ b/components/pg/src/component.ts
@@ -147,13 +147,13 @@ export async function createPgComponent(
     }
   }
 
-  async function withTransaction<T>(callback: (client: PoolClient) => Promise<T>): Promise<T> {
+  async function executeInTransaction<T>(runCallback: (client: PoolClient) => Promise<T>): Promise<T> {
     const client = await pool.connect()
     let rollbackError: Error | undefined
 
     try {
       await client.query('BEGIN')
-      const result = await callback(client)
+      const result = await runCallback(client)
       await client.query('COMMIT')
 
       return result
@@ -170,28 +170,12 @@ export async function createPgComponent(
     }
   }
 
+  async function withTransaction<T>(callback: (client: PoolClient) => Promise<T>): Promise<T> {
+    return executeInTransaction(callback)
+  }
+
   async function withAsyncContextTransaction<T>(callback: () => Promise<T>): Promise<T> {
-    const client = await pool.connect()
-    let rollbackError: Error | undefined
-
-    try {
-      await client.query('BEGIN')
-
-      const result = await transactionContext.run(client, callback)
-
-      await client.query('COMMIT')
-      return result
-    } catch (error) {
-      try {
-        await client.query('ROLLBACK')
-      } catch (err: any) {
-        rollbackError = err
-        logger.error('Error rolling back transaction', { error: err?.message ?? String(err) })
-      }
-      throw error
-    } finally {
-      client.release(rollbackError)
-    }
+    return executeInTransaction((client) => transactionContext.run(client, callback))
   }
 
   async function doQuery<T extends Record<string, any>>(sql: string | SQLStatement): Promise<QueryResult<T>> {
@@ -258,10 +242,12 @@ export async function createPgComponent(
       throw err
     }
 
+    // TODO: remove this workaround once node-postgres/pg-query-stream#1860 is fixed.
     // https://github.com/brianc/node-postgres/issues/1860
-    // Uncaught TypeError: queryCallback is not a function
-    // finish - OK, this call is necessary to finish the query when we configure query_timeout due to a bug in pg
-    // finish - with error, this call is necessary to finish the query when we configure query_timeout due to a bug in pg
+    // Symptom: `Uncaught TypeError: queryCallback is not a function` when
+    // `query_timeout` is configured. We must install a noop `callback` on the
+    // stream (see `stream.callback` below) and invoke it on both success and
+    // failure so pg's timer cleanup can run.
     const stream = new QueryStream(sql.text, sql.values, config) as QueryStreamWithCallback
 
     stream.callback = function () {
@@ -343,6 +329,15 @@ export async function createPgComponent(
         idleCount: pool.idleCount,
         waitingCount: pool.waitingCount,
         timeoutMs: STOP_TIMEOUT
+      })
+      // pool.end() is still pending — we're no longer awaiting it, but we still
+      // want any eventual failure to surface in logs instead of being silently
+      // captured by the `.then(ok, rej)` handler we attached earlier.
+      promise.catch((err: any) => {
+        logger.error('pool.end() failed after stop timeout', {
+          error: err?.message ?? String(err),
+          stack: err?.stack ?? ''
+        })
       })
       return
     }

--- a/components/pg/src/types.ts
+++ b/components/pg/src/types.ts
@@ -31,7 +31,7 @@ export type Options = Partial<{ pool: PoolConfig; migration: Omit<RunnerOption, 
 export interface IPgComponent extends IDatabase {
   start(): Promise<void>
 
-  query<T extends Record<string, any>>(sql: string): Promise<QueryResult<T>>
+  query<T extends Record<string, any>>(sql: string, durationQueryNameLabel?: string): Promise<QueryResult<T>>
   query<T extends Record<string, any>>(sql: SQLStatement, durationQueryNameLabel?: string): Promise<QueryResult<T>>
   streamQuery<T = any>(sql: SQLStatement, config?: { batchSize?: number }): AsyncGenerator<T>
   /**
@@ -56,6 +56,9 @@ export interface IPgComponent extends IDatabase {
    * @warning Nesting transaction methods (calling `withTransaction` or `withAsyncContextTransaction`
    * inside this callback) will create independent transactions, not nested transactions.
    * Each call acquires a new connection from the pool.
+   *
+   * @warning Queries executed concurrently inside the callback (e.g. via `Promise.all`) share a
+   * single pg `Client` and are not supported. Await queries sequentially within the transaction.
    */
   withAsyncContextTransaction<T>(callback: () => Promise<T>): Promise<T>
 


### PR DESCRIPTION
## Summary

This PR fixes a batch of production hazards in `@dcl/pg-component` found during review and adds three configuration knobs so the component can't be trapped by unbounded waits.

## Why

The component had several failure modes where an error or a hang in one place could cascade into lost information or a stuck process:

- A failing `ROLLBACK` during a transaction overwrote the original callback error, so the real cause of the failure was lost. The now-broken connection was then returned to the pool and could be handed out for the next query.
- `pg.Pool` emits `'error'` events on idle clients when the DB closes the socket, the connection dies, or `idle_in_transaction_session_timeout` fires. With no listener, those become unhandled Node errors and, under the default `--unhandled-rejections=throw`, can terminate the process. The dedicated `Client` used by `streamQuery` had the same gap.
- `stop()` waited indefinitely for `pool.end()` to resolve, which only settles when every in-flight query returns. A single stuck query on SIGTERM could block shutdown forever. The drain loop also had a condition where, with `totalCount === 0` but other counters nonzero, it busy-spun without yielding.
- `streamQuery` built its dedicated `Client` with `{ ...finalOptions, query_timeout: STREAM_QUERY_TIMEOUT }`. When `PG_COMPONENT_STREAM_QUERY_TIMEOUT` was unset, that resolved to `undefined`, explicitly overwriting the inherited `query_timeout` and silently disabling the timeout for streams.
- `pool.connect()` has no default connection timeout (pg defaults to 0 — wait forever), so a DB that's just slow to accept TCP could hang `start()` on boot with no way to override via env.
- `GRACE_PERIODS` used `||` for its default, so `PG_COMPONENT_GRACE_PERIODS=0` couldn't actually disable draining.
- `query`'s `string` overload had no `durationQueryNameLabel` parameter, so callers could only label metrics when using `SQLStatement`.

## How

- `withTransaction` / `withAsyncContextTransaction` wrap the `ROLLBACK` call in its own `try`/`catch`. If rollback fails, the error is logged and captured into a `rollbackError` variable, the original error is still rethrown, and the `finally` calls `client.release(rollbackError)` so pg destroys the broken client instead of returning it to the pool.
- A named `onPoolError` handler is registered with `pool.on('error', ...)` at construction and removed in `stop()`. `streamQuery` registers and deregisters its own `onClientError` handler around the dedicated `Client`'s lifetime, including on the `client.connect()` failure path.
- `stop()` now reads `PG_COMPONENT_STOP_TIMEOUT` (default 30 000 ms) and computes a deadline. The drain loop exits when `finished`, when the deadline passes, or when the pool's counters reach zero, and it now unconditionally `await setTimeout(1000)` per iteration so it can't busy-spin. On timeout it logs a warning and returns without awaiting the end promise; on normal completion, it rethrows any error `pool.end()` produced. The `.then(resolve, reject)` handler is attached to the end promise so rejections aren't classified as unhandled between polling ticks.
- `streamQuery` only sets `query_timeout` on the dedicated client when `STREAM_QUERY_TIMEOUT !== undefined`, letting `finalOptions.query_timeout` flow through otherwise.
- Added `PG_COMPONENT_CONNECTION_TIMEOUT` to the `Promise.all` config read and mapped it to `connectionTimeoutMillis` in the `PoolConfig` defaults.
- `GRACE_PERIODS` now uses `??` for its default so explicit zero is honored.
- `start()` tracks a `didStart` flag, logs `'Start called more than once, ignoring'` on repeat invocations, and now emits a single structured `logger.error('Error starting pg-component', { error, stack })` / `'Migration failed'` instead of the prior two-line `warn` + raw `error` pattern.
- `defaultQuery` / `measuredQuery` were collapsed into a single public `query` function that captures `metricsComponent` in a closure and skips the metric wrapper when either the label or the metrics component is missing. This removes the `components.metrics!` non-null assertion and the construction-time `query: components.metrics ? measuredQuery : defaultQuery` branch.
- Added `durationQueryNameLabel` to the `string` overload of `query` in `types.ts` so both overloads accept it, and added a `@warning` to `withAsyncContextTransaction` (with a matching README section) noting that concurrent queries inside the callback share a single pg `Client` and aren't supported.
- The README's configuration table now documents `PG_COMPONENT_CONNECTION_TIMEOUT` and `PG_COMPONENT_STOP_TIMEOUT`, and clarifies the `STREAM_QUERY_TIMEOUT` fallback.

## Test plan

- [x] `pnpm build` (tsc clean)
- [x] `pnpm test` — 20 existing integration tests (Testcontainers + Postgres 16) still pass, including `withTransaction` rollback, `withAsyncContextTransaction` rollback, nested-transaction isolation, streaming, and shutdown.