### PR TITLE
chore: install npm >= 11.5.1 for Trusted Publishing support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,14 @@ jobs:
           node-version: 20
           cache: 'pnpm'
 
+      # Node 20 ships with npm 10.x; Trusted Publishing landed in npm 11.5.1.
+      # pnpm publish shells through npm under the hood, so the npm CLI on the
+      # runner is what needs to support the OIDC exchange. Pin to a known-good
+      # version that has trusted publishing rather than tracking @latest, so a
+      # future npm release can't break this workflow without us noticing.
+      - name: Install npm with Trusted Publishing support
+        run: npm install -g npm@^11.5.1
+
       - name: Get pnpm store directory
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
Replaces [#93](https://github.com/decentraland/core-components/pull/93) — same change, renamed to satisfy ADR-6 (`chore:` prefix + `chore/trusted-publishers` branch instead of `ci:`).

Follow-up to [#92](https://github.com/decentraland/core-components/pull/92). The first OIDC publish run failed with:

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

even though changesets-action correctly detected the OIDC token (`No NPM_TOKEN found, but OIDC is available - using npm trusted publishing`) and `pnpm@10.30.3` is in use.

## Root cause
Node 20 (set in the workflow) ships with **npm 10.x**, but Trusted Publishing was added in **npm 11.5.1**. `pnpm publish` shells through `npm` for the actual upload, so the npm CLI on the runner — not pnpm — is what needs to handle the OIDC exchange. With npm 10.x, the CLI looks for a token, finds none, and bails with ENEEDAUTH before any OIDC negotiation can happen.

## Fix
Add a step right after `actions/setup-node@v4` that installs `npm@^11.5.1` globally so the workflow always runs a Trusted-Publishing-capable npm regardless of which version ships with the chosen Node major.

```yaml
- name: Install npm with Trusted Publishing support
  run: npm install -g npm@^11.5.1
```

Pinned to `^11.5.1` rather than `@latest` so a future npm release can't quietly break this auth path without an explicit bump here.

## The Trusted Publisher npm-side config
Still required, same as called out in #92's body: each `@dcl/*` package needs a Trusted Publisher entry on `npmjs.com → Package → Settings → Trusted Publishers` pointing at:
- Organization: `decentraland`
- Repository: `core-components`
- Workflow file: `.github/workflows/publish.yml`
- Environment: _(empty)_

Without that, the OIDC exchange will succeed on our side but the registry will reject the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)