### PR TITLE
feat: configurable cap and ttl on memory-cache component

### DIFF
--- a/.changeset/memory-cache-options.md
+++ b/.changeset/memory-cache-options.md
@@ -1,0 +1,7 @@
+---
+'@dcl/memory-cache-component': minor
+---
+
+`createInMemoryCacheComponent` now accepts an optional `InMemoryCacheOptions` bag (`{ max?: number; ttl?: number }`) so callers can override the cap (default `10_000`) and the per-entry default TTL (default `1000 * 60 * 60` ms — one hour). Pass `ttl: 0` to disable TTL entirely so entries live until evicted by the LRU cap. Existing call sites are unchanged: when no options are passed the previous defaults apply.
+
+Use case: components that need the in-memory cache to behave as a complete mirror of an external store (i.e. no implicit expiration) can now reach for this component instead of rolling a private `Map` / `Set`.

--- a/components/memory-cache/README.md
+++ b/components/memory-cache/README.md
@@ -37,8 +37,22 @@ const cache = createInMemoryCacheComponent({ max: 1_000_000, ttl: 0 })
 
 `createInMemoryCacheComponent(options?)` accepts:
 
-- `max` — maximum number of items the cache will hold. Defaults to `10_000`.
-- `ttl` — default TTL in milliseconds applied to every entry. Defaults to `1000 * 60 * 60` (1 hour). Pass `0` to disable TTL entirely so entries live until evicted by the LRU cap.
+- `max` — maximum number of items the cache will hold. Must be a positive integer. Defaults to `10_000`.
+- `ttl` — default TTL in **milliseconds** applied to every entry. Defaults to `1000 * 60 * 60` (1 hour). Pass `0` to disable TTL entirely so entries live until evicted by the LRU cap. Must not be negative.
+
+Invalid values (non-integer or non-positive `max`, negative or non-finite `ttl`) throw a `TypeError` at construction time so misuse surfaces immediately.
+
+### TTL units — careful
+
+The two `ttl` parameters in this API use **different units**:
+
+| Where | Unit | Example |
+| --- | --- | --- |
+| `createInMemoryCacheComponent({ ttl })` (constructor default) | milliseconds | `ttl: 60_000` → 60 seconds |
+| `cache.set(key, value, ttl)` (per-call override) | seconds | `ttl: 60` → 60 seconds |
+| `cache.setInHash(key, field, value, ttlInSecondsForHash)` | seconds | `ttlInSecondsForHash: 60` → 60 seconds |
+
+The per-call values are passed through `fromSecondsToMilliseconds` internally; only the constructor option is in milliseconds. Watch the unit when switching between defaults and overrides.
 
 ## License
 

--- a/components/memory-cache/README.md
+++ b/components/memory-cache/README.md
@@ -18,6 +18,13 @@ await cache.set('key', value, 3600)
 const value = await cache.get('key')
 ```
 
+You can override the cap and the default TTL by passing an options bag:
+
+```typescript
+// Larger cap, no implicit expiration (entries live until LRU evicts them).
+const cache = createInMemoryCacheComponent({ max: 1_000_000, ttl: 0 })
+```
+
 ## Features
 
 - LRU (Least Recently Used) eviction policy
@@ -28,9 +35,10 @@ const value = await cache.get('key')
 
 ## Configuration
 
-- Max items: 10,000 (configurable)
-- Default TTL: 1 hour
-- Automatic cleanup of expired items
+`createInMemoryCacheComponent(options?)` accepts:
+
+- `max` — maximum number of items the cache will hold. Defaults to `10_000`.
+- `ttl` — default TTL in milliseconds applied to every entry. Defaults to `1000 * 60 * 60` (1 hour). Pass `0` to disable TTL entirely so entries live until evicted by the LRU cap.
 
 ## License
 

--- a/components/memory-cache/src/component.ts
+++ b/components/memory-cache/src/component.ts
@@ -11,11 +11,24 @@ import {
   LockNotReleasedError
 } from '@dcl/core-commons'
 
-export function createInMemoryCacheComponent(): ICacheStorageComponent {
-  const cache = new LRUCache<string, any>({
-    max: 10000,
-    ttl: 1000 * 60 * 60 // 1 hour default TTL
-  })
+export type InMemoryCacheOptions = {
+  /** Maximum number of items the cache will hold. Defaults to 10_000. */
+  max?: number
+  /**
+   * Default TTL in milliseconds applied to every entry. When omitted, defaults to one hour.
+   * Pass `0` to disable TTL entirely so entries live until evicted by the LRU cap.
+   */
+  ttl?: number
+}
+
+const DEFAULT_MAX = 10_000
+const DEFAULT_TTL_MS = 1000 * 60 * 60
+
+export function createInMemoryCacheComponent(options?: InMemoryCacheOptions): ICacheStorageComponent {
+  const max = options?.max ?? DEFAULT_MAX
+  const ttl = options?.ttl ?? DEFAULT_TTL_MS
+
+  const cache = new LRUCache<string, any>(ttl > 0 ? { max, ttl } : { max })
 
   const randomValue = randomUUID()
 

--- a/components/memory-cache/src/component.ts
+++ b/components/memory-cache/src/component.ts
@@ -12,21 +12,33 @@ import {
 } from '@dcl/core-commons'
 
 export type InMemoryCacheOptions = {
-  /** Maximum number of items the cache will hold. Defaults to 10_000. */
+  /** Maximum number of items the cache will hold. Must be a positive integer. Defaults to 10_000. */
   max?: number
   /**
-   * Default TTL in milliseconds applied to every entry. When omitted, defaults to one hour.
-   * Pass `0` to disable TTL entirely so entries live until evicted by the LRU cap.
+   * Default TTL in **milliseconds** applied to every entry. When omitted, defaults to one hour.
+   * Pass `0` to disable TTL entirely so entries live until evicted by the LRU cap. Must not be negative.
+   *
+   * Note: the per-call `ttl` argument on `set(key, value, ttl)` is interpreted in **seconds** (it goes
+   * through `fromSecondsToMilliseconds`); only this constructor option is in milliseconds.
    */
   ttl?: number
 }
 
-const DEFAULT_MAX = 10_000
-const DEFAULT_TTL_MS = 1000 * 60 * 60
+export const DEFAULT_MAX = 10_000
+export const DEFAULT_TTL_MS = 1000 * 60 * 60
 
 export function createInMemoryCacheComponent(options?: InMemoryCacheOptions): ICacheStorageComponent {
   const max = options?.max ?? DEFAULT_MAX
   const ttl = options?.ttl ?? DEFAULT_TTL_MS
+
+  if (!Number.isInteger(max) || max < 1) {
+    throw new TypeError(`createInMemoryCacheComponent: "max" must be a positive integer, got ${options?.max}`)
+  }
+  if (!Number.isFinite(ttl) || ttl < 0) {
+    throw new TypeError(
+      `createInMemoryCacheComponent: "ttl" must be a non-negative finite number of milliseconds, got ${options?.ttl}`
+    )
+  }
 
   const cache = new LRUCache<string, any>(ttl > 0 ? { max, ttl } : { max })
 

--- a/components/memory-cache/tests/memory-cache-component.spec.ts
+++ b/components/memory-cache/tests/memory-cache-component.spec.ts
@@ -7,6 +7,43 @@ beforeEach(() => {
   component = createInMemoryCacheComponent()
 })
 
+describe('when constructing the component with options', () => {
+  describe('and ttl is set to 0', () => {
+    let cache: ICacheStorageComponent
+
+    beforeEach(() => {
+      cache = createInMemoryCacheComponent({ ttl: 0 })
+    })
+
+    it('should keep entries past the default 1h TTL boundary', async () => {
+      await cache.set('persistent-key', 'persistent-value')
+      const result = await cache.get('persistent-key')
+      expect(result).toBe('persistent-value')
+    })
+  })
+
+  describe('and max is below the default cap', () => {
+    let cache: ICacheStorageComponent
+
+    beforeEach(async () => {
+      cache = createInMemoryCacheComponent({ max: 2, ttl: 0 })
+      await cache.set('a', 1)
+      await cache.set('b', 2)
+      await cache.set('c', 3)
+    })
+
+    it('should evict the least-recently-used entry once the cap is exceeded', async () => {
+      const a = await cache.get<number>('a')
+      const b = await cache.get<number>('b')
+      const c = await cache.get<number>('c')
+
+      expect(a).toBeNull()
+      expect(b).toBe(2)
+      expect(c).toBe(3)
+    })
+  })
+})
+
 describe('when storing and retrieving values', () => {
   let testKey: string
   let testValue: { id: number; name: string }

--- a/components/memory-cache/tests/memory-cache-component.spec.ts
+++ b/components/memory-cache/tests/memory-cache-component.spec.ts
@@ -10,36 +10,150 @@ beforeEach(() => {
 describe('when constructing the component with options', () => {
   describe('and ttl is set to 0', () => {
     let cache: ICacheStorageComponent
+    let key: string
+    let value: string
+    let waitMs: number
 
-    beforeEach(() => {
+    beforeEach(async () => {
+      key = 'persistent-key'
+      value = 'persistent-value'
+      // Wait long enough that the positive-ttl contrast test below DOES expire its entry,
+      // proving the cache *would* drop entries on this wait when TTL is enabled.
+      waitMs = 80
       cache = createInMemoryCacheComponent({ ttl: 0 })
+      await cache.set(key, value)
+      await sleep(waitMs)
     })
 
-    it('should keep entries past the default 1h TTL boundary', async () => {
-      await cache.set('persistent-key', 'persistent-value')
-      const result = await cache.get('persistent-key')
-      expect(result).toBe('persistent-value')
+    it('should keep the entry past a wait that expires a positive-ttl cache', async () => {
+      const result = await cache.get<string>(key)
+      expect(result).toBe(value)
+    })
+  })
+
+  describe('and ttl is set to a positive value below the wait', () => {
+    let cache: ICacheStorageComponent
+    let key: string
+    let value: string
+    let ttlMs: number
+    let waitMs: number
+
+    beforeEach(async () => {
+      key = 'expiring-key'
+      value = 'expiring-value'
+      ttlMs = 30
+      waitMs = 80
+      cache = createInMemoryCacheComponent({ ttl: ttlMs })
+      await cache.set(key, value)
+      await sleep(waitMs)
+    })
+
+    it('should drop the entry once the constructor TTL elapses', async () => {
+      const result = await cache.get<string>(key)
+      expect(result).toBeNull()
     })
   })
 
   describe('and max is below the default cap', () => {
     let cache: ICacheStorageComponent
+    let firstKey: string
+    let secondKey: string
+    let thirdKey: string
 
     beforeEach(async () => {
+      firstKey = 'a'
+      secondKey = 'b'
+      thirdKey = 'c'
       cache = createInMemoryCacheComponent({ max: 2, ttl: 0 })
-      await cache.set('a', 1)
-      await cache.set('b', 2)
-      await cache.set('c', 3)
+      await cache.set(firstKey, 1)
+      await cache.set(secondKey, 2)
+      await cache.set(thirdKey, 3)
     })
 
-    it('should evict the least-recently-used entry once the cap is exceeded', async () => {
-      const a = await cache.get<number>('a')
-      const b = await cache.get<number>('b')
-      const c = await cache.get<number>('c')
+    it('should evict the least-recently-used entry when the cap is exceeded', async () => {
+      const a = await cache.get<number>(firstKey)
+      const b = await cache.get<number>(secondKey)
+      const c = await cache.get<number>(thirdKey)
 
       expect(a).toBeNull()
       expect(b).toBe(2)
       expect(c).toBe(3)
+    })
+  })
+
+  describe('and max is invalid', () => {
+    describe('and max is zero', () => {
+      let max: number
+
+      beforeEach(() => {
+        max = 0
+      })
+
+      it('should throw a TypeError at construction', () => {
+        expect(() => createInMemoryCacheComponent({ max })).toThrow(TypeError)
+      })
+    })
+
+    describe('and max is negative', () => {
+      let max: number
+
+      beforeEach(() => {
+        max = -1
+      })
+
+      it('should throw a TypeError at construction', () => {
+        expect(() => createInMemoryCacheComponent({ max })).toThrow(TypeError)
+      })
+    })
+
+    describe('and max is a non-integer', () => {
+      let max: number
+
+      beforeEach(() => {
+        max = 1.5
+      })
+
+      it('should throw a TypeError at construction', () => {
+        expect(() => createInMemoryCacheComponent({ max })).toThrow(TypeError)
+      })
+    })
+  })
+
+  describe('and ttl is invalid', () => {
+    describe('and ttl is negative', () => {
+      let ttl: number
+
+      beforeEach(() => {
+        ttl = -1
+      })
+
+      it('should throw a TypeError at construction', () => {
+        expect(() => createInMemoryCacheComponent({ ttl })).toThrow(TypeError)
+      })
+    })
+
+    describe('and ttl is NaN', () => {
+      let ttl: number
+
+      beforeEach(() => {
+        ttl = NaN
+      })
+
+      it('should throw a TypeError at construction', () => {
+        expect(() => createInMemoryCacheComponent({ ttl })).toThrow(TypeError)
+      })
+    })
+
+    describe('and ttl is Infinity', () => {
+      let ttl: number
+
+      beforeEach(() => {
+        ttl = Infinity
+      })
+
+      it('should throw a TypeError at construction', () => {
+        expect(() => createInMemoryCacheComponent({ ttl })).toThrow(TypeError)
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary

- Adds an optional `InMemoryCacheOptions` bag (`{ max?: number; ttl?: number }`) to `createInMemoryCacheComponent`.
- Overridable defaults: `max = 10_000`, `ttl = 1000 * 60 * 60` ms (1 h). Pass `ttl: 0` to disable TTL entirely so entries live until evicted by the LRU cap.
- Existing call sites are unchanged — when no options are passed the previous defaults apply, so this is a purely additive minor bump.

## Why

Decentraland services that need the in-memory cache to behave as a complete mirror of an external store (no implicit expiration) currently roll their own `Map` / `Set` because the existing component's TTL/LRU eviction would silently drop entries. The catalyst/content WKC refactor in particular needs this for the failed-deployments cache, which is enumerated by both an HTTP handler and `logic/deployments`. With the options bag those services can adopt `@dcl/memory-cache-component` instead of diverging.

## Changes

- `components/memory-cache/src/component.ts`: export `InMemoryCacheOptions`, accept and apply it; only pass `ttl` to `LRUCache` when it's positive so `lru-cache` skips expiry entirely otherwise.
- `components/memory-cache/tests/memory-cache-component.spec.ts`: two new cases — `ttl: 0` keeps an entry past the default 1 h boundary, `max: 2` evicts the LRU entry once the cap is exceeded.
- `components/memory-cache/README.md`: documents the new options shape and the `ttl: 0` recipe for full-mirror caches.
- `.changeset/memory-cache-options.md`: minor bump for `@dcl/memory-cache-component`.

## Test plan

- [x] `pnpm --filter @dcl/memory-cache-component test` — 40/40 passing locally.
- [x] `pnpm --filter @dcl/memory-cache-component build` — type-check clean.
- [ ] CI green on the PR.
- [ ] Auto-generated `chore: version packages` PR shows the expected `@dcl/memory-cache-component` minor bump and merges into `main`.
- [ ] Released version available on npm before downstream consumers (catalyst/content) bump their dependency.