### PR TITLE
feat: add cron scheduling and harden the job runner

### DIFF
--- a/.changeset/cron-job-component.md
+++ b/.changeset/cron-job-component.md
@@ -1,0 +1,14 @@
+---
+'@dcl/job-component': minor
+---
+
+- Add `createCronJobComponent` for cron-expression scheduling alongside the existing fixed-interval `createJobComponent`. Schedules accept an optional `timezone` and a `skipFirstRun` flag that waits for the first cron match before running.
+- Fix `stop()` so it awaits the entire run loop — including an async `onFinish` — before resolving. Previously `stop()` only awaited the current iteration's promise, so cleanup was still in-flight when the lifecycle manager considered shutdown complete.
+- Fix `stop()` re-throwing a rejection from an earlier iteration when called during the inter-iteration sleep.
+- Guard `start()` against double invocation: the second call logs a warning and returns instead of racing against the first `runJob`.
+- Isolate `onError` and `onFinish` callback errors: a throwing callback is logged and the runner continues, instead of producing an unhandled rejection or silently killing the component.
+- Harden `nextDelayMs`: throwing or non-finite (`NaN`, `Infinity`) values are logged and fall back to a 60s sleep instead of corrupting the loop.
+- Warn when `skipFirstRun: true` is combined with a non-default `startupDelay`, since `startupDelay` is silently ignored in favor of the next cron match.
+- New `InvalidStartupDelayError` (thrown when `startupDelay < 0`). `InvalidCronExpressionError` now preserves the raw parser error on `.cause`. All error subclasses now set `.name` for clearer diagnostics.
+- Correct the `WrongOnTimeError` message to match the `>= 500ms` bound.
+- Tighten public types: `job: () => unknown` on both factories (was `() => any`); `JobOptions.onFinish: () => void | Promise<void>` (was `() => any`).

--- a/.changeset/cron-job-component.md
+++ b/.changeset/cron-job-component.md
@@ -7,8 +7,11 @@
 - Fix `stop()` re-throwing a rejection from an earlier iteration when called during the inter-iteration sleep.
 - Guard `start()` against double invocation: the second call logs a warning and returns instead of racing against the first `runJob`.
 - Isolate `onError` and `onFinish` callback errors: a throwing callback is logged and the runner continues, instead of producing an unhandled rejection or silently killing the component.
-- Harden `nextDelayMs`: throwing or non-finite (`NaN`, `Infinity`) values are logged and fall back to a 60s sleep instead of corrupting the loop.
+- Harden `nextDelayMs`: throwing or non-finite (`NaN`, `Infinity`) values are logged and fall back to a 60s sleep instead of corrupting the loop. Finite values are also clamped to Node's 32-bit `setTimeout` maximum (~24.85 days), so long cron delays (e.g. monthly expressions) no longer overflow into a ~1ms hot loop.
+- Fix `stop()` called mid-job: once the executing iteration resolves, the run loop now re-checks `shouldStop` before scheduling the next inter-iteration sleep, so shutdown no longer waits out a full cron delay.
+- Surface unexpected run-loop failures: the defensive `.catch` on `runJob()` now logs any rejection instead of silently dropping it, so bugs in the runner itself are visible.
+- Reject non-finite `onTime` and `startupDelay`: `NaN` and `Infinity` previously bypassed the `< 500` / `< 0` guards and fell through to a 1ms `setTimeout` or the 60s fallback. They now throw `WrongOnTimeError` / `InvalidStartupDelayError` at construction time.
 - Warn when `skipFirstRun: true` is combined with a non-default `startupDelay`, since `startupDelay` is silently ignored in favor of the next cron match.
-- New `InvalidStartupDelayError` (thrown when `startupDelay < 0`). `InvalidCronExpressionError` now preserves the raw parser error on `.cause`. All error subclasses now set `.name` for clearer diagnostics.
+- New `InvalidStartupDelayError` (thrown when `startupDelay` is negative or non-finite). `InvalidCronExpressionError` preserves the raw parser error via the ES2022 `Error` `cause` option, keeping it interoperable with the native error-cause chain. All error subclasses now set `.name` for clearer diagnostics.
 - Correct the `WrongOnTimeError` message to match the `>= 500ms` bound.
 - Tighten public types: `job: () => unknown` on both factories (was `() => any`); `JobOptions.onFinish: () => void | Promise<void>` (was `() => any`).

--- a/components/job/README.md
+++ b/components/job/README.md
@@ -1,15 +1,16 @@
 # Job Component (`@dcl/job-component`)
 
-A component for scheduling and executing recurring jobs with configurable timing and error handling.
+Two factories for scheduling and executing jobs with configurable timing and error handling.
 
 ## Features
 
-- Recurring job execution with configurable intervals
+- Fixed-interval recurring execution via `createJobComponent`
+- Cron-expression recurring execution via `createCronJobComponent`
 - Startup delay support
 - Error handling and completion callbacks
-- Graceful shutdown capabilities
+- Graceful shutdown via `STOP_COMPONENT`
 
-## Usage
+## Interval mode
 
 ```typescript
 import { createJobComponent } from '@dcl/job-component'
@@ -18,9 +19,8 @@ const job = createJobComponent(
   { logs },
   async () => {
     // Your job logic here
-    console.log('Executing job...')
   },
-  5000, // Run every 5 seconds
+  5000, // Run every 5 seconds (minimum 500ms)
   {
     repeat: true,
     startupDelay: 1000,
@@ -29,3 +29,44 @@ const job = createJobComponent(
   }
 )
 ```
+
+## Cron mode
+
+```typescript
+import { createCronJobComponent } from '@dcl/job-component'
+
+const job = createCronJobComponent(
+  { logs },
+  async () => {
+    // Your job logic here
+  },
+  { cron: '0 3 * * *', timezone: 'UTC' }, // Every day at 03:00 UTC
+  {
+    repeat: true,
+    startupDelay: 0,
+    onError: (error) => console.error('Job error:', error),
+    onFinish: () => console.log('Job finished')
+  }
+)
+```
+
+Cron expressions are parsed by [`cron-parser`](https://www.npmjs.com/package/cron-parser) and support both 5- and 6-field forms plus predefined aliases (`@hourly`, `@daily`, etc.). The next fire time is recomputed from the current clock after each run, so late or long-running jobs drop missed ticks instead of stampeding. An invalid expression throws `InvalidCronExpressionError` at construction.
+
+By default, the job runs **immediately** after `startupDelay` and only waits until the next cron match for subsequent iterations. Pass `skipFirstRun: true` on the schedule to instead wait until the first matching cron time before the first run:
+
+```typescript
+const job = createCronJobComponent(
+  { logs },
+  async () => { /* ... */ },
+  { cron: '0 3 * * *', timezone: 'UTC', skipFirstRun: true }
+)
+```
+
+## Options
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `repeat` | `true` | Run repeatedly or once. |
+| `startupDelay` | `0` | Milliseconds to wait before the first run. |
+| `onError` | no-op | Called with the thrown error if a job run rejects. |
+| `onFinish` | no-op | Called once after the loop exits (either `repeat: false` completes or `STOP_COMPONENT` is invoked). |

--- a/components/job/package.json
+++ b/components/job/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "@dcl/core-commons": "workspace:*",
-    "@well-known-components/interfaces": "^1.5.2"
+    "@well-known-components/interfaces": "^1.5.2",
+    "cron-parser": "^5.0.0"
   },
   "devDependencies": {
     "typescript": "^5.8.3"

--- a/components/job/src/component.ts
+++ b/components/job/src/component.ts
@@ -11,7 +11,7 @@ export function createJobComponent(
   onTime: number,
   options: JobOptions = {}
 ): IJobComponent {
-  if (onTime < 500) {
+  if (!Number.isFinite(onTime) || onTime < 500) {
     throw new WrongOnTimeError(onTime)
   }
 

--- a/components/job/src/component.ts
+++ b/components/job/src/component.ts
@@ -1,84 +1,24 @@
-import { START_COMPONENT, STOP_COMPONENT, ILoggerComponent } from '@well-known-components/interfaces'
+import { ILoggerComponent } from '@well-known-components/interfaces'
 import { IJobComponent, JobOptions } from './types'
 import { WrongOnTimeError } from './errors'
+import { createScheduledRunner } from './runner'
 
 export function createJobComponent(
   components: Pick<{ logs: ILoggerComponent }, 'logs'>,
   /** The function to execute as a job. Admits asynchronous functions. */
-  job: () => any,
-  /** The amount of time to wait between jobs */
+  job: () => unknown,
+  /** The amount of time in ms to wait between jobs */
   onTime: number,
-  { repeat = true, startupDelay = 0, onError = () => undefined, onFinish = () => undefined }: JobOptions = {
-    repeat: true,
-    startupDelay: 0,
-    onError: () => undefined,
-    onFinish: () => undefined
-  }
+  options: JobOptions = {}
 ): IJobComponent {
-  const { logs } = components
-  let runningJob: Promise<any> = Promise.resolve()
-  let shouldStop: boolean = false
-  let timeout: ReturnType<typeof setTimeout> | undefined
-  let resolveSleepCancel: ((value: unknown) => void) | undefined
-  const logger = logs.getLogger('job')
-
   if (onTime < 500) {
     throw new WrongOnTimeError(onTime)
   }
 
-  async function sleep(time: number) {
-    return new Promise((resolve) => {
-      resolveSleepCancel = resolve
-      timeout = setTimeout(() => {
-        resolveSleepCancel = undefined
-        timeout = undefined
-        resolve(undefined)
-      }, time)
-    })
-  }
-
-  function cancelSleep() {
-    if (timeout && resolveSleepCancel) {
-      clearTimeout(timeout)
-      resolveSleepCancel(undefined)
-    }
-  }
-
-  async function start() {
-    // Start the job but don't wait for it
-    runJob().catch(() => {
-      // Do nothing
-    })
-  }
-
-  async function runJob() {
-    await sleep(startupDelay)
-    while (!shouldStop) {
-      try {
-        runningJob = job()
-        await runningJob
-      } catch (error) {
-        onError(error)
-      }
-      if (!repeat) {
-        break
-      }
-      await sleep(onTime)
-    }
-    await onFinish()
-    logger.info('[Stopped]')
-  }
-
-  async function stop() {
-    logger.info('[Cancelling]')
-    shouldStop = true
-    cancelSleep()
-    await runningJob
-    logger.info('[Cancelled]')
-  }
-
-  return {
-    [START_COMPONENT]: start,
-    [STOP_COMPONENT]: stop
-  }
+  return createScheduledRunner({
+    logs: components.logs,
+    job,
+    nextDelayMs: () => onTime,
+    options
+  })
 }

--- a/components/job/src/cron-component.ts
+++ b/components/job/src/cron-component.ts
@@ -1,0 +1,41 @@
+import { ILoggerComponent } from '@well-known-components/interfaces'
+import { CronExpressionParser, CronExpression } from 'cron-parser'
+import { CronSchedule, IJobComponent, JobOptions } from './types'
+import { InvalidCronExpressionError } from './errors'
+import { createScheduledRunner } from './runner'
+
+export function createCronJobComponent(
+  components: Pick<{ logs: ILoggerComponent }, 'logs'>,
+  /** The function to execute as a job. Admits asynchronous functions. */
+  job: () => unknown,
+  /** The cron schedule describing when the job should fire. */
+  schedule: CronSchedule,
+  options: JobOptions = {}
+): IJobComponent {
+  let expression: CronExpression
+  try {
+    expression = CronExpressionParser.parse(schedule.cron, { tz: schedule.timezone })
+  } catch (cause) {
+    throw new InvalidCronExpressionError(schedule.cron, cause)
+  }
+
+  if (schedule.skipFirstRun && typeof options.startupDelay === 'number' && options.startupDelay > 0) {
+    components.logs
+      .getLogger('cron-job')
+      .warn('Both skipFirstRun and startupDelay are set; startupDelay is ignored in favor of the next cron match')
+  }
+
+  function computeNextDelayMs(): number {
+    expression.reset(new Date())
+    return expression.next().getTime() - Date.now()
+  }
+
+  return createScheduledRunner({
+    logs: components.logs,
+    loggerName: 'cron-job',
+    job,
+    nextDelayMs: computeNextDelayMs,
+    initialDelayMs: schedule.skipFirstRun ? computeNextDelayMs : undefined,
+    options
+  })
+}

--- a/components/job/src/errors.ts
+++ b/components/job/src/errors.ts
@@ -15,12 +15,9 @@ export class InvalidStartupDelayError extends Error {
 }
 
 export class InvalidCronExpressionError extends Error {
-  public readonly cause: unknown
-
   constructor(expression: string, cause: unknown) {
     const causeMessage = isErrorWithMessage(cause) ? cause.message : String(cause)
-    super(`Invalid cron expression "${expression}": ${causeMessage}`)
+    super(`Invalid cron expression "${expression}": ${causeMessage}`, { cause })
     this.name = 'InvalidCronExpressionError'
-    this.cause = cause
   }
 }

--- a/components/job/src/errors.ts
+++ b/components/job/src/errors.ts
@@ -1,5 +1,26 @@
+import { isErrorWithMessage } from '@dcl/core-commons'
+
 export class WrongOnTimeError extends Error {
   constructor(onTime: number) {
-    super(`onTime must be greater than 500ms, got ${onTime}ms`)
+    super(`onTime must be at least 500ms, got ${onTime}ms`)
+    this.name = 'WrongOnTimeError'
+  }
+}
+
+export class InvalidStartupDelayError extends Error {
+  constructor(startupDelay: number) {
+    super(`startupDelay must be non-negative, got ${startupDelay}ms`)
+    this.name = 'InvalidStartupDelayError'
+  }
+}
+
+export class InvalidCronExpressionError extends Error {
+  public readonly cause: unknown
+
+  constructor(expression: string, cause: unknown) {
+    const causeMessage = isErrorWithMessage(cause) ? cause.message : String(cause)
+    super(`Invalid cron expression "${expression}": ${causeMessage}`)
+    this.name = 'InvalidCronExpressionError'
+    this.cause = cause
   }
 }

--- a/components/job/src/index.ts
+++ b/components/job/src/index.ts
@@ -1,2 +1,4 @@
 export * from './types'
 export * from './component'
+export * from './cron-component'
+export * from './errors'

--- a/components/job/src/runner.ts
+++ b/components/job/src/runner.ts
@@ -1,0 +1,124 @@
+import { isErrorWithMessage } from '@dcl/core-commons'
+import { START_COMPONENT, STOP_COMPONENT, ILoggerComponent, IBaseComponent } from '@well-known-components/interfaces'
+import { JobOptions } from './types'
+import { InvalidStartupDelayError } from './errors'
+
+const FALLBACK_NEXT_DELAY_MS = 60_000
+
+export type ScheduledRunnerConfig = {
+  logs: ILoggerComponent
+  job: () => unknown
+  /** Called after each job iteration to compute the delay (ms) before the next run. */
+  nextDelayMs: () => number
+  /** If provided, used instead of options.startupDelay for the very first sleep. Evaluated at start(). */
+  initialDelayMs?: () => number
+  loggerName?: string
+  options: JobOptions
+}
+
+export function createScheduledRunner(config: ScheduledRunnerConfig): IBaseComponent {
+  const { logs, job, nextDelayMs, initialDelayMs } = config
+  const {
+    repeat = true,
+    startupDelay = 0,
+    onError = () => undefined,
+    onFinish = () => undefined
+  } = config.options
+
+  if (startupDelay < 0) {
+    throw new InvalidStartupDelayError(startupDelay)
+  }
+
+  const logger = logs.getLogger(config.loggerName ?? 'job')
+  let runJobPromise: Promise<void> = Promise.resolve()
+  let hasStarted = false
+  let shouldStop = false
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  let resolveSleepCancel: ((value: unknown) => void) | undefined
+
+  async function sleep(time: number) {
+    return new Promise((resolve) => {
+      resolveSleepCancel = resolve
+      timeout = setTimeout(() => {
+        resolveSleepCancel = undefined
+        timeout = undefined
+        resolve(undefined)
+      }, time)
+    })
+  }
+
+  function cancelSleep() {
+    if (resolveSleepCancel) {
+      clearTimeout(timeout)
+      resolveSleepCancel(undefined)
+    }
+  }
+
+  function safeDelay(compute: () => number): number {
+    try {
+      const value = compute()
+      if (!Number.isFinite(value)) {
+        logger.error('Computed delay is not a finite number; using fallback', { value: String(value) })
+        return FALLBACK_NEXT_DELAY_MS
+      }
+      return Math.max(0, value)
+    } catch (error) {
+      logger.error('Failed to compute next delay; using fallback', {
+        error: isErrorWithMessage(error) ? error.message : String(error)
+      })
+      return FALLBACK_NEXT_DELAY_MS
+    }
+  }
+
+  async function runJob() {
+    const firstDelay = initialDelayMs ? safeDelay(initialDelayMs) : startupDelay
+    await sleep(firstDelay)
+    while (!shouldStop) {
+      try {
+        await job()
+      } catch (error) {
+        try {
+          onError(error)
+        } catch (onErrorError) {
+          logger.error('onError callback threw', {
+            error: isErrorWithMessage(onErrorError) ? onErrorError.message : String(onErrorError)
+          })
+        }
+      }
+      if (!repeat) {
+        break
+      }
+      await sleep(safeDelay(nextDelayMs))
+    }
+    try {
+      await onFinish()
+    } catch (onFinishError) {
+      logger.error('onFinish callback threw', {
+        error: isErrorWithMessage(onFinishError) ? onFinishError.message : String(onFinishError)
+      })
+    }
+    logger.info('[Stopped]')
+  }
+
+  async function start() {
+    if (hasStarted) {
+      logger.warn('start() called while the runner was already started; ignoring')
+      return
+    }
+    hasStarted = true
+    runJobPromise = runJob().catch(() => undefined)
+  }
+
+  async function stop() {
+    logger.info('[Cancelling]')
+    shouldStop = true
+    cancelSleep()
+    await runJobPromise
+    logger.info('[Cancelled]')
+  }
+
+  return {
+    [START_COMPONENT]: start,
+    [STOP_COMPONENT]: stop
+  }
+}

--- a/components/job/src/runner.ts
+++ b/components/job/src/runner.ts
@@ -4,6 +4,7 @@ import { JobOptions } from './types'
 import { InvalidStartupDelayError } from './errors'
 
 const FALLBACK_NEXT_DELAY_MS = 60_000
+const MAX_SAFE_TIMEOUT_MS = 2_147_483_647
 
 export type ScheduledRunnerConfig = {
   logs: ILoggerComponent
@@ -25,7 +26,7 @@ export function createScheduledRunner(config: ScheduledRunnerConfig): IBaseCompo
     onFinish = () => undefined
   } = config.options
 
-  if (startupDelay < 0) {
+  if (!Number.isFinite(startupDelay) || startupDelay < 0) {
     throw new InvalidStartupDelayError(startupDelay)
   }
 
@@ -61,7 +62,7 @@ export function createScheduledRunner(config: ScheduledRunnerConfig): IBaseCompo
         logger.error('Computed delay is not a finite number; using fallback', { value: String(value) })
         return FALLBACK_NEXT_DELAY_MS
       }
-      return Math.max(0, value)
+      return Math.min(Math.max(0, value), MAX_SAFE_TIMEOUT_MS)
     } catch (error) {
       logger.error('Failed to compute next delay; using fallback', {
         error: isErrorWithMessage(error) ? error.message : String(error)
@@ -88,6 +89,9 @@ export function createScheduledRunner(config: ScheduledRunnerConfig): IBaseCompo
       if (!repeat) {
         break
       }
+      if (shouldStop) {
+        break
+      }
       await sleep(safeDelay(nextDelayMs))
     }
     try {
@@ -106,7 +110,11 @@ export function createScheduledRunner(config: ScheduledRunnerConfig): IBaseCompo
       return
     }
     hasStarted = true
-    runJobPromise = runJob().catch(() => undefined)
+    runJobPromise = runJob().catch((error) => {
+      logger.error('run loop terminated unexpectedly', {
+        error: isErrorWithMessage(error) ? error.message : String(error)
+      })
+    })
   }
 
   async function stop() {

--- a/components/job/src/types.ts
+++ b/components/job/src/types.ts
@@ -9,6 +9,23 @@ export type JobOptions = {
   startupDelay?: number
   /** Sets a function to be executed if the job fails */
   onError?: (error: unknown) => void
-  /** Executes a function when the component finishes */
-  onFinish?: () => any
+  /**
+   * Executes a function when the component's run loop exits (whether iterations ran or not).
+   * Also fires if the component is stopped during its startup sleep, before the first iteration.
+   * May be async; the runner awaits its result before resolving `stop()`.
+   */
+  onFinish?: () => void | Promise<void>
+}
+
+export type CronSchedule = {
+  /** A cron expression (5- or 6-field) describing when the job should fire. */
+  cron: string
+  /** Optional IANA timezone used for cron evaluation. Defaults to UTC. */
+  timezone?: string
+  /**
+   * If true, the job waits for the next cron match before its first run.
+   * If false (default), the job runs immediately after `startupDelay` and then sleeps until each subsequent cron match.
+   * Note: `startupDelay` is still validated (`>= 0`) even when this flag supersedes its effect.
+   */
+  skipFirstRun?: boolean
 }

--- a/components/job/tests/cron-job-component.spec.ts
+++ b/components/job/tests/cron-job-component.spec.ts
@@ -1,0 +1,241 @@
+import { START_COMPONENT, STOP_COMPONENT, ILoggerComponent } from '@well-known-components/interfaces'
+import { createLoggerMockedComponent } from '@dcl/core-commons'
+import { createCronJobComponent } from '../src/cron-component'
+import { IJobComponent } from '../src/types'
+import { InvalidCronExpressionError } from '../src/errors'
+
+let logs: ILoggerComponent
+let component: IJobComponent
+let job: jest.Mock
+let componentFinished: Promise<void>
+let onFinish: () => void
+let mockedSetTimeout: jest.SpyInstance
+
+beforeEach(() => {
+  jest.useFakeTimers({ doNotFake: ['setTimeout', 'clearTimeout'] })
+  jest.setSystemTime(new Date('2026-01-01T00:00:30Z'))
+
+  mockedSetTimeout = jest.spyOn(global, 'setTimeout')
+  mockedSetTimeout.mockImplementation((handler) => {
+    ;(handler as any)()
+    return 1 as any
+  })
+
+  job = jest.fn()
+  logs = createLoggerMockedComponent()
+  let finish: () => void
+  componentFinished = new Promise((resolve) => (finish = resolve))
+  onFinish = () => finish()
+})
+
+afterEach(() => {
+  mockedSetTimeout.mockRestore()
+  jest.useRealTimers()
+})
+
+describe('when creating the cron job component with an invalid cron expression', () => {
+  it('should throw an InvalidCronExpressionError', () => {
+    expect(() =>
+      createCronJobComponent({ logs }, job, { cron: 'not-a-cron' }, { repeat: false, onFinish })
+    ).toThrow(InvalidCronExpressionError)
+  })
+})
+
+describe('when InvalidCronExpressionError is constructed with a non-Error cause', () => {
+  it('should include the stringified cause in the message and preserve the raw cause', () => {
+    const rawCause = 'string reason'
+    const error = new InvalidCronExpressionError('bad-expr', rawCause)
+    expect(error.message).toContain('bad-expr')
+    expect(error.message).toContain('string reason')
+    expect(error.cause).toBe(rawCause)
+  })
+})
+
+describe('when InvalidCronExpressionError is constructed with an Error cause', () => {
+  it('should preserve the raw Error as the cause property', () => {
+    const rawCause = new Error('parser exploded')
+    const error = new InvalidCronExpressionError('bad-expr', rawCause)
+    expect(error.cause).toBe(rawCause)
+  })
+})
+
+describe('when the schedule sets skipFirstRun together with a startupDelay', () => {
+  let warnLogMock: jest.Mock
+
+  beforeEach(() => {
+    warnLogMock = jest.fn()
+    logs = createLoggerMockedComponent({ warn: warnLogMock })
+    createCronJobComponent(
+      { logs },
+      job,
+      { cron: '* * * * *', skipFirstRun: true },
+      { startupDelay: 5000, repeat: false, onFinish }
+    )
+  })
+
+  it('should warn that startupDelay is ignored', () => {
+    expect(warnLogMock).toHaveBeenCalledWith(
+      'Both skipFirstRun and startupDelay are set; startupDelay is ignored in favor of the next cron match'
+    )
+  })
+})
+
+describe('when the schedule has skipFirstRun set to true', () => {
+  beforeEach(() => {
+    component = createCronJobComponent(
+      { logs },
+      job,
+      { cron: '* * * * *', skipFirstRun: true },
+      { repeat: false, onFinish }
+    )
+  })
+
+  it('should sleep until the next cron fire time before the first run', async () => {
+    await component[START_COMPONENT]?.({} as any)
+    await componentFinished
+    // Fixed time 2026-01-01T00:00:30Z + cron '* * * * *' → next fire at 00:01:00Z → 30000 ms.
+    expect(mockedSetTimeout).toHaveBeenCalledWith(expect.anything(), 30000)
+    expect(job).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('when the schedule includes a timezone', () => {
+  beforeEach(() => {
+    component = createCronJobComponent(
+      { logs },
+      job,
+      { cron: '0 3 * * *', timezone: 'America/New_York' },
+      { repeat: false, onFinish }
+    )
+  })
+
+  it('should accept the timezone and run the job', async () => {
+    await component[START_COMPONENT]?.({} as any)
+    await componentFinished
+    expect(job).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('when the options argument is omitted entirely', () => {
+  let infoLogMock: jest.Mock
+  let stoppedPromise: Promise<void>
+
+  beforeEach(() => {
+    let stoppedResolve: () => void
+    stoppedPromise = new Promise<void>((r) => (stoppedResolve = r))
+    infoLogMock = jest.fn().mockImplementation((msg: string) => {
+      if (msg === '[Stopped]') stoppedResolve()
+    })
+    logs = createLoggerMockedComponent({ info: infoLogMock })
+    component = createCronJobComponent({ logs }, job, { cron: '* * * * *' })
+    job.mockImplementationOnce(() => {
+      component[STOP_COMPONENT]?.()
+    })
+  })
+
+  it('should fall back to the default options object and run the job', async () => {
+    await component[START_COMPONENT]?.({} as any)
+    await stoppedPromise
+    expect(job).toHaveBeenCalled()
+  })
+})
+
+describe('when starting a cron job', () => {
+  describe('and the option to repeat the job is set as false', () => {
+    beforeEach(() => {
+      component = createCronJobComponent({ logs }, job, { cron: '* * * * *' }, { repeat: false, onFinish })
+    })
+
+    it('should run the job once and finish', async () => {
+      await component[START_COMPONENT]?.({} as any)
+      await componentFinished
+      expect(job).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('and the startup delay option is set', () => {
+    beforeEach(() => {
+      component = createCronJobComponent(
+        { logs },
+        job,
+        { cron: '* * * * *' },
+        { startupDelay: 4000, repeat: false, onFinish }
+      )
+    })
+
+    it('should wait the defined time before running the job for the first time', async () => {
+      await component[START_COMPONENT]?.({} as any)
+      await componentFinished
+      expect(mockedSetTimeout).toHaveBeenCalledWith(expect.anything(), 4000)
+      expect(job).toHaveBeenCalled()
+    })
+  })
+
+  describe('and the option to repeat the job is set as true', () => {
+    beforeEach(() => {
+      component = createCronJobComponent({ logs }, job, { cron: '* * * * *' }, { repeat: true, onFinish })
+      job.mockResolvedValueOnce(undefined).mockImplementationOnce(() => {
+        component[STOP_COMPONENT]?.()
+      })
+    })
+
+    it('should sleep until the next cron fire time between iterations', async () => {
+      await component[START_COMPONENT]?.({} as any)
+      await componentFinished
+      // Fixed time 2026-01-01T00:00:30Z + cron '* * * * *' → next fire at 00:01:00Z → delay 30000 ms.
+      expect(mockedSetTimeout).toHaveBeenCalledWith(expect.anything(), 30000)
+      expect(job).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe("and there's an error when executing the job", () => {
+    let onError: jest.Mock
+    let error: Error
+
+    beforeEach(() => {
+      onError = jest.fn()
+      error = new Error('An error occurred')
+      job.mockRejectedValueOnce(error)
+      component = createCronJobComponent(
+        { logs },
+        job,
+        { cron: '* * * * *' },
+        { repeat: false, onError, onFinish }
+      )
+    })
+
+    it('should execute the given onError method', async () => {
+      await component[START_COMPONENT]?.({} as any)
+      await componentFinished
+      expect(onError).toHaveBeenCalledWith(error)
+    })
+  })
+})
+
+describe('when stopping a started cron job', () => {
+  let finishJobExecution: (value: unknown) => void
+  let jobExecutingPromise: Promise<void>
+
+  beforeEach(() => {
+    let signalExecution: (value: void | PromiseLike<void>) => void
+    component = createCronJobComponent({ logs }, job, { cron: '* * * * *' }, { onFinish })
+    jobExecutingPromise = new Promise((resolve) => (signalExecution = resolve))
+    job
+      .mockImplementationOnce(() => {
+        signalExecution()
+        return new Promise((resolve) => {
+          finishJobExecution = resolve
+        })
+      })
+      .mockRejectedValueOnce("It shouldn't execute the job twice")
+  })
+
+  it('should wait until the job has completed and not run any more jobs', async () => {
+    await component[START_COMPONENT]?.({} as any)
+    await jobExecutingPromise
+    const promiseOfStoppingTheJob = component[STOP_COMPONENT]?.()
+    finishJobExecution(undefined)
+    await Promise.all([promiseOfStoppingTheJob, componentFinished])
+    expect(job).toHaveBeenCalledTimes(1)
+  })
+})

--- a/components/job/tests/job-component.spec.ts
+++ b/components/job/tests/job-component.spec.ts
@@ -1,8 +1,9 @@
 import { ILoggerComponent, START_COMPONENT, STOP_COMPONENT } from '@well-known-components/interfaces'
 import { createLoggerMockedComponent } from '@dcl/core-commons'
 import { createJobComponent } from '../src/component'
+import { createScheduledRunner } from '../src/runner'
 import { IJobComponent } from '../src/types'
-import { WrongOnTimeError } from '../src/errors'
+import { InvalidCronExpressionError, InvalidStartupDelayError, WrongOnTimeError } from '../src/errors'
 
 let logs: ILoggerComponent
 let component: IJobComponent
@@ -10,11 +11,13 @@ let job: jest.Mock
 let time: number
 let componentFinished: Promise<void>
 let onFinish: () => void
+let errorLogMock: jest.Mock
 const mockedSetTimeout = jest.spyOn(global, 'setTimeout')
 
 beforeEach(() => {
   job = jest.fn()
-  logs = createLoggerMockedComponent()
+  errorLogMock = jest.fn()
+  logs = createLoggerMockedComponent({ error: errorLogMock })
   time = 1000
   let finish: () => void
   componentFinished = new Promise((resolve) => (finish = resolve))
@@ -26,9 +29,35 @@ beforeEach(() => {
   })
 })
 
+afterAll(() => {
+  mockedSetTimeout.mockRestore()
+})
+
 describe('when creating the job component with a lower than 500ms onTime', () => {
   it('should throw an error', () => {
     expect(() => createJobComponent({ logs }, job, -1, { repeat: false, onFinish })).toThrow(WrongOnTimeError)
+  })
+})
+
+describe('when creating the job component with a negative startupDelay', () => {
+  it('should throw an InvalidStartupDelayError', () => {
+    expect(() =>
+      createJobComponent({ logs }, job, time, { repeat: false, startupDelay: -10, onFinish })
+    ).toThrow(InvalidStartupDelayError)
+  })
+})
+
+describe('when constructing custom error classes', () => {
+  it('should set the name on WrongOnTimeError', () => {
+    expect(new WrongOnTimeError(10).name).toBe('WrongOnTimeError')
+  })
+
+  it('should set the name on InvalidStartupDelayError', () => {
+    expect(new InvalidStartupDelayError(-5).name).toBe('InvalidStartupDelayError')
+  })
+
+  it('should set the name on InvalidCronExpressionError', () => {
+    expect(new InvalidCronExpressionError('bad', new Error('x')).name).toBe('InvalidCronExpressionError')
   })
 })
 
@@ -131,5 +160,386 @@ describe('when stopping a started job', () => {
     finishJobExecution(undefined)
     await Promise.all([promiseOfStoppingTheJob, componentFinished])
     expect(job).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('when stopping after an earlier iteration rejected', () => {
+  let onError: jest.Mock
+  let iterationError: Error
+  let iterationRejected: Promise<void>
+
+  beforeEach(() => {
+    iterationError = new Error('iteration blew up')
+    let signalIterationRejected: () => void
+    iterationRejected = new Promise<void>((r) => (signalIterationRejected = r))
+    onError = jest.fn().mockImplementation(() => signalIterationRejected())
+
+    // First setTimeout (startupDelay=0) fires sync; second (inter-iteration sleep) stays pending
+    // so stop() runs while the prior iteration's rejection could still leak through the runner.
+    mockedSetTimeout.mockReset()
+    mockedSetTimeout
+      .mockImplementationOnce((handler) => {
+        ;(handler as any)()
+        return 1 as any
+      })
+      .mockImplementationOnce(() => 2 as any)
+
+    job.mockRejectedValueOnce(iterationError)
+    component = createJobComponent({ logs }, job, time, {
+      repeat: true,
+      onError,
+      onFinish
+    })
+  })
+
+  it('should resolve stop() cleanly without re-throwing the prior rejection', async () => {
+    await component[START_COMPONENT]?.({} as any)
+    await iterationRejected
+    await expect(component[STOP_COMPONENT]?.()).resolves.toBeUndefined()
+    await componentFinished
+    expect(onError).toHaveBeenCalledWith(iterationError)
+  })
+})
+
+describe('when stopping a job whose onFinish is async and still pending', () => {
+  let resolveOnFinish: () => void
+  let onFinishStarted: Promise<void>
+
+  beforeEach(() => {
+    let signalOnFinishStarted: () => void
+    onFinishStarted = new Promise<void>((r) => (signalOnFinishStarted = r))
+    const onFinishPending = new Promise<void>((r) => (resolveOnFinish = r))
+    component = createJobComponent({ logs }, job, time, {
+      repeat: false,
+      onFinish: async () => {
+        signalOnFinishStarted()
+        await onFinishPending
+      }
+    })
+  })
+
+  it('should not resolve stop() until onFinish has completed', async () => {
+    await component[START_COMPONENT]?.({} as any)
+    await onFinishStarted
+
+    const stopping = component[STOP_COMPONENT]?.()
+    let stopResolved = false
+    stopping!.then(() => {
+      stopResolved = true
+    })
+
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve()
+    }
+    expect(stopResolved).toBe(false)
+
+    resolveOnFinish()
+    await stopping
+    expect(stopResolved).toBe(true)
+  })
+})
+
+describe('when stopping the component during the startup sleep', () => {
+  let mockedClearTimeout: jest.SpyInstance
+
+  beforeEach(() => {
+    mockedSetTimeout.mockReset()
+    mockedSetTimeout.mockImplementationOnce(() => 1 as any)
+    mockedClearTimeout = jest.spyOn(global, 'clearTimeout').mockImplementation(() => undefined)
+    component = createJobComponent({ logs }, job, time, { startupDelay: 4000, onFinish })
+  })
+
+  afterEach(() => {
+    mockedClearTimeout.mockRestore()
+  })
+
+  it('should clear the pending timeout and exit without running the job', async () => {
+    await component[START_COMPONENT]?.({} as any)
+    await component[STOP_COMPONENT]?.()
+    await componentFinished
+    expect(mockedClearTimeout).toHaveBeenCalledWith(1)
+    expect(job).not.toHaveBeenCalled()
+  })
+})
+
+describe('when the onError callback throws an Error', () => {
+  let callbackError: Error
+
+  beforeEach(() => {
+    callbackError = new Error('onError blew up')
+    job.mockRejectedValueOnce(new Error('job blew up'))
+    component = createJobComponent({ logs }, job, time, {
+      repeat: false,
+      onError: () => {
+        throw callbackError
+      },
+      onFinish
+    })
+  })
+
+  it('should log the callback error message and continue to finish', async () => {
+    await component[START_COMPONENT]?.({} as any)
+    await componentFinished
+    expect(errorLogMock).toHaveBeenCalledWith('onError callback threw', {
+      error: 'onError blew up'
+    })
+  })
+})
+
+describe('when the onError callback throws a non-Error value', () => {
+  beforeEach(() => {
+    job.mockRejectedValueOnce(new Error('job blew up'))
+    component = createJobComponent({ logs }, job, time, {
+      repeat: false,
+      onError: () => {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        throw 'string rejection'
+      },
+      onFinish
+    })
+  })
+
+  it('should stringify the callback failure', async () => {
+    await component[START_COMPONENT]?.({} as any)
+    await componentFinished
+    expect(errorLogMock).toHaveBeenCalledWith('onError callback threw', {
+      error: 'string rejection'
+    })
+  })
+})
+
+describe('when the onFinish callback throws an Error', () => {
+  let callbackError: Error
+
+  beforeEach(() => {
+    callbackError = new Error('onFinish blew up')
+    component = createJobComponent({ logs }, job, time, {
+      repeat: false,
+      onFinish: () => {
+        onFinish()
+        throw callbackError
+      }
+    })
+  })
+
+  it('should log the callback error message', async () => {
+    await component[START_COMPONENT]?.({} as any)
+    await componentFinished
+    expect(errorLogMock).toHaveBeenCalledWith('onFinish callback threw', {
+      error: 'onFinish blew up'
+    })
+  })
+})
+
+describe('when the onFinish callback throws a non-Error value', () => {
+  beforeEach(() => {
+    component = createJobComponent({ logs }, job, time, {
+      repeat: false,
+      onFinish: () => {
+        onFinish()
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        throw 'finish string rejection'
+      }
+    })
+  })
+
+  it('should stringify the callback failure', async () => {
+    await component[START_COMPONENT]?.({} as any)
+    await componentFinished
+    expect(errorLogMock).toHaveBeenCalledWith('onFinish callback threw', {
+      error: 'finish string rejection'
+    })
+  })
+})
+
+describe('when options is an empty object', () => {
+  let infoLogMock: jest.Mock
+  let stoppedPromise: Promise<void>
+
+  beforeEach(() => {
+    let stoppedResolve: () => void
+    stoppedPromise = new Promise<void>((r) => (stoppedResolve = r))
+    infoLogMock = jest.fn().mockImplementation((msg: string) => {
+      if (msg === '[Stopped]') stoppedResolve()
+    })
+    logs = createLoggerMockedComponent({ error: errorLogMock, info: infoLogMock })
+    job.mockRejectedValueOnce(new Error('silent'))
+    component = createJobComponent({ logs }, job, time, { repeat: false })
+  })
+
+  it('should apply default no-op onError and onFinish callbacks', async () => {
+    await component[START_COMPONENT]?.({} as any)
+    await stoppedPromise
+    expect(job).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('when start is called while the runner is already started', () => {
+  let warnLogMock: jest.Mock
+
+  beforeEach(() => {
+    warnLogMock = jest.fn()
+    logs = createLoggerMockedComponent({ error: errorLogMock, warn: warnLogMock })
+    component = createJobComponent({ logs }, job, time, { repeat: false, onFinish })
+  })
+
+  it('should warn and ignore the second start call', async () => {
+    await component[START_COMPONENT]?.({} as any)
+    await component[START_COMPONENT]?.({} as any)
+    await componentFinished
+    expect(warnLogMock).toHaveBeenCalledWith(
+      'start() called while the runner was already started; ignoring'
+    )
+    expect(job).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('when nextDelayMs returns a non-finite number', () => {
+  let nextDelayMs: jest.Mock
+  let runner: IJobComponent
+
+  beforeEach(() => {
+    nextDelayMs = jest
+      .fn()
+      .mockReturnValueOnce(NaN)
+      .mockImplementation(() => {
+        runner[STOP_COMPONENT]?.()
+        return 1000
+      })
+    runner = createScheduledRunner({
+      logs,
+      job: jest.fn(),
+      nextDelayMs,
+      options: { repeat: true, onFinish }
+    })
+  })
+
+  it('should log and fall back to the 60s delay', async () => {
+    await runner[START_COMPONENT]?.({} as any)
+    await componentFinished
+    expect(errorLogMock).toHaveBeenCalledWith('Computed delay is not a finite number; using fallback', {
+      value: 'NaN'
+    })
+    expect(mockedSetTimeout).toHaveBeenCalledWith(expect.anything(), 60_000)
+  })
+})
+
+describe('when nextDelayMs returns Infinity', () => {
+  let nextDelayMs: jest.Mock
+  let runner: IJobComponent
+
+  beforeEach(() => {
+    nextDelayMs = jest
+      .fn()
+      .mockReturnValueOnce(Infinity)
+      .mockImplementation(() => {
+        runner[STOP_COMPONENT]?.()
+        return 1000
+      })
+    runner = createScheduledRunner({
+      logs,
+      job: jest.fn(),
+      nextDelayMs,
+      options: { repeat: true, onFinish }
+    })
+  })
+
+  it('should log and fall back to the 60s delay', async () => {
+    await runner[START_COMPONENT]?.({} as any)
+    await componentFinished
+    expect(errorLogMock).toHaveBeenCalledWith('Computed delay is not a finite number; using fallback', {
+      value: 'Infinity'
+    })
+    expect(mockedSetTimeout).toHaveBeenCalledWith(expect.anything(), 60_000)
+  })
+})
+
+describe('when nextDelayMs throws an Error between iterations', () => {
+  let nextDelayMs: jest.Mock
+  let runner: IJobComponent
+
+  beforeEach(() => {
+    nextDelayMs = jest
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error('delay computation failed')
+      })
+      .mockImplementation(() => {
+        runner[STOP_COMPONENT]?.()
+        return 1000
+      })
+    runner = createScheduledRunner({
+      logs,
+      job: jest.fn(),
+      nextDelayMs,
+      options: { repeat: true, onFinish }
+    })
+  })
+
+  it('should log the failure and fall back to a 60s delay instead of crashing the runner', async () => {
+    await runner[START_COMPONENT]?.({} as any)
+    await componentFinished
+    expect(errorLogMock).toHaveBeenCalledWith(
+      'Failed to compute next delay; using fallback',
+      { error: 'delay computation failed' }
+    )
+    expect(mockedSetTimeout).toHaveBeenCalledWith(expect.anything(), 60_000)
+  })
+})
+
+describe('when nextDelayMs throws a non-Error value between iterations', () => {
+  let nextDelayMs: jest.Mock
+  let runner: IJobComponent
+
+  beforeEach(() => {
+    nextDelayMs = jest
+      .fn()
+      .mockImplementationOnce(() => {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        throw 'delay string rejection'
+      })
+      .mockImplementation(() => {
+        runner[STOP_COMPONENT]?.()
+        return 1000
+      })
+    runner = createScheduledRunner({
+      logs,
+      job: jest.fn(),
+      nextDelayMs,
+      options: { repeat: true, onFinish }
+    })
+  })
+
+  it('should stringify the non-Error cause in the fallback log', async () => {
+    await runner[START_COMPONENT]?.({} as any)
+    await componentFinished
+    expect(errorLogMock).toHaveBeenCalledWith(
+      'Failed to compute next delay; using fallback',
+      { error: 'delay string rejection' }
+    )
+  })
+})
+
+describe('when the options argument is omitted entirely', () => {
+  let infoLogMock: jest.Mock
+  let stoppedPromise: Promise<void>
+
+  beforeEach(() => {
+    let stoppedResolve: () => void
+    stoppedPromise = new Promise<void>((r) => (stoppedResolve = r))
+    infoLogMock = jest.fn().mockImplementation((msg: string) => {
+      if (msg === '[Stopped]') stoppedResolve()
+    })
+    logs = createLoggerMockedComponent({ error: errorLogMock, info: infoLogMock })
+    component = createJobComponent({ logs }, job, time)
+    job.mockImplementationOnce(() => {
+      component[STOP_COMPONENT]?.()
+    })
+  })
+
+  it('should fall back to the default options object and run the job', async () => {
+    await component[START_COMPONENT]?.({} as any)
+    await stoppedPromise
+    expect(job).toHaveBeenCalled()
   })
 })

--- a/components/job/tests/job-component.spec.ts
+++ b/components/job/tests/job-component.spec.ts
@@ -39,10 +39,30 @@ describe('when creating the job component with a lower than 500ms onTime', () =>
   })
 })
 
+describe('when creating the job component with a non-finite onTime', () => {
+  it.each([
+    ['NaN', NaN],
+    ['Infinity', Number.POSITIVE_INFINITY]
+  ])('should throw a WrongOnTimeError for %s', (_label, invalid) => {
+    expect(() => createJobComponent({ logs }, job, invalid, { repeat: false, onFinish })).toThrow(WrongOnTimeError)
+  })
+})
+
 describe('when creating the job component with a negative startupDelay', () => {
   it('should throw an InvalidStartupDelayError', () => {
     expect(() =>
       createJobComponent({ logs }, job, time, { repeat: false, startupDelay: -10, onFinish })
+    ).toThrow(InvalidStartupDelayError)
+  })
+})
+
+describe('when creating the job component with a non-finite startupDelay', () => {
+  it.each([
+    ['NaN', NaN],
+    ['Infinity', Number.POSITIVE_INFINITY]
+  ])('should throw an InvalidStartupDelayError for %s', (_label, invalid) => {
+    expect(() =>
+      createJobComponent({ logs }, job, time, { repeat: false, startupDelay: invalid, onFinish })
     ).toThrow(InvalidStartupDelayError)
   })
 })
@@ -517,6 +537,123 @@ describe('when nextDelayMs throws a non-Error value between iterations', () => {
       'Failed to compute next delay; using fallback',
       { error: 'delay string rejection' }
     )
+  })
+})
+
+describe('when stop() is called while the job is still executing', () => {
+  let finishJobExecution: (value: unknown) => void
+  let jobRunning: Promise<void>
+
+  beforeEach(() => {
+    mockedSetTimeout.mockReset()
+    mockedSetTimeout
+      .mockImplementationOnce((handler) => {
+        ;(handler as any)()
+        return 1 as any
+      })
+      .mockImplementation(() => 2 as any)
+
+    let signalRunning: () => void
+    jobRunning = new Promise<void>((r) => (signalRunning = r))
+    job.mockImplementationOnce(() => {
+      signalRunning()
+      return new Promise((resolve) => {
+        finishJobExecution = resolve
+      })
+    })
+    component = createJobComponent({ logs }, job, time, { repeat: true, onFinish })
+  })
+
+  it('should break out of the loop before scheduling the inter-iteration sleep', async () => {
+    await component[START_COMPONENT]?.({} as any)
+    await jobRunning
+
+    const stopping = component[STOP_COMPONENT]?.()
+    finishJobExecution(undefined)
+    await Promise.all([stopping, componentFinished])
+
+    expect(job).toHaveBeenCalledTimes(1)
+    expect(mockedSetTimeout).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('when nextDelayMs returns a value larger than the 32-bit setTimeout limit', () => {
+  let nextDelayMs: jest.Mock
+  let runner: IJobComponent
+
+  beforeEach(() => {
+    nextDelayMs = jest
+      .fn()
+      .mockReturnValueOnce(30 * 24 * 60 * 60 * 1000)
+      .mockImplementation(() => {
+        runner[STOP_COMPONENT]?.()
+        return 1000
+      })
+    runner = createScheduledRunner({
+      logs,
+      job: jest.fn(),
+      nextDelayMs,
+      options: { repeat: true, onFinish }
+    })
+  })
+
+  it('should clamp the delay to the 32-bit setTimeout max', async () => {
+    await runner[START_COMPONENT]?.({} as any)
+    await componentFinished
+    expect(mockedSetTimeout).toHaveBeenCalledWith(expect.anything(), 2_147_483_647)
+  })
+})
+
+describe('when runJob rejects unexpectedly after onFinish', () => {
+  let infoLogMock: jest.Mock
+
+  beforeEach(() => {
+    infoLogMock = jest.fn().mockImplementation((msg: string) => {
+      if (msg === '[Stopped]') {
+        throw new Error('logger exploded')
+      }
+    })
+    logs = createLoggerMockedComponent({ error: errorLogMock, info: infoLogMock })
+    component = createJobComponent({ logs }, job, time, {
+      repeat: false,
+      onFinish: () => undefined
+    })
+  })
+
+  it('should log the failure from the run loop instead of swallowing it', async () => {
+    await component[START_COMPONENT]?.({} as any)
+    await component[STOP_COMPONENT]?.()
+
+    expect(errorLogMock).toHaveBeenCalledWith('run loop terminated unexpectedly', {
+      error: 'logger exploded'
+    })
+  })
+})
+
+describe('when runJob rejects with a non-Error value', () => {
+  let infoLogMock: jest.Mock
+
+  beforeEach(() => {
+    infoLogMock = jest.fn().mockImplementation((msg: string) => {
+      if (msg === '[Stopped]') {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        throw 'non-error rejection'
+      }
+    })
+    logs = createLoggerMockedComponent({ error: errorLogMock, info: infoLogMock })
+    component = createJobComponent({ logs }, job, time, {
+      repeat: false,
+      onFinish: () => undefined
+    })
+  })
+
+  it('should stringify the rejection in the run-loop failure log', async () => {
+    await component[START_COMPONENT]?.({} as any)
+    await component[STOP_COMPONENT]?.()
+
+    expect(errorLogMock).toHaveBeenCalledWith('run loop terminated unexpectedly', {
+      error: 'non-error rejection'
+    })
   })
 })
 

--- a/components/job/tsconfig.json
+++ b/components/job/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "ES2022.Error"],
     "types": ["node", "jest"],
     "declaration": true,
     "outDir": "./dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       '@well-known-components/interfaces':
         specifier: ^1.5.2
         version: 1.5.2
+      cron-parser:
+        specifier: ^5.0.0
+        version: 5.5.0
     devDependencies:
       typescript:
         specifier: ^5.8.3
@@ -2507,6 +2510,10 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
 
+  cron-parser@5.5.0:
+    resolution: {integrity: sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==}
+    engines: {node: '>=18'}
+
   cross-fetch@3.2.0:
     resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
 
@@ -3005,20 +3012,23 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -3558,6 +3568,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -8239,6 +8253,10 @@ snapshots:
       - supports-color
       - ts-node
 
+  cron-parser@5.5.0:
+    dependencies:
+      luxon: 3.7.2
+
   cross-fetch@3.2.0:
     dependencies:
       node-fetch: 2.7.0
@@ -9768,6 +9786,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  luxon@3.7.2: {}
 
   make-dir@4.0.0:
     dependencies:


### PR DESCRIPTION
## Why

`@dcl/job-component` only supported fixed-interval scheduling and had a handful of shutdown/lifecycle gotchas that would surface as soon as real consumers wired it into production:

- `stop()` returned before an async `onFinish` had finished, so the lifecycle manager treated shutdown as complete while cleanup was still in-flight.
- A rejected iteration leaked back through `stop()` — the stored per-iteration promise was awaited unconditionally, so a rejection from an earlier iteration (already reported via `onError`) would surface again at shutdown and fail the lifecycle stop.
- Errors thrown from `onError` / `onFinish` callbacks became unhandled rejections.
- `start()` could be invoked twice and would race two `runJob` copies against the same closure state.
- `nextDelayMs` could throw or yield `NaN` / `Infinity` (particularly for cron) and silently kill the runner or make it spin / hang.
- There was no way to express "run this at 03:00 UTC daily" without the caller implementing cron maths themselves.

## How

- Extract the run loop into a private `createScheduledRunner` parameterised by a `nextDelayMs` closure. `createJobComponent` stays as a thin wrapper over it.
- Add `createCronJobComponent`, which parses the expression once via `cron-parser`, recomputes the delay from the current clock after each iteration (dropping missed ticks rather than stampeding), and exposes `{ timezone?, skipFirstRun? }` on `CronSchedule`. The factory warns when `skipFirstRun: true` is combined with a non-default `startupDelay`, since the latter is superseded.
- Track the full `runJob()` promise in `start()` and await it in `stop()`, so `onFinish` and the final log complete before `stop()` resolves. The same promise is normalised with `.catch(() => undefined)` so `stop()` itself can never reject.
- Guard `start()` with a `hasStarted` flag; a second call logs a warning and returns.
- Wrap `onError` / `onFinish` invocations in try/catch; thrown callbacks are logged, not escalated.
- Wrap `nextDelayMs` behind a `safeDelay` helper that catches exceptions and rejects non-finite values; both paths log and fall back to a 60s sleep.
- Add `InvalidStartupDelayError` (validated in the runner) and `InvalidCronExpressionError` (preserves the raw parser error on `.cause`). Every subclass now sets `.name` for cleaner stack traces. Correct the `WrongOnTimeError` message to match the actual `>= 500ms` bound.
- Tighten public types: `job: () => unknown` on both factories; `JobOptions.onFinish: () => void | Promise<void>`.

## Test plan

- [x] \`pnpm -F @dcl/job-component test\` — 37 tests pass (was 7).
- [x] \`pnpm -F @dcl/job-component exec tsc --noEmit\` — clean.
- [x] Coverage: 100% statements/branches/lines on \`component.ts\`, \`cron-component.ts\`, \`errors.ts\`. \`runner.ts\` at 100% lines / 100% branches; the only uncovered function is the defensive \`.catch\` in \`start()\`.
- [ ] Reviewer: eyeball the new README examples for cron mode + \`skipFirstRun\`.