### PR TITLE
fix: restore GitHub Releases by routing publish through changeset publish

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "origin/main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/.changeset/heavy-snakes-work.md
+++ b/.changeset/heavy-snakes-work.md
@@ -1,4 +1,0 @@
----
----
-
-No release needed. Switches `ci:publish` to `changeset publish` so the publish step emits the JSON `changesets/action` consumes — without it, GitHub Releases are never created even when npm publishes succeed. Also moves `--access=public` into `.changeset/config.json` and `--provenance` into the `NPM_CONFIG_PROVENANCE` env var, since `changeset publish` doesn't accept those as flags.

--- a/.changeset/heavy-snakes-work.md
+++ b/.changeset/heavy-snakes-work.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release needed. Switches `ci:publish` to `changeset publish` so the publish step emits the JSON `changesets/action` consumes — without it, GitHub Releases are never created even when npm publishes succeed. Also moves `--access=public` into `.changeset/config.json` and `--provenance` into the `NPM_CONFIG_PROVENANCE` env var, since `changeset publish` doesn't accept those as flags.

--- a/.changeset/solid-houses-do.md
+++ b/.changeset/solid-houses-do.md
@@ -1,4 +1,0 @@
----
----
-
-No release needed. Adds the `repository` field required by npm Trusted Publishing's provenance validation to all publishable packages. Pure package.json metadata; no source, dist, or behavior change.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,10 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        # Pinned to v6.0.8 by commit SHA. Tags on third-party actions are
+        # mutable; a SHA is not. Bump deliberately when reviewing a new
+        # release rather than tracking a floating tag.
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,10 @@ jobs:
           title: 'chore: version packages'
           commit: 'chore: version packages [skip ci]'
           publish: pnpm ci:publish
+          createGithubReleases: true
           commitMode: 'github-api'
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          # changeset publish shells through `npm publish`; this env flips on
+          # provenance the same way the previous `--provenance` flag did.
+          NPM_CONFIG_PROVENANCE: 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,10 @@ jobs:
 
       - name: Create Release Pull Request or Publish
         id: changesets
-        uses: changesets/action@v1
+        # Pinned to v1.8.0 by commit SHA. Tags on third-party actions are
+        # mutable; a SHA is not. Bump deliberately when reviewing a new
+        # release rather than tracking a floating tag.
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           title: 'chore: version packages'
           commit: 'chore: version packages [skip ci]'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        # Pinned to v6.0.8 by commit SHA. Tags on third-party actions are
+        # mutable; a SHA is not. Bump deliberately when reviewing a new
+        # release rather than tracking a floating tag.
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup node.js
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Monorepo for core components",
   "scripts": {
     "build": "pnpm -r build",
-    "ci:publish": "pnpm publish -r --access=public --provenance",
+    "ci:publish": "changeset publish",
     "dev": "pnpm -r dev",
     "test": "pnpm -r test",
     "lint": "pnpm -r lint",


### PR DESCRIPTION
## Summary

GitHub Releases haven't been created on merge even when the npm publish succeeds. Root cause: `changesets/action@v1` only emits GitHub Releases when its `publish` script outputs the JSON that `changeset publish` produces. Our `ci:publish` was running `pnpm publish -r --access=public --provenance` directly — which uploads to npm fine, but doesn't emit that JSON, so the action has no idea what was published and creates no Releases.

Restoring the standard `changeset publish` path while preserving the OIDC/provenance setup from #92/#94 requires three coordinated changes:

| File | Change | Why |
|---|---|---|
| `package.json` | `ci:publish` → `changeset publish` | Emits the JSON `changesets/action` consumes; also handles `workspace:*` dep rewriting in published tarballs |
| `.changeset/config.json` | `access: "restricted"` → `"public"` | `changeset publish` reads access from config, not a CLI flag. `@dcl/*` is scoped so without explicit `public` npm defaults to restricted |
| `.github/workflows/publish.yml` | `NPM_CONFIG_PROVENANCE: 'true'` env on the changesets step | `changeset publish` shells through `npm publish`; this env enables provenance the same way the previous `--provenance` flag did |

Also makes `createGithubReleases: true` explicit on the action call. The default is `true` when `publish` is set, but spelling it out makes the intent obvious from the workflow file alone.

## What this changes about the release flow

Before: `merge → workflow runs → pnpm publish -r ... → npm gets the package → no Release on GitHub`

After: `merge → workflow runs → changeset publish → npm gets the package (same as before, same OIDC flow, same provenance) → action parses the JSON output → GitHub Release entry per published package`

## Why this is safe to retry the previously-failed publishes

`@dcl/core-commons@0.8.0` (and any other pre-bumped packages) are still in `package.json` but never landed on npm (the earlier publish failed at E422 before #95 added the `repository` field). `changeset publish` compares each package's `package.json` version against the registry and publishes any that are ahead, so this PR's first run will retry those — same versions, no further bump needed. From that point onward, each future merge with a real changeset will produce both an npm publish and a matching GitHub Release.

## Test plan

- [ ] On merge to main: the publish workflow run logs show `changeset publish` (not `pnpm publish -r`)
- [ ] `@dcl/core-commons@0.8.0` (and any other pre-bumped packages) appear on npm with provenance attestation
- [ ] A new entry appears at https://github.com/decentraland/core-components/releases for each newly published package version