### PR TITLE
fix: add repository field to all published packages

### DIFF
--- a/.changeset/solid-houses-do.md
+++ b/.changeset/solid-houses-do.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release needed. Adds the `repository` field required by npm Trusted Publishing's provenance validation to all publishable packages. Pure package.json metadata; no source, dist, or behavior change.

--- a/components/analytics/package.json
+++ b/components/analytics/package.json
@@ -2,6 +2,11 @@
   "name": "@dcl/analytics-component",
   "version": "1.0.1",
   "description": "Analytics component for core components library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/analytics"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [

--- a/components/block-indexer/package.json
+++ b/components/block-indexer/package.json
@@ -2,6 +2,11 @@
   "name": "@dcl/block-indexer",
   "version": "1.2.0",
   "description": "On-chain block indexer component — finds the block at the tip of the blockchain at a given timestamp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/block-indexer"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [

--- a/components/http-server/package.json
+++ b/components/http-server/package.json
@@ -2,6 +2,11 @@
   "name": "@dcl/http-server",
   "version": "1.0.1",
   "description": "http server component",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/http-server"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/components/job/package.json
+++ b/components/job/package.json
@@ -2,6 +2,11 @@
   "name": "@dcl/job-component",
   "version": "0.3.2",
   "description": "Job component for core components library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/job"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [

--- a/components/memory-cache/package.json
+++ b/components/memory-cache/package.json
@@ -2,6 +2,11 @@
   "name": "@dcl/memory-cache-component",
   "version": "2.4.0",
   "description": "In-memory cache component for core components library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/memory-cache"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [

--- a/components/memory-queue/package.json
+++ b/components/memory-queue/package.json
@@ -2,6 +2,11 @@
   "name": "@dcl/memory-queue-component",
   "version": "2.1.1",
   "description": "In-memory queue component for local development and testing",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/memory-queue"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [

--- a/components/metrics/package.json
+++ b/components/metrics/package.json
@@ -2,6 +2,11 @@
   "name": "@dcl/metrics",
   "version": "1.0.1",
   "description": "metrics component",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/metrics"
+  },
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [

--- a/components/pg/package.json
+++ b/components/pg/package.json
@@ -2,6 +2,11 @@
   "name": "@dcl/pg-component",
   "version": "0.2.0",
   "description": "PG component for core components library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/pg"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [

--- a/components/queue-consumer/package.json
+++ b/components/queue-consumer/package.json
@@ -2,6 +2,11 @@
   "name": "@dcl/queue-consumer-component",
   "version": "3.0.1",
   "description": "Queue consumer component for core components library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/queue-consumer"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [

--- a/components/redis/package.json
+++ b/components/redis/package.json
@@ -2,6 +2,11 @@
   "name": "@dcl/redis-component",
   "version": "3.1.0",
   "description": "Redis cache component for core components library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/redis"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [

--- a/components/s3/package.json
+++ b/components/s3/package.json
@@ -2,6 +2,11 @@
   "name": "@dcl/s3-component",
   "version": "2.1.1",
   "description": "AWS S3 component for core components library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/s3"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [

--- a/components/schema-validator/package.json
+++ b/components/schema-validator/package.json
@@ -2,6 +2,11 @@
   "name": "@dcl/schema-validator-component",
   "version": "0.3.2",
   "description": "Schema validator component for core components library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/schema-validator"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [

--- a/components/slack/package.json
+++ b/components/slack/package.json
@@ -2,6 +2,11 @@
   "name": "@dcl/slack-component",
   "version": "1.0.8",
   "description": "Slack component for core components library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/slack"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [

--- a/components/sns/package.json
+++ b/components/sns/package.json
@@ -2,6 +2,11 @@
   "name": "@dcl/sns-component",
   "version": "3.1.2",
   "description": "AWS SNS component for core components library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/sns"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [

--- a/components/sqs/package.json
+++ b/components/sqs/package.json
@@ -2,6 +2,11 @@
   "name": "@dcl/sqs-component",
   "version": "2.2.1",
   "description": "AWS SQS component for core components library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/sqs"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [

--- a/components/traced-fetch/package.json
+++ b/components/traced-fetch/package.json
@@ -2,6 +2,11 @@
   "name": "@dcl/traced-fetch-component",
   "version": "1.0.4",
   "description": "Traced fetch component for core components library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/traced-fetch"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [

--- a/shared/commons/package.json
+++ b/shared/commons/package.json
@@ -2,6 +2,11 @@
   "name": "@dcl/core-commons",
   "version": "0.8.0",
   "description": "Shared utilities and types for core components",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "shared/commons"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
## Summary

Follow-up to #92 / #94. After enabling npm Trusted Publishing, the first publish run signed provenance successfully but the registry then rejected the upload with:

```
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@dcl%2fcore-commons
  Error verifying sigstore provenance bundle: Failed to validate repository information:
  package.json: "repository.url" is "", expected to match
  "https://github.com/decentraland/core-components" from provenance
```

Trusted Publishing requires `package.json` to declare a `repository.url` matching the GitHub repo recorded in the OIDC provenance attestation. None of our packages had one.

This PR adds the same `repository` block to all 17 publishable packages:

```json
"repository": {
  "type": "git",
  "url": "https://github.com/decentraland/core-components",
  "directory": "<package's path in the monorepo>"
}
```

## Why this is the right URL

GitHub's OIDC token records the source repo as `https://github.com/<owner>/<repo>` (no `.git` suffix, no fragment). The error message above quotes the exact expected string, and that's what every package now declares. The per-package `directory` field is npm convention for monorepo packages so `npm view <pkg> repository` resolves to the actual sub-path.

## Test plan

- [ ] Once merged, the existing pending publish for `@dcl/core-commons@0.8.0` (and any other version-bumped packages) should succeed
- [ ] `npm view @dcl/core-commons repository.url` returns the expected URL after publish