### PR TITLE
ci: switch npm publishing to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,11 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Required so the runner can mint an OIDC token; pnpm exchanges it
+      # with the npm registry for a short-lived publish credential (Trusted
+      # Publishing). Replaces the long-lived NPM_TOKEN secret that used to
+      # be written into ~/.npmrc.
+      id-token: write
     runs-on: ubuntu-latest
     # Prevents multiple jobs from running at the same time
     concurrency:
@@ -38,14 +43,6 @@ jobs:
       - name: Build packages
         run: pnpm build
 
-      - name: Creating .npmrc
-        run: |
-          cat << EOF > "$HOME/.npmrc"
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          EOF
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1
@@ -55,5 +52,4 @@ jobs:
           publish: pnpm ci:publish
           commitMode: 'github-api'
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Monorepo for core components",
   "scripts": {
     "build": "pnpm -r build",
-    "ci:publish": "pnpm publish -r --access=public",
+    "ci:publish": "pnpm publish -r --access=public --provenance",
     "dev": "pnpm -r dev",
     "test": "pnpm -r test",
     "lint": "pnpm -r lint",
@@ -28,5 +28,5 @@
     "node": ">=18.0.0",
     "pnpm": ">=8.0.0"
   },
-  "packageManager": "pnpm@10.12.3"
+  "packageManager": "pnpm@10.30.3"
 }


### PR DESCRIPTION
## Summary
Replaces the long-lived `NPM_TOKEN` secret + manual `~/.npmrc` setup with GitHub OIDC. The runner mints a short-lived OIDC token, pnpm exchanges it with the npm registry for a publish credential, and provenance attestations are generated automatically.

## Why
The most recent publish run failed with `404 Not Found - PUT https://registry.npmjs.org/@dcl%2fcore-commons` — the underlying cause was an `NPM_TOKEN` that no longer has publish rights on the `@dcl` scope (expired, revoked, or downgraded). Trusted Publishing eliminates that whole class of credential-rotation failure: there's no secret to expire because there is no secret.

## Changes
- **`.github/workflows/publish.yml`**: add `id-token: write` permission so the runner can request the OIDC token; drop the "Creating .npmrc" step and the `NPM_TOKEN` env var from the changesets action.
- **`package.json`**: bump `packageManager` from `pnpm@10.12.3` to `10.30.3` (pnpm 10.20+ added Trusted Publishing support; 10.30.x is the current 10.x stable). Add `--provenance` to `ci:publish` so every published package carries an npm supply-chain attestation.

## Required ops step before this merges
Trusted Publishing requires per-package configuration on npmjs.com. **An org owner must do this for each `@dcl/*` package this repo publishes** before the next publish run succeeds. For each package:

1. Go to `npmjs.com → Package → Settings → Trusted Publishers → Add a Trusted Publisher`.
2. Pick **GitHub Actions**.
3. Fill in:
   - Organization or user: `decentraland`
   - Repository: `core-components`
   - Workflow file: `.github/workflows/publish.yml`
   - Environment: _(leave empty)_

Packages this repo publishes (today): `@dcl/core-commons`, `@dcl/redis-component`, `@dcl/memory-cache-component`, `@dcl/sqs-component`, `@dcl/queue-consumer-component`, `@dcl/pg-component`, `@dcl/s3-component`, `@dcl/sns-component`, `@dcl/slack-component`, `@dcl/traced-fetch-component`, `@dcl/analytics-component`, `@dcl/http-server-component`, `@dcl/schema-validator-component`, `@dcl/job-component`, `@dcl/metrics-component`, `@dcl/block-indexer-component`. (Adjust as needed — anything currently with prior versions on npm needs the Trusted Publisher link added.)

Once the Trusted Publisher entries exist, the very next push to `main` (with a Release PR merged) publishes via OIDC without any token.

## Cleanup after this lands
The `NPM_TOKEN` repo secret can be deleted (`Settings → Secrets and variables → Actions`). It's no longer referenced anywhere in CI.

## Versioning impact
None — this is purely a CI change. No new changeset needed; the next versions will publish with provenance attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)