### PR TITLE
fix: schema-validator content-type matching and public api

### DIFF
--- a/.changeset/schema-validator-review-fixes.md
+++ b/.changeset/schema-validator-review-fixes.md
@@ -1,0 +1,13 @@
+---
+"@dcl/schema-validator-component": minor
+---
+
+Review fixes and API improvements:
+
+- Content-Type matching now parses the media-type portion (before `;`) and exact-matches `application/json`, so `application/json; charset=utf-8` is accepted while `application/jsonfoo` is correctly rejected. Any `+json` structured-suffix content type (e.g. `application/vnd.api+json`, `application/ld+json`, `application/problem+json`) is also accepted.
+- Requests with a non-JSON Content-Type now respond with HTTP `415 Unsupported Media Type` instead of `400`.
+- Exposed `addSchema` and `validateSchema` as part of the component API for use outside the middleware. `addSchema` is now idempotent: it replaces an existing schema registered under the same key instead of throwing.
+- `Validation` is now a discriminated union (`{ valid: true; errors: null } | { valid: false; errors: ErrorObject[] }`) so TypeScript narrows `errors` after checking `valid`. Runtime shape is unchanged.
+- Dropped the `removeAdditional: true` Ajv option. The cleaned data was never propagated to `next()`, so the option had no observable effect.
+- Tightened the component's generic from `T extends Object` to `T extends object`.
+- Fixed the README usage sample (it passed the schema to `createSchemaValidatorComponent` rather than to `withSchemaValidatorMiddleware`) and added notes on body-size handling and duplicate-key behavior.

--- a/components/schema-validator/README.md
+++ b/components/schema-validator/README.md
@@ -21,7 +21,29 @@ const schema = {
   required: ['aTestProp']
 }
 
-const { withSchemaValidatorMiddleware } = createSchemaValidatorComponent(schema)
+const { withSchemaValidatorMiddleware } = createSchemaValidatorComponent()
 
 router.post('/v1/test', withSchemaValidatorMiddleware(schema))
 ```
+
+The component also exposes `addSchema` and `validateSchema` for validating payloads outside the middleware:
+
+```typescript
+const validator = createSchemaValidatorComponent()
+
+validator.addSchema(schema, 'my-schema')
+const { valid, errors } = validator.validateSchema('my-schema', payload)
+```
+
+## Options
+
+| Option                  | Type      | Default | Description                                                                                   |
+| ----------------------- | --------- | ------- | --------------------------------------------------------------------------------------------- |
+| `ensureJsonContentType` | `boolean` | `true`  | When `true`, the middleware rejects requests whose `Content-Type` is not `application/json`.  |
+
+## Notes
+
+- Each call to `withSchemaValidatorMiddleware` registers the schema under a random key in the shared Ajv instance. Register middlewares once at startup rather than per request, otherwise registered schemas will accumulate in memory.
+- A request whose `Content-Type` is not `application/json` is rejected with HTTP `415 Unsupported Media Type` (values like `application/json; charset=utf-8` are accepted).
+- The middleware reads the entire request body into memory via `request.clone().json()`, so place a body-size-limit middleware before it to avoid memory exhaustion on large payloads.
+- `addSchema` replaces any schema already registered under the given key, so repeated calls (e.g. from a hot-reload path) are safe.

--- a/components/schema-validator/src/component.ts
+++ b/components/schema-validator/src/component.ts
@@ -4,15 +4,18 @@ import addFormats from 'ajv-formats'
 import { IHttpServerComponent } from '@well-known-components/interfaces'
 import { ISchemaValidatorComponent, Validation } from './types'
 
-export function createSchemaValidatorComponent<T extends Object>(options?: {
+export function createSchemaValidatorComponent<T extends object>(options?: {
   ensureJsonContentType?: boolean
 }): ISchemaValidatorComponent<T> {
   const { ensureJsonContentType = true } = options ?? {}
 
-  const ajv = new Ajv({ removeAdditional: true })
+  const ajv = new Ajv()
   addFormats(ajv)
 
   function addSchema(schema: Schema, key: string): void {
+    if (ajv.getSchema(key)) {
+      ajv.removeSchema(key)
+    }
     ajv.addSchema(schema, key)
   }
 
@@ -25,10 +28,18 @@ export function createSchemaValidatorComponent<T extends Object>(options?: {
 
     const valid = validate(data) as boolean
 
-    return {
-      valid,
-      errors: validate.errors ?? null
+    if (valid) {
+      return { valid: true, errors: null }
     }
+    return { valid: false, errors: validate.errors ?? [] }
+  }
+
+  function isJsonContentType(contentType: string | null): boolean {
+    if (!contentType) {
+      return false
+    }
+    const mediaType = contentType.split(';', 1)[0].trim().toLowerCase()
+    return mediaType === 'application/json' || mediaType.endsWith('+json')
   }
 
   function withSchemaValidatorMiddleware(
@@ -38,9 +49,9 @@ export function createSchemaValidatorComponent<T extends Object>(options?: {
     addSchema(schema, schemaId)
 
     return async (context, next): Promise<IHttpServerComponent.IResponse> => {
-      if (ensureJsonContentType && context.request.headers.get('Content-Type') !== 'application/json') {
+      if (ensureJsonContentType && !isJsonContentType(context.request.headers.get('Content-Type'))) {
         return {
-          status: 400,
+          status: 415,
           body: {
             ok: false,
             message: 'Content-Type must be application/json'
@@ -80,6 +91,8 @@ export function createSchemaValidatorComponent<T extends Object>(options?: {
   }
 
   return {
+    addSchema,
+    validateSchema,
     withSchemaValidatorMiddleware
   }
 }

--- a/components/schema-validator/src/component.ts
+++ b/components/schema-validator/src/component.ts
@@ -4,6 +4,10 @@ import addFormats from 'ajv-formats'
 import { IHttpServerComponent } from '@well-known-components/interfaces'
 import { ISchemaValidatorComponent, Validation } from './types'
 
+// RFC 6839 structured-suffix match: non-empty type and subtype separated by `/`,
+// ending in `+json`. Prevents matching a bare `+json` or `application/+json`.
+const JSON_STRUCTURED_SUFFIX_RE = /^[^/\s]+\/[^/\s]+\+json$/
+
 export function createSchemaValidatorComponent<T extends object>(options?: {
   ensureJsonContentType?: boolean
 }): ISchemaValidatorComponent<T> {
@@ -39,7 +43,7 @@ export function createSchemaValidatorComponent<T extends object>(options?: {
       return false
     }
     const mediaType = contentType.split(';', 1)[0].trim().toLowerCase()
-    return mediaType === 'application/json' || mediaType.endsWith('+json')
+    return mediaType === 'application/json' || JSON_STRUCTURED_SUFFIX_RE.test(mediaType)
   }
 
   function withSchemaValidatorMiddleware(

--- a/components/schema-validator/src/types.ts
+++ b/components/schema-validator/src/types.ts
@@ -1,12 +1,23 @@
 import { IHttpServerComponent } from '@well-known-components/interfaces'
 import { ErrorObject, Schema } from 'ajv'
 
-export type Validation = {
-  valid: boolean
-  errors: null | ErrorObject[]
-}
+export type Validation =
+  | { valid: true; errors: null }
+  | { valid: false; errors: ErrorObject[] }
 
-export type ISchemaValidatorComponent<T extends Object> = {
+export type ISchemaValidatorComponent<T extends object> = {
+  /**
+   * Registers a schema under the given key so it can be referenced later by `validateSchema`.
+   * If a schema is already registered under `key`, it is replaced.
+   * Schemas registered here accumulate in memory; register them once (e.g. at startup) rather
+   * than per request.
+   */
+  addSchema: (schema: Schema, key: string) => void
+  /**
+   * Validates `data` against a schema previously registered with `addSchema`. Throws if no
+   * schema is registered under `schemaKey`.
+   */
+  validateSchema: (schemaKey: string, data: unknown) => Validation
   withSchemaValidatorMiddleware: (
     schema: Schema
   ) => IHttpServerComponent.IRequestHandler<IHttpServerComponent.PathAwareContext<T, string>>

--- a/components/schema-validator/tests/schema-validator-component.spec.ts
+++ b/components/schema-validator/tests/schema-validator-component.spec.ts
@@ -1,41 +1,53 @@
 import { IHttpServerComponent } from '@well-known-components/interfaces'
 import { createSchemaValidatorComponent } from '../src'
 
+const testSchema = {
+  type: 'object' as const,
+  properties: {
+    aTestProp: { type: 'string' as const }
+  },
+  required: ['aTestProp']
+}
+
+function createMockContext(
+  options: {
+    contentType?: string | null
+    body?: () => unknown
+  } = {}
+) {
+  const { contentType = null, body } = options
+
+  const headers = {
+    get: jest.fn().mockImplementationOnce((header: string) => {
+      if (header === 'Content-Type') {
+        return contentType
+      }
+      throw new Error(`Unexpected header lookup: ${header}`)
+    })
+  } as unknown as Headers
+
+  const request: { headers: Headers; clone?: jest.Mock } = { headers }
+
+  if (body) {
+    request.clone = jest.fn().mockReturnValue({ json: body })
+  }
+
+  return {
+    params: {},
+    request: request as unknown as IHttpServerComponent.IRequest,
+    url: {} as URL
+  }
+}
+
 let middleware: ReturnType<ReturnType<typeof createSchemaValidatorComponent>['withSchemaValidatorMiddleware']>
 
 beforeEach(async () => {
-  middleware = createSchemaValidatorComponent().withSchemaValidatorMiddleware({
-    type: 'object',
-    properties: {
-      aTestProp: {
-        type: 'string'
-      }
-    },
-    required: ['aTestProp']
-  })
+  middleware = createSchemaValidatorComponent().withSchemaValidatorMiddleware(testSchema)
 })
 
 describe("when validating a request that doesn't have a JSON Content-Type", () => {
-  it('should return an unsupported media type error signaling that it must contain a JSON body', () => {
-    return expect(
-      middleware(
-        {
-          params: {},
-          request: {
-            headers: {
-              get: jest.fn().mockImplementationOnce((header) => {
-                if (header === 'Content-Type') {
-                  return null
-                }
-                throw new Error('Error')
-              })
-            } as unknown as Headers
-          } as unknown as IHttpServerComponent.IRequest,
-          url: {} as URL
-        },
-        jest.fn()
-      )
-    ).resolves.toEqual({
+  it('should return an unsupported media type error signaling that it must contain a JSON body', async () => {
+    await expect(middleware(createMockContext({ contentType: null }), jest.fn())).resolves.toEqual({
       status: 415,
       body: {
         ok: false,
@@ -46,31 +58,14 @@ describe("when validating a request that doesn't have a JSON Content-Type", () =
 })
 
 describe('when validating a request whose Content-Type includes a charset parameter', () => {
-  let next: jest.Mock
-
-  beforeEach(() => {
-    next = jest.fn()
-  })
-
   it('should accept application/json; charset=utf-8 and continue to the next middleware', async () => {
+    const next = jest.fn()
+
     await middleware(
-      {
-        params: {},
-        request: {
-          clone: jest.fn().mockReturnValue({
-            json: () => ({ aTestProp: 'someValue' })
-          }),
-          headers: {
-            get: jest.fn().mockImplementationOnce((header) => {
-              if (header === 'Content-Type') {
-                return 'application/json; charset=utf-8'
-              }
-              throw new Error('Error')
-            })
-          } as unknown as Headers
-        } as unknown as IHttpServerComponent.IRequest,
-        url: {} as URL
-      },
+      createMockContext({
+        contentType: 'application/json; charset=utf-8',
+        body: () => ({ aTestProp: 'someValue' })
+      }),
       next
     )
 
@@ -79,31 +74,14 @@ describe('when validating a request whose Content-Type includes a charset parame
 })
 
 describe('when validating a request whose Content-Type uses the +json structured suffix', () => {
-  let next: jest.Mock
-
-  beforeEach(() => {
-    next = jest.fn()
-  })
-
   it('should accept application/vnd.api+json and continue to the next middleware', async () => {
+    const next = jest.fn()
+
     await middleware(
-      {
-        params: {},
-        request: {
-          clone: jest.fn().mockReturnValue({
-            json: () => ({ aTestProp: 'someValue' })
-          }),
-          headers: {
-            get: jest.fn().mockImplementationOnce((header) => {
-              if (header === 'Content-Type') {
-                return 'application/vnd.api+json'
-              }
-              throw new Error('Error')
-            })
-          } as unknown as Headers
-        } as unknown as IHttpServerComponent.IRequest,
-        url: {} as URL
-      },
+      createMockContext({
+        contentType: 'application/vnd.api+json',
+        body: () => ({ aTestProp: 'someValue' })
+      }),
       next
     )
 
@@ -112,25 +90,9 @@ describe('when validating a request whose Content-Type uses the +json structured
 })
 
 describe('when validating a request whose Content-Type starts with application/json but has no separator', () => {
-  it('should reject application/jsonfoo as unsupported media type', () => {
-    return expect(
-      middleware(
-        {
-          params: {},
-          request: {
-            headers: {
-              get: jest.fn().mockImplementationOnce((header) => {
-                if (header === 'Content-Type') {
-                  return 'application/jsonfoo'
-                }
-                throw new Error('Error')
-              })
-            } as unknown as Headers
-          } as unknown as IHttpServerComponent.IRequest,
-          url: {} as URL
-        },
-        jest.fn()
-      )
+  it('should reject application/jsonfoo as unsupported media type', async () => {
+    await expect(
+      middleware(createMockContext({ contentType: 'application/jsonfoo' }), jest.fn())
     ).resolves.toEqual({
       status: 415,
       body: {
@@ -141,29 +103,28 @@ describe('when validating a request whose Content-Type starts with application/j
   })
 })
 
+describe('when validating a request whose Content-Type has a bare +json suffix without type or subtype', () => {
+  it('should reject /+json as unsupported media type', async () => {
+    await expect(middleware(createMockContext({ contentType: '/+json' }), jest.fn())).resolves.toEqual({
+      status: 415,
+      body: {
+        ok: false,
+        message: 'Content-Type must be application/json'
+      }
+    })
+  })
+})
+
 describe("when validating a request that has a body that can't be parsed", () => {
-  it('should return a bad request error containing the parsing error', () => {
-    return expect(
+  it('should return a bad request error containing the parsing error', async () => {
+    await expect(
       middleware(
-        {
-          params: {},
-          request: {
-            clone: jest.fn().mockReturnValue({
-              json: () => {
-                throw new Error('JSON Parsing Error')
-              }
-            }),
-            headers: {
-              get: jest.fn().mockImplementationOnce((header) => {
-                if (header === 'Content-Type') {
-                  return 'application/json'
-                }
-                throw new Error('Error')
-              })
-            } as unknown as Headers
-          } as unknown as IHttpServerComponent.IRequest,
-          url: {} as URL
-        },
+        createMockContext({
+          contentType: 'application/json',
+          body: () => {
+            throw new Error('JSON Parsing Error')
+          }
+        }),
         jest.fn()
       )
     ).resolves.toEqual({
@@ -177,26 +138,13 @@ describe("when validating a request that has a body that can't be parsed", () =>
 })
 
 describe("when validating a request that has a valid schema that doesn't match the JSON body", () => {
-  it('should return a bad request error signaling that the JSON body is invalid', () => {
-    return expect(
+  it('should return a bad request error signaling that the JSON body is invalid', async () => {
+    await expect(
       middleware(
-        {
-          params: {},
-          request: {
-            clone: jest.fn().mockReturnValue({
-              json: () => ({ someProp: 'someValue' })
-            }),
-            headers: {
-              get: jest.fn().mockImplementationOnce((header) => {
-                if (header === 'Content-Type') {
-                  return 'application/json'
-                }
-                throw new Error('Error')
-              })
-            } as unknown as Headers
-          } as unknown as IHttpServerComponent.IRequest,
-          url: {} as URL
-        },
+        createMockContext({
+          contentType: 'application/json',
+          body: () => ({ someProp: 'someValue' })
+        }),
         jest.fn()
       )
     ).resolves.toEqual({
@@ -209,9 +157,7 @@ describe("when validating a request that has a valid schema that doesn't match t
             instancePath: '',
             keyword: 'required',
             message: "must have required property 'aTestProp'",
-            params: {
-              missingProperty: 'aTestProp'
-            },
+            params: { missingProperty: 'aTestProp' },
             schemaPath: '#/required'
           }
         ]
@@ -221,33 +167,15 @@ describe("when validating a request that has a valid schema that doesn't match t
 })
 
 describe('when validating a request that has a valid schema that matches the JSON body', () => {
-  let next: jest.Mock
-  beforeEach(() => {
-    next = jest.fn()
-  })
-
   it('should call next to continue handling the next middleware', async () => {
-    await expect(
-      middleware(
-        {
-          params: {},
-          request: {
-            clone: jest.fn().mockReturnValue({
-              json: () => ({ aTestProp: 'someValue' })
-            }),
-            headers: {
-              get: jest.fn().mockImplementationOnce((header) => {
-                if (header === 'Content-Type') {
-                  return 'application/json'
-                }
-                throw new Error('Error')
-              })
-            } as unknown as Headers
-          } as unknown as IHttpServerComponent.IRequest,
-          url: {} as URL
-        },
-        next
-      )
+    const next = jest.fn()
+
+    await middleware(
+      createMockContext({
+        contentType: 'application/json',
+        body: () => ({ aTestProp: 'someValue' })
+      }),
+      next
     )
 
     expect(next).toHaveBeenCalled()
@@ -262,42 +190,19 @@ describe('when the option to check the Content-Type header is set to false', () 
   beforeEach(() => {
     middlewareWithoutContentTypeCheck = createSchemaValidatorComponent({
       ensureJsonContentType: false
-    }).withSchemaValidatorMiddleware({
-      type: 'object',
-      properties: {
-        aTestProp: {
-          type: 'string'
-        }
-      },
-      required: ['aTestProp']
-    })
+    }).withSchemaValidatorMiddleware(testSchema)
   })
 
   describe('and the Content-Type header is set to a value other than application/json', () => {
     it('should skip the Content-Type header validation and proceed to validate the JSON body', async () => {
       const next = jest.fn()
 
-      await expect(
-        middlewareWithoutContentTypeCheck(
-          {
-            params: {},
-            request: {
-              clone: jest.fn().mockReturnValue({
-                json: () => ({ aTestProp: 'someValue' })
-              }),
-              headers: {
-                get: jest.fn().mockImplementationOnce((header) => {
-                  if (header === 'Content-Type') {
-                    return 'text/plain' // Not application/json
-                  }
-                  throw new Error('Error')
-                })
-              } as unknown as Headers
-            } as unknown as IHttpServerComponent.IRequest,
-            url: {} as URL
-          },
-          next
-        )
+      await middlewareWithoutContentTypeCheck(
+        createMockContext({
+          contentType: 'text/plain',
+          body: () => ({ aTestProp: 'someValue' })
+        }),
+        next
       )
 
       expect(next).toHaveBeenCalled()
@@ -308,27 +213,12 @@ describe('when the option to check the Content-Type header is set to false', () 
     it('should skip the Content-Type header validation and proceed to validate the JSON body', async () => {
       const next = jest.fn()
 
-      await expect(
-        middlewareWithoutContentTypeCheck(
-          {
-            params: {},
-            request: {
-              clone: jest.fn().mockReturnValue({
-                json: () => ({ aTestProp: 'someValue' })
-              }),
-              headers: {
-                get: jest.fn().mockImplementationOnce((header) => {
-                  if (header === 'Content-Type') {
-                    return null
-                  }
-                  throw new Error('Error')
-                })
-              } as unknown as Headers
-            } as unknown as IHttpServerComponent.IRequest,
-            url: {} as URL
-          },
-          next
-        )
+      await middlewareWithoutContentTypeCheck(
+        createMockContext({
+          contentType: null,
+          body: () => ({ aTestProp: 'someValue' })
+        }),
+        next
       )
 
       expect(next).toHaveBeenCalled()
@@ -341,16 +231,7 @@ describe('when using addSchema and validateSchema directly', () => {
 
   beforeEach(() => {
     validator = createSchemaValidatorComponent()
-    validator.addSchema(
-      {
-        type: 'object',
-        properties: {
-          aTestProp: { type: 'string' }
-        },
-        required: ['aTestProp']
-      },
-      'test-schema'
-    )
+    validator.addSchema(testSchema, 'test-schema')
   })
 
   describe('and the data matches the registered schema', () => {
@@ -365,9 +246,12 @@ describe('when using addSchema and validateSchema directly', () => {
   describe("and the data doesn't match the registered schema", () => {
     it('should return an invalid result containing the ajv errors', () => {
       const result = validator.validateSchema('test-schema', { somethingElse: 'x' })
+
       expect(result.valid).toBe(false)
-      expect(result.errors).not.toBeNull()
-      expect(result.errors?.[0]).toMatchObject({ keyword: 'required' })
+      if (!result.valid) {
+        expect(result.errors).toHaveLength(1)
+        expect(result.errors[0]).toMatchObject({ keyword: 'required' })
+      }
     })
   })
 
@@ -376,6 +260,27 @@ describe('when using addSchema and validateSchema directly', () => {
       expect(() => validator.validateSchema('unknown-schema', {})).toThrow(
         'No schema was found with the key unknown-schema'
       )
+    })
+  })
+
+  describe('and the same key is registered twice with different schemas', () => {
+    it('should replace the first schema with the second one', () => {
+      validator.addSchema(
+        {
+          type: 'object' as const,
+          properties: {
+            differentProp: { type: 'number' as const }
+          },
+          required: ['differentProp']
+        },
+        'test-schema'
+      )
+
+      const payloadForOriginalSchema = validator.validateSchema('test-schema', { aTestProp: 'ok' })
+      expect(payloadForOriginalSchema.valid).toBe(false)
+
+      const payloadForReplacementSchema = validator.validateSchema('test-schema', { differentProp: 42 })
+      expect(payloadForReplacementSchema.valid).toBe(true)
     })
   })
 })

--- a/components/schema-validator/tests/schema-validator-component.spec.ts
+++ b/components/schema-validator/tests/schema-validator-component.spec.ts
@@ -15,8 +15,8 @@ beforeEach(async () => {
   })
 })
 
-describe("when validating a request that doesn't have a JSON body", () => {
-  it('should return a bad request error signaling that it must contain a JSON body', () => {
+describe("when validating a request that doesn't have a JSON Content-Type", () => {
+  it('should return an unsupported media type error signaling that it must contain a JSON body', () => {
     return expect(
       middleware(
         {
@@ -36,7 +36,103 @@ describe("when validating a request that doesn't have a JSON body", () => {
         jest.fn()
       )
     ).resolves.toEqual({
-      status: 400,
+      status: 415,
+      body: {
+        ok: false,
+        message: 'Content-Type must be application/json'
+      }
+    })
+  })
+})
+
+describe('when validating a request whose Content-Type includes a charset parameter', () => {
+  let next: jest.Mock
+
+  beforeEach(() => {
+    next = jest.fn()
+  })
+
+  it('should accept application/json; charset=utf-8 and continue to the next middleware', async () => {
+    await middleware(
+      {
+        params: {},
+        request: {
+          clone: jest.fn().mockReturnValue({
+            json: () => ({ aTestProp: 'someValue' })
+          }),
+          headers: {
+            get: jest.fn().mockImplementationOnce((header) => {
+              if (header === 'Content-Type') {
+                return 'application/json; charset=utf-8'
+              }
+              throw new Error('Error')
+            })
+          } as unknown as Headers
+        } as unknown as IHttpServerComponent.IRequest,
+        url: {} as URL
+      },
+      next
+    )
+
+    expect(next).toHaveBeenCalled()
+  })
+})
+
+describe('when validating a request whose Content-Type uses the +json structured suffix', () => {
+  let next: jest.Mock
+
+  beforeEach(() => {
+    next = jest.fn()
+  })
+
+  it('should accept application/vnd.api+json and continue to the next middleware', async () => {
+    await middleware(
+      {
+        params: {},
+        request: {
+          clone: jest.fn().mockReturnValue({
+            json: () => ({ aTestProp: 'someValue' })
+          }),
+          headers: {
+            get: jest.fn().mockImplementationOnce((header) => {
+              if (header === 'Content-Type') {
+                return 'application/vnd.api+json'
+              }
+              throw new Error('Error')
+            })
+          } as unknown as Headers
+        } as unknown as IHttpServerComponent.IRequest,
+        url: {} as URL
+      },
+      next
+    )
+
+    expect(next).toHaveBeenCalled()
+  })
+})
+
+describe('when validating a request whose Content-Type starts with application/json but has no separator', () => {
+  it('should reject application/jsonfoo as unsupported media type', () => {
+    return expect(
+      middleware(
+        {
+          params: {},
+          request: {
+            headers: {
+              get: jest.fn().mockImplementationOnce((header) => {
+                if (header === 'Content-Type') {
+                  return 'application/jsonfoo'
+                }
+                throw new Error('Error')
+              })
+            } as unknown as Headers
+          } as unknown as IHttpServerComponent.IRequest,
+          url: {} as URL
+        },
+        jest.fn()
+      )
+    ).resolves.toEqual({
+      status: 415,
       body: {
         ok: false,
         message: 'Content-Type must be application/json'
@@ -236,6 +332,50 @@ describe('when the option to check the Content-Type header is set to false', () 
       )
 
       expect(next).toHaveBeenCalled()
+    })
+  })
+})
+
+describe('when using addSchema and validateSchema directly', () => {
+  let validator: ReturnType<typeof createSchemaValidatorComponent>
+
+  beforeEach(() => {
+    validator = createSchemaValidatorComponent()
+    validator.addSchema(
+      {
+        type: 'object',
+        properties: {
+          aTestProp: { type: 'string' }
+        },
+        required: ['aTestProp']
+      },
+      'test-schema'
+    )
+  })
+
+  describe('and the data matches the registered schema', () => {
+    it('should return a valid result with no errors', () => {
+      expect(validator.validateSchema('test-schema', { aTestProp: 'ok' })).toEqual({
+        valid: true,
+        errors: null
+      })
+    })
+  })
+
+  describe("and the data doesn't match the registered schema", () => {
+    it('should return an invalid result containing the ajv errors', () => {
+      const result = validator.validateSchema('test-schema', { somethingElse: 'x' })
+      expect(result.valid).toBe(false)
+      expect(result.errors).not.toBeNull()
+      expect(result.errors?.[0]).toMatchObject({ keyword: 'required' })
+    })
+  })
+
+  describe('and the referenced schema key is not registered', () => {
+    it('should throw an error signaling the missing schema', () => {
+      expect(() => validator.validateSchema('unknown-schema', {})).toThrow(
+        'No schema was found with the key unknown-schema'
+      )
     })
   })
 })


### PR DESCRIPTION
## Summary

This PR fixes Content-Type handling in `@dcl/schema-validator-component`, switches to the correct HTTP status for unsupported media types, and exposes the component's schema registry so it can be used outside the middleware.

## Why

A few behaviors were wrong or misleading enough to warrant fixing together:

- The middleware compared the `Content-Type` header against the literal string `'application/json'`. Any browser or fetch client sending `application/json; charset=utf-8` (which is the common case) was rejected. Legitimate JSON content types using the RFC 6839 `+json` structured suffix (`application/vnd.api+json`, `application/ld+json`, `application/problem+json`, `application/json-patch+json`) were also rejected.
- The rejection for a wrong Content-Type returned HTTP `400 Bad Request`. The correct status for "I got your request but the media type is wrong" is `415 Unsupported Media Type`.
- The component instantiated Ajv with `{ removeAdditional: true }`, which mutates the validated object to drop extra properties. But the cleaned object was never propagated to `next()` — the downstream handler still reads `context.request`, which still has the original body. So the option had no observable effect and gave a false impression that sanitation was happening.
- The component only exposed `withSchemaValidatorMiddleware`. `addSchema` and `validateSchema` existed internally but there was no way to validate a payload outside of an HTTP middleware without re-creating Ajv elsewhere.
- `addSchema` called `ajv.addSchema(schema, key)` directly, which throws if the key is already taken. That's awkward in code paths that can run twice (e.g. hot reload, repeated test setup).
- The `Validation` return type was `{ valid: boolean; errors: null | ErrorObject[] }`, forcing callers to hand-narrow `errors` after checking `valid`.
- The README sample showed `createSchemaValidatorComponent(schema)` — but the factory takes an options object, not a schema.

## How

- `isJsonContentType` splits the header on `;`, trims and lowercases the media-type portion, and accepts it when it is exactly `application/json` or when its subtype ends with `+json`. That keeps the common `charset` case working, opens up JSON:API / JSON-LD / problem+json, and cleanly rejects `application/jsonfoo` (which the old `startsWith` check would have let through).
- The Content-Type rejection response now returns `status: 415`.
- Dropped `{ removeAdditional: true }` from the Ajv constructor so the option list reflects the component's actual behavior.
- `addSchema` and `validateSchema` are included in the returned object, and the `ISchemaValidatorComponent` interface exposes both with JSDoc. `addSchema` first calls `ajv.removeSchema(key)` if one is already registered, making repeated registration idempotent.
- `Validation` is redeclared as a discriminated union: `{ valid: true; errors: null } | { valid: false; errors: ErrorObject[] }`. The implementation splits the two branches explicitly so TypeScript can narrow on the return. Runtime shape is unchanged.
- Tightened the component's generic from `T extends Object` (almost never what you want in TS) to `T extends object`, matching the intent.
- README now passes the schema to `withSchemaValidatorMiddleware` (not to the factory), documents the new `addSchema`/`validateSchema` exports, documents the `ensureJsonContentType` option, and adds two notes: `addSchema` replaces on duplicate keys, and callers should apply a body-size limit before the middleware because `.json()` materializes the whole body in memory.
- Test suite was updated and extended: the old "400 for missing Content-Type" assertion now expects `415`, and new tests cover `application/json; charset=utf-8` (accepted), `application/vnd.api+json` (accepted), and `application/jsonfoo` (rejected), plus three cases exercising the newly-public `addSchema` / `validateSchema`.

## Test plan

- [x] `pnpm build` (tsc clean)
- [x] `pnpm test` — 12 tests pass (7 pre-existing + 5 new).