### PR TITLE
feat: add request timeout and tighten analytics typing

### DIFF
--- a/.changeset/analytics-request-timeout.md
+++ b/.changeset/analytics-request-timeout.md
@@ -1,8 +1,8 @@
 ---
-'@dcl/analytics-component': minor
+'@dcl/analytics-component': major
 ---
 
 - Apply a request timeout to the Analytics API call to prevent hung fetches. The timeout is read from the optional `ANALYTICS_REQUEST_TIMEOUT` env var; only finite positive numbers are accepted, otherwise the default (10000 ms) is used.
 - Remove the per-event `logger.debug`. It sat outside the try/catch, which meant a failing logger could produce an unhandled rejection through `fireEvent`.
-- Tighten `sendEvent` / `fireEvent` typing so `body` is bound to the specific event key (`<K extends keyof T>(name: K, body: T[K])`) instead of the union of all event bodies. Export `AnalyticsEventMap` as the generic constraint so primitive event bodies are rejected at compile time.
+- **Breaking:** Tighten `sendEvent` / `fireEvent` typing so `body` is bound to the specific event key (`<K extends keyof T>(name: K, body: T[K])`) instead of the union of all event bodies. Export `AnalyticsEventMap = Record<string, Record<string, any>>` as the generic constraint on `IAnalyticsComponent` and `createAnalyticsComponent`, so primitive event bodies are rejected at compile time. Consumers that declared an event map with a primitive body (e.g. `{ page_view: string }`) will see a compile error — in practice these were already broken at runtime because spreading a primitive into the outgoing payload yields `{}`.
 - Rewrite the README to match the current constructor and public API.

--- a/.changeset/analytics-request-timeout.md
+++ b/.changeset/analytics-request-timeout.md
@@ -1,0 +1,8 @@
+---
+'@dcl/analytics-component': minor
+---
+
+- Apply a request timeout to the Analytics API call to prevent hung fetches. The timeout is read from the optional `ANALYTICS_REQUEST_TIMEOUT` env var; only finite positive numbers are accepted, otherwise the default (10000 ms) is used.
+- Remove the per-event `logger.debug`. It sat outside the try/catch, which meant a failing logger could produce an unhandled rejection through `fireEvent`.
+- Tighten `sendEvent` / `fireEvent` typing so `body` is bound to the specific event key (`<K extends keyof T>(name: K, body: T[K])`) instead of the union of all event bodies. Export `AnalyticsEventMap` as the generic constraint so primitive event bodies are rejected at compile time.
+- Rewrite the README to match the current constructor and public API.

--- a/components/analytics/README.md
+++ b/components/analytics/README.md
@@ -4,25 +4,43 @@ A component for sending analytics events to an external API.
 
 ## Features
 
-- Send analytics events with environment context
+- Send analytics events with environment and service context
 - Error handling and logging
-- Configurable API endpoint and authentication
+- Configurable request timeout
+- Fire-and-forget or awaited delivery modes
+
+## Configuration
+
+The component reads the following environment variables via the config component:
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `ANALYTICS_API_URL` | yes | Endpoint that receives the POSTed events. |
+| `ANALYTICS_API_TOKEN` | yes | Token sent in the `x-token` header. |
+| `ANALYTICS_CONTEXT` | yes | Context value included with every event (e.g. service name). |
+| `ENV` | yes | Environment name injected into each event body. |
+| `ANALYTICS_REQUEST_TIMEOUT` | no | Request timeout in ms. Defaults to `10000`. |
 
 ## Usage
 
 ```typescript
 import { createAnalyticsComponent } from '@dcl/analytics-component'
 
-const analytics = await createAnalyticsComponent(
-  { fetch, logs },
-  'service-name',
-  'prd',
-  'https://api.analytics.com/events',
-  'your-api-token'
-)
+type Events = {
+  user_login: { userId: string; timestamp: number }
+}
 
-await analytics.sendEvent({
-  event: 'user_action',
-  body: { userId: '123', action: 'click' }
+const analytics = await createAnalyticsComponent<Events>({
+  fetcher,
+  logs,
+  config
 })
+
+// Await delivery (errors are logged, never thrown):
+await analytics.sendEvent('user_login', { userId: '123', timestamp: Date.now() })
+
+// Fire-and-forget:
+analytics.fireEvent('user_login', { userId: '123', timestamp: Date.now() })
 ```
+
+> Note: the caller's `body` is merged with `{ env }`, so `env` is a reserved key and will be overwritten if passed.

--- a/components/analytics/src/component.ts
+++ b/components/analytics/src/component.ts
@@ -13,10 +13,14 @@ export async function createAnalyticsComponent<T extends AnalyticsEventMap>(
   const analyticsApiToken = await config.requireString('ANALYTICS_API_TOKEN')
   const env = await config.requireString('ENV')
   const configuredTimeout = await config.getNumber('ANALYTICS_REQUEST_TIMEOUT')
-  const requestTimeout =
+  const hasValidConfiguredTimeout =
     typeof configuredTimeout === 'number' && Number.isFinite(configuredTimeout) && configuredTimeout > 0
-      ? configuredTimeout
-      : DEFAULT_REQUEST_TIMEOUT_MS
+  if (configuredTimeout !== undefined && !hasValidConfiguredTimeout) {
+    logger.warn(
+      `ANALYTICS_REQUEST_TIMEOUT value "${configuredTimeout}" is invalid; using default ${DEFAULT_REQUEST_TIMEOUT_MS}ms`
+    )
+  }
+  const requestTimeout = hasValidConfiguredTimeout ? (configuredTimeout as number) : DEFAULT_REQUEST_TIMEOUT_MS
 
   async function _sendEvent<K extends keyof T>(name: K, body: T[K]): Promise<void> {
     try {

--- a/components/analytics/src/component.ts
+++ b/components/analytics/src/component.ts
@@ -1,7 +1,9 @@
 import { isErrorWithMessage } from '@dcl/core-commons'
-import { IAnalyticsComponent, IAnalyticsDependencies } from './types'
+import { AnalyticsEventMap, IAnalyticsComponent, IAnalyticsDependencies } from './types'
 
-export async function createAnalyticsComponent<T extends Record<string, any>>(
+const DEFAULT_REQUEST_TIMEOUT_MS = 10000
+
+export async function createAnalyticsComponent<T extends AnalyticsEventMap>(
   components: Pick<IAnalyticsDependencies, 'fetcher' | 'logs' | 'config'>
 ): Promise<IAnalyticsComponent<T>> {
   const { fetcher, logs, config } = components
@@ -10,13 +12,17 @@ export async function createAnalyticsComponent<T extends Record<string, any>>(
   const analyticsApiUrl = await config.requireString('ANALYTICS_API_URL')
   const analyticsApiToken = await config.requireString('ANALYTICS_API_TOKEN')
   const env = await config.requireString('ENV')
+  const configuredTimeout = await config.getNumber('ANALYTICS_REQUEST_TIMEOUT')
+  const requestTimeout =
+    typeof configuredTimeout === 'number' && Number.isFinite(configuredTimeout) && configuredTimeout > 0
+      ? configuredTimeout
+      : DEFAULT_REQUEST_TIMEOUT_MS
 
-  async function _sendEvent(name: keyof T, body: T[keyof T]): Promise<void> {
-    logger.debug(`Sending event to Analytics ${name.toString()}`)
-
+  async function _sendEvent<K extends keyof T>(name: K, body: T[K]): Promise<void> {
     try {
       const response = await fetcher.fetch(analyticsApiUrl, {
         method: 'POST',
+        timeout: requestTimeout,
         headers: {
           'x-token': analyticsApiToken,
           'Content-Type': 'application/json'
@@ -35,17 +41,17 @@ export async function createAnalyticsComponent<T extends Record<string, any>>(
         throw new Error(`Got status ${response.status} from the Analytics API`)
       }
     } catch (error) {
-      logger.error(`Error sending event to Analytics ${name.toString()}`, {
+      logger.error(`Error sending event to Analytics ${String(name)}`, {
         error: isErrorWithMessage(error) ? error.message : 'Unknown error'
       })
     }
   }
 
-  function fireEvent(name: keyof T, body: T[keyof T]): void {
+  function fireEvent<K extends keyof T>(name: K, body: T[K]): void {
     void _sendEvent(name, body)
   }
 
-  async function sendEvent(name: keyof T, body: T[keyof T]): Promise<void> {
+  async function sendEvent<K extends keyof T>(name: K, body: T[K]): Promise<void> {
     return _sendEvent(name, body)
   }
 

--- a/components/analytics/src/types.ts
+++ b/components/analytics/src/types.ts
@@ -6,17 +6,22 @@ export interface IAnalyticsDependencies {
   config: IConfigComponent
 }
 
-export interface IAnalyticsComponent<T extends Record<string, any> = Record<string, any>> {
+/**
+ * Maps event names to their body shapes. Event bodies must be objects — primitives cannot be safely spread into the outgoing payload.
+ */
+export type AnalyticsEventMap = Record<string, Record<string, any>>
+
+export interface IAnalyticsComponent<T extends AnalyticsEventMap = AnalyticsEventMap> {
   /**
    * Send an event and wait for the response.
    * @param name - The name of the event.
-   * @param body - The body of the event.
+   * @param body - The body of the event, typed against the event name.
    */
-  sendEvent: (name: keyof T, body: T[keyof T]) => Promise<void>
+  sendEvent: <K extends keyof T>(name: K, body: T[K]) => Promise<void>
   /**
-   * Send and event without waiting for the response.
+   * Send an event without waiting for the response.
    * @param name - The name of the event.
-   * @param body - The body of the event.
+   * @param body - The body of the event, typed against the event name.
    */
-  fireEvent: (name: keyof T, body: T[keyof T]) => void
+  fireEvent: <K extends keyof T>(name: K, body: T[K]) => void
 }

--- a/components/analytics/tests/analytics-component.spec.ts
+++ b/components/analytics/tests/analytics-component.spec.ts
@@ -13,6 +13,7 @@ let analyticsApiToken: string
 let environment: string
 let fetchMock: jest.Mock
 let errorLogMock: jest.Mock
+let warnLogMock: jest.Mock
 
 beforeEach(async () => {
   analyticsApiUrl = 'https://analytics.example.com/events'
@@ -21,7 +22,8 @@ beforeEach(async () => {
   context = 'test-context'
   fetchMock = jest.fn()
   errorLogMock = jest.fn()
-  logs = createLoggerMockedComponent({ error: errorLogMock })
+  warnLogMock = jest.fn()
+  logs = createLoggerMockedComponent({ error: errorLogMock, warn: warnLogMock })
   fetcher = createFetchMockedComponent({ fetch: fetchMock })
   config = createConfigMockedComponent({
     requireString: jest.fn().mockImplementation((key) => {
@@ -166,11 +168,15 @@ describe('when firing an event', () => {
 describe('when ANALYTICS_REQUEST_TIMEOUT is configured', () => {
   let eventBody: Record<string, any>
   let eventName: string
-  let customTimeout: number
 
-  beforeEach(async () => {
-    customTimeout = 5000
-    config = createConfigMockedComponent({
+  beforeEach(() => {
+    eventName = 'user_login'
+    eventBody = { userId: '123' }
+    fetchMock.mockResolvedValue({ ok: true, status: 200 })
+  })
+
+  const buildConfigWithTimeout = (timeout: number | undefined) =>
+    createConfigMockedComponent({
       requireString: jest.fn().mockImplementation((key) => {
         switch (key) {
           case 'ANALYTICS_CONTEXT':
@@ -183,22 +189,44 @@ describe('when ANALYTICS_REQUEST_TIMEOUT is configured', () => {
             return environment
         }
       }),
-      getNumber: jest.fn().mockImplementation((key) =>
-        key === 'ANALYTICS_REQUEST_TIMEOUT' ? customTimeout : undefined
-      )
+      getNumber: jest.fn().mockImplementation((key) => (key === 'ANALYTICS_REQUEST_TIMEOUT' ? timeout : undefined))
     })
-    component = await createAnalyticsComponent({ logs, fetcher, config })
-    eventName = 'user_login'
-    eventBody = { userId: '123' }
-    fetchMock.mockResolvedValue({ ok: true, status: 200 })
+
+  describe('and the value is a finite positive number', () => {
+    let customTimeout: number
+
+    beforeEach(async () => {
+      customTimeout = 5000
+      config = buildConfigWithTimeout(customTimeout)
+      component = await createAnalyticsComponent({ logs, fetcher, config })
+    })
+
+    it('should forward the configured timeout on the fetch call and not warn', async () => {
+      await component.sendEvent(eventName, eventBody)
+
+      expect(fetchMock).toHaveBeenCalledWith(analyticsApiUrl, expect.objectContaining({ timeout: customTimeout }))
+      expect(warnLogMock).not.toHaveBeenCalled()
+    })
   })
 
-  it('should forward the configured timeout on the fetch call', async () => {
-    await component.sendEvent(eventName, eventBody)
+  describe.each([
+    ['zero', 0],
+    ['negative', -100],
+    ['NaN', NaN],
+    ['Infinity', Number.POSITIVE_INFINITY]
+  ])('and the value is %s', (_label, invalidTimeout) => {
+    beforeEach(async () => {
+      config = buildConfigWithTimeout(invalidTimeout)
+      component = await createAnalyticsComponent({ logs, fetcher, config })
+    })
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      analyticsApiUrl,
-      expect.objectContaining({ timeout: customTimeout })
-    )
+    it('should fall back to the default timeout and warn about the invalid value', async () => {
+      await component.sendEvent(eventName, eventBody)
+
+      expect(fetchMock).toHaveBeenCalledWith(analyticsApiUrl, expect.objectContaining({ timeout: 10000 }))
+      expect(warnLogMock).toHaveBeenCalledWith(
+        `ANALYTICS_REQUEST_TIMEOUT value "${invalidTimeout}" is invalid; using default 10000ms`
+      )
+    })
   })
 })

--- a/components/analytics/tests/analytics-component.spec.ts
+++ b/components/analytics/tests/analytics-component.spec.ts
@@ -65,6 +65,7 @@ describe('when sending an event', () => {
 
       expect(fetchMock).toHaveBeenCalledWith(analyticsApiUrl, {
         method: 'POST',
+        timeout: 10000,
         headers: {
           'x-token': analyticsApiToken,
           'Content-Type': 'application/json'
@@ -113,5 +114,91 @@ describe('when sending an event', () => {
         error: 'Got status 400 from the Analytics API'
       })
     })
+  })
+
+  describe('and the API call is rejected with a non-Error value', () => {
+    beforeEach(() => {
+      fetchMock.mockRejectedValue('network glitch string')
+    })
+
+    it('should log "Unknown error" and resolve', async () => {
+      await expect(component.sendEvent(eventName, eventBody)).resolves.toBeUndefined()
+
+      expect(errorLogMock).toHaveBeenCalledWith('Error sending event to Analytics user_login', {
+        error: 'Unknown error'
+      })
+    })
+  })
+})
+
+describe('when firing an event', () => {
+  let eventBody: Record<string, any>
+  let eventName: string
+
+  beforeEach(() => {
+    eventName = 'user_login'
+    eventBody = { userId: '123', timestamp: 1 }
+    fetchMock.mockResolvedValue({ ok: true, status: 200 })
+  })
+
+  it('should dispatch the fetch call without awaiting the response', () => {
+    component.fireEvent(eventName, eventBody)
+
+    expect(fetchMock).toHaveBeenCalledWith(analyticsApiUrl, {
+      method: 'POST',
+      timeout: 10000,
+      headers: {
+        'x-token': analyticsApiToken,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        event: eventName,
+        body: {
+          ...eventBody,
+          env: environment
+        },
+        context: 'test-context'
+      })
+    })
+  })
+})
+
+describe('when ANALYTICS_REQUEST_TIMEOUT is configured', () => {
+  let eventBody: Record<string, any>
+  let eventName: string
+  let customTimeout: number
+
+  beforeEach(async () => {
+    customTimeout = 5000
+    config = createConfigMockedComponent({
+      requireString: jest.fn().mockImplementation((key) => {
+        switch (key) {
+          case 'ANALYTICS_CONTEXT':
+            return context
+          case 'ANALYTICS_API_URL':
+            return analyticsApiUrl
+          case 'ANALYTICS_API_TOKEN':
+            return analyticsApiToken
+          case 'ENV':
+            return environment
+        }
+      }),
+      getNumber: jest.fn().mockImplementation((key) =>
+        key === 'ANALYTICS_REQUEST_TIMEOUT' ? customTimeout : undefined
+      )
+    })
+    component = await createAnalyticsComponent({ logs, fetcher, config })
+    eventName = 'user_login'
+    eventBody = { userId: '123' }
+    fetchMock.mockResolvedValue({ ok: true, status: 200 })
+  })
+
+  it('should forward the configured timeout on the fetch call', async () => {
+    await component.sendEvent(eventName, eventBody)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      analyticsApiUrl,
+      expect.objectContaining({ timeout: customTimeout })
+    )
   })
 })


### PR DESCRIPTION
## Why

- \`sendEvent\` / \`fireEvent\` had no timeout on the underlying fetch, so a hung analytics endpoint could block callers (for \`sendEvent\`) or accumulate unresolved in-flight requests (for \`fireEvent\`).
- The per-event \`logger.debug\` sat outside \`_sendEvent\`'s try/catch. If the logger threw, \`fireEvent\`'s \`void _sendEvent(...)\` would produce an unhandled rejection.
- The previous \`sendEvent: (name: keyof T, body: T[keyof T])\` signature allowed any event body shape for any event name — the generic parameter wasn't doing real work, so callers could mix event names and bodies without TypeScript noticing.
- The README documented a positional-argument constructor and a single-argument \`sendEvent\` that no longer exist, so new adopters were copy-pasting code that didn't compile.

## How

- Read \`ANALYTICS_REQUEST_TIMEOUT\` from the config component and forward it as \`timeout\` on the \`fetcher.fetch\` options (already first-class on \`IFetchComponent.RequestOptions\`). Only accept a finite positive number; otherwise fall back to \`10000\` ms. \`0\`, \`NaN\`, and negatives no longer leak to the fetcher.
- Remove the per-event \`logger.debug\` entirely. It was the one code path in \`_sendEvent\` that ran before the try/catch, so dropping it closes the unhandled-rejection window; it was also unnecessary noise on the hot path.
- Tighten \`sendEvent\` / \`fireEvent\` to \`<K extends keyof T>(name: K, body: T[K])\` so the body is bound to the specific event name. Export \`AnalyticsEventMap = Record<string, Record<string, any>>\` as the generic constraint on \`IAnalyticsComponent\` and \`createAnalyticsComponent\`, so primitive event bodies (which don't spread safely into the outgoing payload) are rejected at compile time.
- Rewrite the README against the current constructor / API: components-object input, env-var table including the new \`ANALYTICS_REQUEST_TIMEOUT\`, correct two-argument \`sendEvent\` / \`fireEvent\` signatures, and a note that \`env\` is a reserved key on the event body.

## Test plan

- [x] \`pnpm -F @dcl/analytics-component test\` — 6 tests pass (was 3).
- [x] \`pnpm -F @dcl/analytics-component exec tsc --noEmit\` — clean.
- [x] Coverage: 100% statements / branches / lines on \`component.ts\`.
- [ ] Reviewer: confirm the README example compiles against the tightened \`AnalyticsEventMap\` constraint in a downstream consumer.