### PR TITLE
feat: move fetch-component into core-components

### DIFF
--- a/.changeset/consumers-use-shared-fetch.md
+++ b/.changeset/consumers-use-shared-fetch.md
@@ -1,0 +1,6 @@
+---
+"@dcl/traced-fetch-component": patch
+"@dcl/analytics-component": patch
+---
+
+use the shared `IFetchComponent` type from `@dcl/core-commons`. `@dcl/traced-fetch-component` now wraps `@dcl/fetch-component` instead of `@well-known-components/fetch-component`.

--- a/.changeset/fetch-component-initial.md
+++ b/.changeset/fetch-component-initial.md
@@ -1,0 +1,5 @@
+---
+"@dcl/fetch-component": major
+---
+
+initial release of `@dcl/fetch-component`, moved into core-components from `@well-known-components/fetch-component`. it now uses the default node `fetch` api instead of `cross-fetch` (dropping the browser `buffer` polyfill) and types the component through the shared `IFetchComponent` from `@dcl/core-commons`.

--- a/.changeset/shared-fetch-type.md
+++ b/.changeset/shared-fetch-type.md
@@ -1,0 +1,5 @@
+---
+"@dcl/core-commons": minor
+---
+
+add the shared `IFetchComponent` and `RequestOptions` types, backed by the default node `fetch` api, so server components share a single fetch type instead of importing it from `@well-known-components/interfaces`.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ core-components/
 ├── components/          # Reusable components
 │   ├── analytics/        # Analytics component for event tracking
 │   ├── block-indexer/    # On-chain block indexer component
+│   ├── fetch/            # Fetch component using the native Node fetch API
 │   ├── http-server/      # HTTP server component
 │   ├── job/              # Job scheduling and execution component
 │   ├── memory-cache/     # In-memory LRU cache component
@@ -67,6 +68,7 @@ core-components/
 
 - **Job Component** (`@dcl/job-component`) - Job scheduling and execution
 - **Schema Validator Component** (`@dcl/schema-validator-component`) - JSON schema validation middleware
+- **Fetch Component** (`@dcl/fetch-component`) - HTTP client with retries and timeouts on the native Node fetch API
 - **Traced Fetch Component** (`@dcl/traced-fetch-component`) - HTTP requests with distributed tracing
 - **Core Commons** (`@dcl/core-commons`) - Shared utilities, types, and constants
 
@@ -155,6 +157,7 @@ This project uses [Changesets](https://github.com/changesets/changesets) for aut
 - `@dcl/queue-consumer-component`
 - `@dcl/redis-component`
 - `@dcl/s3-component`
+- `@dcl/fetch-component`
 - `@dcl/schema-validator-component`
 - `@dcl/slack-component`
 - `@dcl/sns-component`

--- a/components/analytics/src/types.ts
+++ b/components/analytics/src/types.ts
@@ -1,4 +1,5 @@
-import { IConfigComponent, IFetchComponent, ILoggerComponent } from '@well-known-components/interfaces'
+import { IConfigComponent, ILoggerComponent } from '@well-known-components/interfaces'
+import { IFetchComponent } from '@dcl/core-commons'
 
 export interface IAnalyticsDependencies {
   logs: ILoggerComponent

--- a/components/analytics/tests/analytics-component.spec.ts
+++ b/components/analytics/tests/analytics-component.spec.ts
@@ -1,5 +1,10 @@
-import { ILoggerComponent, IFetchComponent, IConfigComponent } from '@well-known-components/interfaces'
-import { createFetchMockedComponent, createLoggerMockedComponent, createConfigMockedComponent } from '@dcl/core-commons'
+import { ILoggerComponent, IConfigComponent } from '@well-known-components/interfaces'
+import {
+  IFetchComponent,
+  createFetchMockedComponent,
+  createLoggerMockedComponent,
+  createConfigMockedComponent
+} from '@dcl/core-commons'
 import { createAnalyticsComponent } from '../src/component'
 import { IAnalyticsComponent } from '../src/types'
 

--- a/components/fetch/CHANGELOG.md
+++ b/components/fetch/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @dcl/fetch-component

--- a/components/fetch/README.md
+++ b/components/fetch/README.md
@@ -1,0 +1,54 @@
+# @dcl/fetch-component
+
+Fetch component for core components library. It wraps the default Node `fetch`
+API with retry, timeout and default-options support, and is meant to be used by
+servers running on the default Node runtime.
+
+## Installation
+
+```bash
+npm install @dcl/fetch-component
+```
+
+## Usage
+
+```typescript
+import { createFetchComponent } from '@dcl/fetch-component'
+
+const fetcher = createFetchComponent({
+  defaultHeaders: { 'X-Custom': 'value' }
+})
+
+const response = await fetcher.fetch('https://api.example.com/data', {
+  method: 'GET',
+  attempts: 3,
+  retryDelay: 100,
+  timeout: 5000
+})
+
+const data = await response.json()
+```
+
+## Features
+
+- Backed by the default Node `fetch` API (no `cross-fetch`/`node-fetch` dependency)
+- Automatic retries for idempotent requests (`GET`, `HEAD`, `OPTIONS`, `PUT`, `DELETE`)
+- Configurable retry delay and timeout per request
+- Default headers and default request options shared across calls
+- Type-safe through the shared `IFetchComponent` type from `@dcl/core-commons`
+
+## Request options
+
+In addition to the standard `RequestInit` options, `fetch` accepts:
+
+- `attempts` - number of attempts for idempotent requests before giving up
+- `retryDelay` - milliseconds to wait between retry attempts
+- `timeout` - milliseconds to wait before aborting the request
+- `abortController` - an `AbortController` used to abort the request
+
+Non-retryable status codes (`400`, `401`, `403`, `404`) and non-idempotent
+methods are never retried.
+
+## License
+
+Apache-2.0

--- a/components/fetch/jest.config.js
+++ b/components/fetch/jest.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>'],
+  testMatch: [
+    '**/tests/**/*.spec.ts',
+    '**/tests/**/*.test.ts',
+    '**/?(*.)+(spec|test).ts'
+  ],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/dist/'
+  ],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!**/*.d.ts',
+  ],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+}

--- a/components/fetch/package.json
+++ b/components/fetch/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@dcl/traced-fetch-component",
-  "version": "1.0.4",
-  "description": "Traced fetch component for core components library",
+  "name": "@dcl/fetch-component",
+  "version": "0.0.0",
+  "description": "Fetch component for core components library",
   "repository": {
     "type": "git",
     "url": "https://github.com/decentraland/core-components",
-    "directory": "components/traced-fetch"
+    "directory": "components/fetch"
   },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -20,9 +20,7 @@
     "lint": "echo \"No linting configured\""
   },
   "dependencies": {
-    "@dcl/core-commons": "workspace:*",
-    "@dcl/fetch-component": "workspace:*",
-    "@well-known-components/interfaces": "^1.5.2"
+    "@dcl/core-commons": "workspace:*"
   },
   "devDependencies": {
     "typescript": "^5.8.3"

--- a/components/fetch/src/fetcher.ts
+++ b/components/fetch/src/fetcher.ts
@@ -35,9 +35,11 @@ async function fetchWithRetriesAndTimeout(url: string | URL | Request, options: 
       --attempts
 
       response = await racePromise
-
-      if (timer) clearTimeout(timer)
     } finally {
+      // Clear the timeout timer on every exit (success, retryable failure or a
+      // rejected fetch) so a pending timer can't later abort a controller that
+      // is reused by the caller or by a subsequent retry.
+      if (timer) clearTimeout(timer)
       if (!!response && (response.ok || NON_RETRYABLE_STATUS_CODES.includes(response.status) || attempts === 0)) break
       else await new Promise((resolve) => setTimeout(resolve, retryDelay))
     }
@@ -52,11 +54,18 @@ async function fetchWithRetriesAndTimeout(url: string | URL | Request, options: 
  * @param defaultOptions - default headers and request options injected on every call performed by this component
  */
 export function createFetchComponent(defaultOptions?: FetcherOptions): IFetchComponent {
-  async function fetch(url: string | URL | Request, options?: RequestOptions): Promise<Response> {
+  async function wrappedFetch(url: string | URL | Request, options?: RequestOptions): Promise<Response> {
     // Parse options
     const optionsWithDefault = { ...defaultOptions?.defaultFetcherOptions, ...options }
-    const { timeout, method = 'GET', retryDelay = 0, abortController, ...fetchOptions } = optionsWithDefault
-    let attempts = fetchOptions.attempts || 1
+    const {
+      timeout,
+      method = 'GET',
+      retryDelay = 0,
+      abortController,
+      attempts: attemptsOption,
+      ...fetchOptions
+    } = optionsWithDefault
+    let attempts = attemptsOption ?? 1
     const controller = abortController || new AbortController()
     const { signal } = controller
 
@@ -88,5 +97,5 @@ export function createFetchComponent(defaultOptions?: FetcherOptions): IFetchCom
     return response
   }
 
-  return { fetch }
+  return { fetch: wrappedFetch }
 }

--- a/components/fetch/src/fetcher.ts
+++ b/components/fetch/src/fetcher.ts
@@ -1,0 +1,92 @@
+import { IFetchComponent, RequestOptions } from '@dcl/core-commons'
+import { FetcherOptions } from './types'
+
+const NON_RETRYABLE_STATUS_CODES = [400, 401, 403, 404]
+const IDEMPOTENT_HTTP_METHODS = ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE']
+
+async function fetchWithRetriesAndTimeout(url: string | URL | Request, options: RequestOptions): Promise<Response> {
+  const { timeout, abortController, signal: timeoutSignal, retryDelay } = options
+  let attempts = options.attempts!
+  let timer: NodeJS.Timeout | null = null
+  let response: Response | undefined = undefined
+
+  do {
+    try {
+      if (timeout) {
+        timer = setTimeout(() => {
+          abortController!.abort()
+        }, timeout)
+      }
+
+      const fetchPromise = fetch(url, {
+        ...options,
+        signal: timeoutSignal
+      })
+
+      const racePromise = Promise.race([
+        fetchPromise,
+        new Promise<Response>((resolve) => {
+          timeoutSignal!.addEventListener('abort', () => {
+            resolve(new Response('timeout', { status: 408, statusText: 'Request Timeout' }))
+          })
+        })
+      ])
+
+      --attempts
+
+      response = await racePromise
+
+      if (timer) clearTimeout(timer)
+    } finally {
+      if (!!response && (response.ok || NON_RETRYABLE_STATUS_CODES.includes(response.status) || attempts === 0)) break
+      else await new Promise((resolve) => setTimeout(resolve, retryDelay))
+    }
+  } while ((!response || !response.ok) && attempts > 0)
+
+  return response as Response
+}
+
+/**
+ * @public
+ * Creates a fetch component backed by the default Node `fetch` API.
+ * @param defaultOptions - default headers and request options injected on every call performed by this component
+ */
+export function createFetchComponent(defaultOptions?: FetcherOptions): IFetchComponent {
+  async function fetch(url: string | URL | Request, options?: RequestOptions): Promise<Response> {
+    // Parse options
+    const optionsWithDefault = { ...defaultOptions?.defaultFetcherOptions, ...options }
+    const { timeout, method = 'GET', retryDelay = 0, abortController, ...fetchOptions } = optionsWithDefault
+    let attempts = fetchOptions.attempts || 1
+    const controller = abortController || new AbortController()
+    const { signal } = controller
+
+    // Add default headers
+    if (defaultOptions?.defaultHeaders)
+      fetchOptions.headers = {
+        ...(defaultOptions.defaultHeaders as Record<string, string>),
+        ...((fetchOptions.headers as Record<string, string>) || {})
+      }
+
+    // Fix attempts in case of POST
+    if (!IDEMPOTENT_HTTP_METHODS.includes(method.toUpperCase())) attempts = 1
+
+    // Fetch with retries and timeout
+    const response = await fetchWithRetriesAndTimeout(url, {
+      ...fetchOptions,
+      attempts,
+      method,
+      timeout,
+      retryDelay,
+      signal,
+      abortController: controller
+    })
+
+    if (signal.aborted) {
+      throw new Error('Request aborted (timed out)')
+    }
+
+    return response
+  }
+
+  return { fetch }
+}

--- a/components/fetch/src/fetcher.ts
+++ b/components/fetch/src/fetcher.ts
@@ -5,8 +5,11 @@ const NON_RETRYABLE_STATUS_CODES = [400, 401, 403, 404]
 const IDEMPOTENT_HTTP_METHODS = ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE']
 
 async function fetchWithRetriesAndTimeout(url: string | URL | Request, options: RequestOptions): Promise<Response> {
-  const { timeout, abortController, signal: timeoutSignal, retryDelay } = options
-  let attempts = options.attempts!
+  // Split the component-specific controls (timeout, retries, abort controller) from
+  // the standard `RequestInit` keys that are forwarded as-is to the native fetch.
+  const { timeout, abortController, retryDelay, attempts: attemptsOption, ...fetchInit } = options
+  const timeoutSignal = fetchInit.signal
+  let attempts = attemptsOption!
   let timer: NodeJS.Timeout | null = null
   let response: Response | undefined = undefined
 
@@ -18,10 +21,7 @@ async function fetchWithRetriesAndTimeout(url: string | URL | Request, options: 
         }, timeout)
       }
 
-      const fetchPromise = fetch(url, {
-        ...options,
-        signal: timeoutSignal
-      })
+      const fetchPromise = fetch(url, fetchInit)
 
       const racePromise = Promise.race([
         fetchPromise,

--- a/components/fetch/src/index.ts
+++ b/components/fetch/src/index.ts
@@ -1,0 +1,2 @@
+export { createFetchComponent } from './fetcher'
+export type { FetcherOptions } from './types'

--- a/components/fetch/src/types.ts
+++ b/components/fetch/src/types.ts
@@ -1,0 +1,11 @@
+import { RequestOptions } from '@dcl/core-commons'
+
+/**
+ * Options used to configure a fetch component instance.
+ */
+export type FetcherOptions = {
+  /** Headers injected on every request performed by the component. */
+  defaultHeaders?: RequestInit['headers']
+  /** Default request options merged into every request performed by the component. */
+  defaultFetcherOptions?: RequestOptions
+}

--- a/components/fetch/tests/fetch.spec.ts
+++ b/components/fetch/tests/fetch.spec.ts
@@ -1,0 +1,250 @@
+import { IFetchComponent } from '@dcl/core-commons'
+import { createFetchComponent } from '../src/fetcher'
+
+describe('when fetching with the fetch component', () => {
+  let sut: IFetchComponent
+  let fetchMock: jest.Mock
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    fetchMock = jest.fn()
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+    sut = createFetchComponent()
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    jest.clearAllMocks()
+  })
+
+  describe('and the request succeeds', () => {
+    const expectedResponseBody = { mock: 'successful' }
+
+    beforeEach(() => {
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify(expectedResponseBody), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      )
+    })
+
+    it('should perform a single request and resolve the parsed body', async () => {
+      const response = await (await sut.fetch('https://example.com')).json()
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(response).toEqual(expectedResponseBody)
+    })
+  })
+
+  describe('and the first attempt fails with a retryable status', () => {
+    const expectedResponseBody = { mock: 'successful' }
+
+    beforeEach(() => {
+      fetchMock
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ error: 'error' }), {
+            status: 503,
+            headers: { 'Content-Type': 'application/json' }
+          })
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify(expectedResponseBody), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          })
+        )
+    })
+
+    it('should retry and resolve the successful response from the second attempt', async () => {
+      const response = await (await sut.fetch('https://example.com', { attempts: 3, retryDelay: 100 })).json()
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(response).toEqual(expectedResponseBody)
+    })
+  })
+
+  describe('and every attempt fails with a retryable status', () => {
+    beforeEach(() => {
+      fetchMock
+        .mockResolvedValueOnce(new Response('test error', { status: 502, headers: { 'Content-Type': 'text/plain' } }))
+        .mockResolvedValue(new Response('test error', { status: 503, headers: { 'Content-Type': 'text/plain' } }))
+    })
+
+    it('should exhaust the retries and resolve the latest response instead of throwing', async () => {
+      const response = await sut.fetch('https://example.com', { attempts: 3, retryDelay: 10 })
+
+      expect(response.status).toBe(503)
+      expect(await response.text()).toBe('test error')
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('and the request exceeds the configured timeout', () => {
+    let timer: NodeJS.Timeout | undefined
+
+    beforeEach(() => {
+      fetchMock.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            timer = setTimeout(
+              () => resolve(new Response('success', { status: 201, headers: { 'Content-Type': 'text/plain' } })),
+              3500
+            )
+          })
+      )
+    })
+
+    afterEach(() => {
+      if (timer) clearTimeout(timer)
+    })
+
+    it('should throw a timeout error', async () => {
+      await expect(sut.fetch('https://example.com', { timeout: 500 })).rejects.toThrow('Request aborted (timed out)')
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('and the request completes before the configured timeout', () => {
+    const expectedResponseBody = { mock: 'successful' }
+
+    beforeEach(() => {
+      fetchMock.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(
+              () =>
+                resolve(
+                  new Response(JSON.stringify(expectedResponseBody), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' }
+                  })
+                ),
+              50
+            )
+          })
+      )
+    })
+
+    it('should resolve the parsed body', async () => {
+      const response = await (await sut.fetch('https://example.com', { timeout: 3000 })).json()
+
+      expect(response).toEqual(expectedResponseBody)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('and default headers are configured', () => {
+    const defaultHeaders = { 'X-Custom': 'Test' }
+
+    beforeEach(() => {
+      sut = createFetchComponent({ defaultHeaders })
+      fetchMock.mockResolvedValue(new Response('test', { status: 200 }))
+    })
+
+    it('should send the default headers', async () => {
+      await sut.fetch('https://example.com')
+
+      expect(fetchMock.mock.calls[0][1].headers).toEqual(defaultHeaders)
+    })
+
+    describe('and the same header is passed on the call', () => {
+      const overwrittenHeader = { 'X-Custom': 'Override' }
+
+      it('should override the default header with the call header', async () => {
+        await sut.fetch('https://example.com', { headers: overwrittenHeader })
+
+        expect(fetchMock.mock.calls[0][1].headers).toEqual(overwrittenHeader)
+      })
+    })
+  })
+
+  describe('and default fetcher options are configured', () => {
+    const defaultBodyOption = JSON.stringify({ test: 'test' })
+
+    beforeEach(() => {
+      sut = createFetchComponent({ defaultFetcherOptions: { body: defaultBodyOption } })
+      fetchMock.mockResolvedValue(new Response('test', { status: 200 }))
+    })
+
+    it('should send the default fetcher options', async () => {
+      await sut.fetch('https://example.com')
+
+      expect(fetchMock.mock.calls[0][1].body).toEqual(defaultBodyOption)
+    })
+
+    describe('and the same option is passed on the call', () => {
+      const overwrittenBody = JSON.stringify({ overwritten: 'overwritten' })
+
+      it('should override the default option with the call option', async () => {
+        await sut.fetch('https://example.com', { body: overwrittenBody })
+
+        expect(fetchMock.mock.calls[0][1].body).toEqual(overwrittenBody)
+      })
+    })
+  })
+
+  describe('and the request uses a non-idempotent method', () => {
+    beforeEach(() => {
+      fetchMock
+        .mockResolvedValueOnce(new Response('test error', { status: 503, headers: { 'Content-Type': 'text/plain' } }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ mock: 'successful' }), { status: 200 }))
+    })
+
+    it('should not retry a POST request', async () => {
+      const response = await sut.fetch('https://example.com', { method: 'POST', attempts: 3, retryDelay: 10 })
+
+      expect(response.status).toBe(503)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('and the request fails with a non-retryable status', () => {
+    const nonRetryableStatuses = [400, 401, 403, 404]
+
+    nonRetryableStatuses.forEach((status) => {
+      describe(`and the status is ${status}`, () => {
+        beforeEach(() => {
+          fetchMock
+            .mockResolvedValueOnce(new Response('test error', { status, headers: { 'Content-Type': 'text/plain' } }))
+            .mockResolvedValueOnce(new Response(JSON.stringify({ mock: 'successful' }), { status: 200 }))
+        })
+
+        it(`should not retry and resolve the ${status} response`, async () => {
+          const response = await sut.fetch('https://example.com', { attempts: 3, retryDelay: 10 })
+
+          expect(response.status).toBe(status)
+          expect(fetchMock).toHaveBeenCalledTimes(1)
+        })
+      })
+    })
+  })
+
+  describe('and the request is aborted through the provided controller', () => {
+    let timer: NodeJS.Timeout | undefined
+
+    beforeEach(() => {
+      fetchMock.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            timer = setTimeout(() => resolve(new Response('success', { status: 201 })), 3000)
+          })
+      )
+    })
+
+    afterEach(() => {
+      if (timer) clearTimeout(timer)
+    })
+
+    it('should throw an aborted error', async () => {
+      const controller = new AbortController()
+      const fetchPromise = sut.fetch('https://example.com', { abortController: controller })
+
+      controller.abort()
+
+      await expect(fetchPromise).rejects.toThrow('Request aborted (timed out)')
+    })
+  })
+})

--- a/components/fetch/tests/fetch.spec.ts
+++ b/components/fetch/tests/fetch.spec.ts
@@ -247,4 +247,23 @@ describe('when fetching with the fetch component', () => {
       await expect(fetchPromise).rejects.toThrow('Request aborted (timed out)')
     })
   })
+
+  describe('and the fetch rejects while a timeout is configured', () => {
+    let controller: AbortController
+
+    beforeEach(() => {
+      controller = new AbortController()
+      fetchMock.mockRejectedValueOnce(new Error('network error'))
+    })
+
+    it('should clear the timeout so the provided controller is not aborted after the failure', async () => {
+      await expect(
+        sut.fetch('https://example.com', { timeout: 50, abortController: controller })
+      ).rejects.toThrow('network error')
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      expect(controller.signal.aborted).toBe(false)
+    })
+  })
 })

--- a/components/fetch/tsconfig.json
+++ b/components/fetch/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/components/http-server/package.json
+++ b/components/http-server/package.json
@@ -31,6 +31,7 @@
     "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {
+    "@dcl/core-commons": "workspace:*",
     "@types/busboy": "^1.5.4",
     "@types/destroy": "^1.0.0",
     "@types/jest": "^30.0.0",

--- a/components/http-server/test/test-e2e-harness.ts
+++ b/components/http-server/test/test-e2e-harness.ts
@@ -7,7 +7,7 @@ import { createMockedLifecycleComponent } from './mockedLifecycleComponent'
 import { TestComponents, TestComponentsWithStatus } from './test-helpers'
 import wsLib, { WebSocketServer } from 'ws'
 import * as undici from 'undici'
-import { IFetchComponent } from '@well-known-components/interfaces'
+import { IFetchComponent } from '@dcl/core-commons'
 
 let currentPort = 19000
 

--- a/components/http-server/test/test-e2e-test-server.ts
+++ b/components/http-server/test/test-e2e-test-server.ts
@@ -20,7 +20,9 @@ async function initComponents<C extends object>(): Promise<TestComponents> {
 
   const server = createTestServerComponent<C>()
 
-  const fetch = { ...server, isUndici: false }
+  // createTestServerComponent returns a node-fetch based component; bridge it to
+  // the shared (native) fetch type used by the test components.
+  const fetch = { ...server, isUndici: false } as unknown as TestComponents['fetch']
 
   const ws: IWebSocketComponent<wsLib.WebSocket> = {
     createWebSocket(url: string, protocols?: string | string[]) {

--- a/components/http-server/test/test-helpers.ts
+++ b/components/http-server/test/test-helpers.ts
@@ -1,11 +1,11 @@
 import {
   IBaseComponent,
   IConfigComponent,
-  IFetchComponent,
   IHttpServerComponent,
   ILoggerComponent,
   IStatusCheckCapableComponent
 } from '@well-known-components/interfaces'
+import { IFetchComponent } from '@dcl/core-commons'
 import { IWebSocketComponent } from '../src'
 import wsLib from 'ws'
 

--- a/components/metrics/package.json
+++ b/components/metrics/package.json
@@ -23,6 +23,7 @@
     "prom-client": "^15.1.0"
   },
   "devDependencies": {
+    "@dcl/core-commons": "workspace:*",
     "@dcl/http-server": "^1.0.0",
     "@types/node-fetch": "^2.6.12",
     "@well-known-components/env-config-provider": "^1.1.0",

--- a/components/metrics/test/harness/test-e2e-express-server.ts
+++ b/components/metrics/test/harness/test-e2e-express-server.ts
@@ -7,7 +7,7 @@ import { createMetricsComponent } from '../../src'
 import { metricDeclarations } from './defaultMetrics'
 import { mockedRouter } from './mockedServer'
 import { TestComponents } from './test-helpers'
-import { IFetchComponent } from '@well-known-components/interfaces'
+import { IFetchComponent } from '@dcl/core-commons'
 
 let currentPort = 19000
 
@@ -40,8 +40,10 @@ async function initComponents(): Promise<TestComponents> {
   const server = await createServerComponent<any>({ logs, config }, {})
 
   const fetch: IFetchComponent = {
+    // The metrics e2e harness exercises a real node-fetch runtime; its node-fetch
+    // Response is bridged to the shared (native) fetch type used by the components.
     async fetch(url, initRequest?) {
-      return nodeFetch(protocolHostAndProtocol + url, initRequest ? initRequest : {})
+      return nodeFetch(protocolHostAndProtocol + url, (initRequest ?? {}) as any) as unknown as Response
     }
   }
 

--- a/components/metrics/test/harness/test-e2e-test-server.ts
+++ b/components/metrics/test/harness/test-e2e-test-server.ts
@@ -9,7 +9,7 @@ import {
 } from '@dcl/http-server'
 import { createRunner } from '@well-known-components/test-helpers'
 import { mockedRouter } from './mockedServer'
-import { IFetchComponent } from '@well-known-components/interfaces'
+import { IFetchComponent } from '@dcl/core-commons'
 
 // creates a "jest-like" describe function to run tests using the test components
 export const describeTestE2E = createRunner({
@@ -29,7 +29,9 @@ async function initComponents(): Promise<TestComponents> {
 
   const server = createTestServerComponent<any>()
 
-  const fetch: IFetchComponent = server
+  // createTestServerComponent returns a node-fetch based component; bridge it to
+  // the shared (native) fetch type used by the components.
+  const fetch: IFetchComponent = server as unknown as IFetchComponent
   const metrics = await createMetricsComponent(metricDeclarations, { config })
   await instrumentHttpServerWithPromClientRegistry({ metrics, server, config, registry: metrics.registry! })
 

--- a/components/metrics/test/harness/test-helpers.ts
+++ b/components/metrics/test/harness/test-helpers.ts
@@ -2,9 +2,9 @@ import {
   IConfigComponent,
   IHttpServerComponent,
   ILoggerComponent,
-  IMetricsComponent,
-  IFetchComponent
+  IMetricsComponent
 } from "@well-known-components/interfaces"
+import { IFetchComponent } from "@dcl/core-commons"
 import { metricDeclarations } from "./defaultMetrics"
 
 export type TestComponents = {

--- a/components/traced-fetch/src/component.ts
+++ b/components/traced-fetch/src/component.ts
@@ -1,5 +1,6 @@
-import { createFetchComponent } from '@well-known-components/fetch-component'
-import type { IFetchComponent, ITracerComponent } from '@well-known-components/interfaces'
+import { createFetchComponent } from '@dcl/fetch-component'
+import type { IFetchComponent } from '@dcl/core-commons'
+import type { ITracerComponent } from '@well-known-components/interfaces'
 
 /**
  * Type guard to check if the headers object is a Headers-like object.

--- a/components/traced-fetch/tests/traced-component.spec.ts
+++ b/components/traced-fetch/tests/traced-component.spec.ts
@@ -1,9 +1,10 @@
-import { ITracerComponent, IFetchComponent } from '@well-known-components/interfaces'
+import { ITracerComponent } from '@well-known-components/interfaces'
+import { IFetchComponent } from '@dcl/core-commons'
 import { createTracedFetcherComponent } from '../src/component'
-import { createFetchComponent } from '@well-known-components/fetch-component'
+import { createFetchComponent } from '@dcl/fetch-component'
 
 // Mock the fetch component module
-jest.mock('@well-known-components/fetch-component', () => ({
+jest.mock('@dcl/fetch-component', () => ({
   createFetchComponent: jest.fn()
 }))
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,16 @@ importers:
         specifier: ^5.8.3
         version: 5.9.3
 
+  components/fetch:
+    dependencies:
+      '@dcl/core-commons':
+        specifier: workspace:*
+        version: link:../../shared/commons
+    devDependencies:
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+
   components/http-server:
     dependencies:
       '@types/http-errors':
@@ -95,6 +105,9 @@ importers:
         specifier: ^0.2.2
         version: 0.2.2
     devDependencies:
+      '@dcl/core-commons':
+        specifier: workspace:*
+        version: link:../../shared/commons
       '@jest/test-sequencer':
         specifier: ^30.0.2
         version: 30.0.2
@@ -201,6 +214,9 @@ importers:
         specifier: ^15.1.0
         version: 15.1.3
     devDependencies:
+      '@dcl/core-commons':
+        specifier: workspace:*
+        version: link:../../shared/commons
       '@dcl/http-server':
         specifier: ^1.0.0
         version: 1.0.0
@@ -386,9 +402,9 @@ importers:
       '@dcl/core-commons':
         specifier: workspace:*
         version: link:../../shared/commons
-      '@well-known-components/fetch-component':
-        specifier: ^3.0.0
-        version: 3.0.0
+      '@dcl/fetch-component':
+        specifier: workspace:*
+        version: link:../fetch
       '@well-known-components/interfaces':
         specifier: ^1.5.2
         version: 1.5.2
@@ -2109,41 +2125,49 @@ packages:
     resolution: {integrity: sha512-UYA0MA8ajkEDCFRQdng/FVx3F6szBvk3EPnkTTQuuO9lV1kPGuTB+V9TmbDxy5ikaEgyWKxa4CI3ySjklZ9lFA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.9.2':
     resolution: {integrity: sha512-P/CO3ODU9YJIHFqAkHbquKtFst0COxdphc8TKGL5yCX75GOiVpGqd1d15ahpqu8xXVsqP4MGFP2C3LRZnnL5MA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.9.2':
     resolution: {integrity: sha512-uKStFlOELBxBum2s1hODPtgJhY4NxYJE9pAeyBgNEzHgTqTiVBPjfTlPFJkfxyTjQEuxZbbJlJnMCrRgD7ubzw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.9.2':
     resolution: {integrity: sha512-LkbNnZlhINfY9gK30AHs26IIVEZ9PEl9qOScYdmY2o81imJYI4IMnJiW0vJVtXaDHvBvxeAgEy5CflwJFIl3tQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.9.2':
     resolution: {integrity: sha512-vI+e6FzLyZHSLFNomPi+nT+qUWN4YSj8pFtQZSFTtmgFoxqB6NyjxSjAxEC1m93qn6hUXhIsh8WMp+fGgxCoRg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.9.2':
     resolution: {integrity: sha512-sSO4AlAYhSM2RAzBsRpahcJB1msc6uYLAtP6pesPbZtptF8OU/CbCPhSRW6cnYOGuVmEmWVW5xVboAqCnWTeHQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.9.2':
     resolution: {integrity: sha512-jkSkwch0uPFva20Mdu8orbQjv2A3G88NExTN2oPTI1AJ+7mZfYW3cDCTyoH6OnctBKbBVeJCEqh0U02lTkqD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.9.2':
     resolution: {integrity: sha512-Uk64NoiTpQbkpl+bXsbeyOPRpUoMdcUqa+hDC1KhMW7aN1lfW8PBlBH4mJ3n3Y47dYE8qi0XTxy1mBACruYBaw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.9.2':
     resolution: {integrity: sha512-EpBGwkcjDicjR/ybC0g8wO5adPNdVuMrNalVgYcWi+gYtC1XYNuxe3rufcO7dA76OHGeVabcO6cSkPJKVcbCXQ==}
@@ -2169,9 +2193,6 @@ packages:
     resolution: {integrity: sha512-QYDL9Uk1zEs5Q4ymgeZo1GVzuHe9Pp/jOLPRIbhwtPOCQ2Bd9yIlUWiFoC36JpcUSIlQ7Fzh8x21v2U95q5/+Q==}
     peerDependencies:
       '@well-known-components/interfaces': ^1.0.0
-
-  '@well-known-components/fetch-component@3.0.0':
-    resolution: {integrity: sha512-ycIaojkwLJvhpicdPsmsEzA9qPbV7voAjrRcVE7+n7UNctIQC8ppymapj0UQ3FFpdEWWVSzjoo33H0BW+sD8eg==}
 
   '@well-known-components/interfaces@1.5.2':
     resolution: {integrity: sha512-TzKQblOci2Azczk1DZ4JL5aJW7hwq7kHrFMO4lCRMmW51bA71BtiZlq0WP72Dln067xTSoHQAU4WHCFJlGYvEQ==}
@@ -2567,9 +2588,6 @@ packages:
   cron-parser@5.5.0:
     resolution: {integrity: sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==}
     engines: {node: '>=18'}
-
-  cross-fetch@3.2.0:
-    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -7836,13 +7854,6 @@ snapshots:
       '@well-known-components/interfaces': 1.5.2
       dotenv: 16.6.1
 
-  '@well-known-components/fetch-component@3.0.0':
-    dependencies:
-      '@well-known-components/interfaces': 1.5.2
-      cross-fetch: 3.2.0
-    transitivePeerDependencies:
-      - encoding
-
   '@well-known-components/interfaces@1.5.2':
     dependencies:
       '@types/node': 20.19.1
@@ -8330,12 +8341,6 @@ snapshots:
   cron-parser@5.5.0:
     dependencies:
       luxon: 3.7.2
-
-  cross-fetch@3.2.0:
-    dependencies:
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
 
   cross-spawn@7.0.6:
     dependencies:

--- a/shared/commons/src/mocks/fetch.ts
+++ b/shared/commons/src/mocks/fetch.ts
@@ -1,4 +1,4 @@
-import { IFetchComponent } from '@well-known-components/interfaces'
+import { IFetchComponent } from '../types'
 
 export const createFetchMockedComponent = (
   overrides?: Partial<jest.Mocked<IFetchComponent>>

--- a/shared/commons/src/types.ts
+++ b/shared/commons/src/types.ts
@@ -5,6 +5,34 @@ export interface ASharedType {
   a: string
 }
 
+// Fetch component types
+
+/**
+ * Options for an outbound fetch request.
+ *
+ * Extends the native Node `fetch` `RequestInit` with the retry and timeout
+ * controls understood by the fetch component. The component targets the
+ * default Node fetch API, so `RequestInit`, `Request` and `Response` are the
+ * global (undici) types shipped with Node, not `node-fetch`.
+ */
+export type RequestOptions = RequestInit & {
+  /** Controller used to abort the request (e.g. on timeout). */
+  abortController?: AbortController
+  /** Milliseconds to wait before aborting the request. */
+  timeout?: number
+  /** Number of attempts for idempotent requests before giving up. */
+  attempts?: number
+  /** Milliseconds to wait between retry attempts. */
+  retryDelay?: number
+}
+
+/**
+ * A fetch component backed by the default Node `fetch` API.
+ */
+export type IFetchComponent = {
+  fetch(url: string | URL | Request, init?: RequestOptions): Promise<Response>
+}
+
 export interface ICacheStorageComponent extends IBaseComponent {
   /**
    * Retrieves a value from cache by key.

--- a/shared/commons/src/types.ts
+++ b/shared/commons/src/types.ts
@@ -28,6 +28,10 @@ export type RequestOptions = RequestInit & {
 
 /**
  * A fetch component backed by the default Node `fetch` API.
+ *
+ * `Request`, `Response` and `RequestInit` are the global types provided by Node
+ * (via `@types/node`), so consumers must run on Node 18+ where `fetch` is part
+ * of the runtime.
  */
 export type IFetchComponent = {
   fetch(url: string | URL | Request, init?: RequestOptions): Promise<Response>


### PR DESCRIPTION
## what

moves `fetch-component` into the core-components monorepo as a new package and standardizes the fetch component type around the default node `fetch` api.

### new package: `@dcl/fetch-component`
- ported from `@well-known-components/fetch-component` into `components/fetch`
- uses the **default node `fetch` api** instead of `cross-fetch`, since consumers are servers
- drops the browser-only `buffer` polyfill and the `isUsingNode` environment check
- retry / timeout / default-options behavior is unchanged
- `@dcl/traced-fetch-component` now wraps this package instead of `@well-known-components/fetch-component`

### shared fetch type
- adds `IFetchComponent` and `RequestOptions` to `@dcl/core-commons`, backed by the native node fetch types (`RequestInit`, `Request`, `Response`)
- every `IFetchComponent` import now resolves to the shared type instead of `@well-known-components/interfaces`

### migrated consumers
- `traced-fetch`, `analytics`, and the shared fetch mock use the shared type
- `http-server` and `metrics` test harnesses use the shared type; their node-fetch runtime stays, bridged with casts at the boundary (node-fetch `Response` lacks `bytes`/`formData` vs the native type)
- `http-server/src/test-component.ts` keeps the node-fetch type, since it is runtime that returns node-fetch responses

## testing
- `pnpm -r build` green across all packages
- tests pass: `fetch` (15), `traced-fetch` (26), `analytics` (10), `metrics` (29), `http-server` (281)

changesets included for `@dcl/fetch-component` (initial), `@dcl/core-commons` (minor), and the consuming components (patch).