### PR TITLE
feat: move http-tracer-component into core-components

### DIFF
--- a/.changeset/http-tracer-component-initial.md
+++ b/.changeset/http-tracer-component-initial.md
@@ -1,0 +1,5 @@
+---
+"@dcl/http-tracer-component": major
+---
+
+initial release of `@dcl/http-tracer-component`, moved into core-components from `@well-known-components/http-tracer-component`. adds tracing spans to each request handler and propagates the w3c trace context headers.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ core-components/
 │   ├── block-indexer/    # On-chain block indexer component
 │   ├── fetch/            # Fetch component using the native Node fetch API
 │   ├── http-server/      # HTTP server component
+│   ├── http-tracer/      # HTTP tracer component (W3C trace context propagation)
 │   ├── job/              # Job scheduling and execution component
 │   ├── memory-cache/     # In-memory LRU cache component
 │   ├── metrics/          # Prometheus metrics component handler
@@ -38,6 +39,7 @@ core-components/
 ### Observability
 
 - **Metrics Component** (`@dcl/metrics`) - Prometheus metrics collection and instrumentation
+- **HTTP Tracer Component** (`@dcl/http-tracer-component`) - Adds tracing spans to request handlers and propagates W3C trace context headers
 
 ### Communication & Messaging
 
@@ -149,6 +151,7 @@ This project uses [Changesets](https://github.com/changesets/changesets) for aut
 - `@dcl/analytics-component`
 - `@dcl/block-indexer`
 - `@dcl/http-server`
+- `@dcl/http-tracer-component`
 - `@dcl/job-component`
 - `@dcl/memory-cache-component`
 - `@dcl/memory-queue-component`

--- a/components/http-tracer/CHANGELOG.md
+++ b/components/http-tracer/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @dcl/http-tracer-component

--- a/components/http-tracer/README.md
+++ b/components/http-tracer/README.md
@@ -1,0 +1,28 @@
+# @dcl/http-tracer-component
+
+Adds tracing spans to each request handler, propagating W3C Trace Context
+(`traceparent` / `tracestate`) headers across HTTP requests.
+
+## Installation
+
+```bash
+npm install @dcl/http-tracer-component
+```
+
+## Usage
+
+```typescript
+import { createHttpTracerComponent } from '@dcl/http-tracer-component'
+
+createHttpTracerComponent({ server, tracer })
+```
+
+It wraps the server with a middleware that:
+
+1. Parses the incoming `traceparent` and `tracestate` headers
+2. Opens a trace span for the request
+3. Injects the resulting `traceparent` (and `tracestate`) headers into the response
+
+## License
+
+Apache-2.0

--- a/components/http-tracer/README.md
+++ b/components/http-tracer/README.md
@@ -22,7 +22,3 @@ It wraps the server with a middleware that:
 1. Parses the incoming `traceparent` and `tracestate` headers
 2. Opens a trace span for the request
 3. Injects the resulting `traceparent` (and `tracestate`) headers into the response
-
-## License
-
-Apache-2.0

--- a/components/http-tracer/jest.config.js
+++ b/components/http-tracer/jest.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>'],
+  testMatch: [
+    '**/tests/**/*.spec.ts',
+    '**/tests/**/*.test.ts',
+    '**/?(*.)+(spec|test).ts'
+  ],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/dist/'
+  ],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!**/*.d.ts',
+  ],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+}

--- a/components/http-tracer/package.json
+++ b/components/http-tracer/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@dcl/http-tracer-component",
+  "version": "0.0.0",
+  "description": "Add tracing spans to each request handler for core components library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/http-tracer"
+  },
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "test": "jest",
+    "lint": "echo \"No linting configured\""
+  },
+  "dependencies": {
+    "@well-known-components/interfaces": "^1.5.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/components/http-tracer/src/component.ts
+++ b/components/http-tracer/src/component.ts
@@ -1,0 +1,40 @@
+import type { IHttpServerComponent, ITracerComponent, TraceContext } from '@well-known-components/interfaces'
+import { parseTraceParentHeader, parseTraceState } from './logic'
+import { IHttpTracerComponent } from './types'
+
+export function createHttpTracerComponent(components: {
+  server: IHttpServerComponent<object>
+  tracer: ITracerComponent
+}): IHttpTracerComponent {
+  const { server, tracer } = components
+
+  server.use((ctx: IHttpServerComponent.DefaultContext<object>, next) => {
+    const traceParentHeader = ctx.request.headers.get('traceparent')
+    const traceParent = traceParentHeader ? parseTraceParentHeader(traceParentHeader) : null
+    const traceStateHeader = ctx.request.headers.get('tracestate')
+    const traceState = traceStateHeader ? parseTraceState(traceStateHeader) : undefined
+
+    const traceContext: Omit<TraceContext, 'id' | 'data' | 'name'> | undefined = traceParent
+      ? { ...traceParent, traceState: traceState ?? undefined }
+      : undefined
+
+    return tracer.span(
+      `${ctx.request.method} ${ctx.url.toString()}`,
+      () => {
+        return next().then(response => {
+          let traceHeaders: { traceparent: string; tracestate?: string } | undefined
+          const traceparent = tracer.getTraceString()
+          if (traceparent) {
+            traceHeaders = { traceparent }
+            const tracestate = tracer.getTraceStateString()
+            if (tracestate) {
+              traceHeaders.tracestate = tracestate
+            }
+          }
+          return { ...response, headers: { ...response.headers, ...traceHeaders } }
+        })
+      },
+      traceContext
+    )
+  })
+}

--- a/components/http-tracer/src/index.ts
+++ b/components/http-tracer/src/index.ts
@@ -1,0 +1,2 @@
+export * from './component'
+export * from './types'

--- a/components/http-tracer/src/logic.ts
+++ b/components/http-tracer/src/logic.ts
@@ -2,7 +2,7 @@ import type { Trace } from '@well-known-components/interfaces'
 
 /**
  * Parses the tracestate header into an object.
- * @param traceParent - The tracestate header.
+ * @param traceState - The tracestate header.
  * @returns An object which contains each property and its value found in the tracestate header or null.
  */
 export function parseTraceState(traceState: string): Record<string, string> | null {

--- a/components/http-tracer/src/logic.ts
+++ b/components/http-tracer/src/logic.ts
@@ -1,0 +1,52 @@
+import type { Trace } from '@well-known-components/interfaces'
+
+/**
+ * Parses the tracestate header into an object.
+ * @param traceParent - The tracestate header.
+ * @returns An object which contains each property and its value found in the tracestate header or null.
+ */
+export function parseTraceState(traceState: string): Record<string, string> | null {
+  const convertedTraceState = traceState.split(',').reduce((acc, curr) => {
+    const [key, value] = curr.split('=')
+    if (!key || !value) {
+      return acc
+    }
+    acc[key.trim()] = value.trim()
+    return acc
+  }, {} as Record<string, string>)
+
+  return Object.keys(convertedTraceState).length > 0 ? convertedTraceState : null
+}
+
+/**
+ * Parses the traceparent header into an object.
+ * @param traceParent - The traceparent header.
+ * @returns An object which contains each property of the tranceparent header or null if it can't be parsed.
+ */
+export function parseTraceParentHeader(traceParent: string): Trace | null {
+  const traceParentProperties = traceParent.split('-')
+  if (!traceParentProperties[0] || !traceParentProperties[1] || !traceParentProperties[2] || !traceParentProperties[3]) {
+    return null
+  }
+
+  const versionHasTheWrongSize = traceParentProperties[0].length !== 2
+  const traceIdHasTheWrongSize = traceParentProperties[1].length !== 32
+  const parentIdHasTheWrongSize = traceParentProperties[2].length !== 16
+  const traceFlagsHaveTheWrongSize = traceParentProperties[3].length !== 2
+  const traceIdIsInvalid = traceParentProperties[1] === '00000000000000000000000000000000'
+  const parentIdIsInvalid = traceParentProperties[2] === '0000000000000000'
+
+  return versionHasTheWrongSize ||
+    traceIdHasTheWrongSize ||
+    parentIdHasTheWrongSize ||
+    traceFlagsHaveTheWrongSize ||
+    traceIdIsInvalid ||
+    parentIdIsInvalid
+    ? null
+    : {
+        version: parseInt(traceParentProperties[0], 16),
+        traceId: traceParentProperties[1],
+        parentId: traceParentProperties[2],
+        traceFlags: parseInt(traceParentProperties[3], 16)
+      }
+}

--- a/components/http-tracer/src/types.ts
+++ b/components/http-tracer/src/types.ts
@@ -1,0 +1,1 @@
+export type IHttpTracerComponent = void

--- a/components/http-tracer/tests/component.spec.ts
+++ b/components/http-tracer/tests/component.spec.ts
@@ -1,0 +1,209 @@
+import type { ITracerComponent, IHttpServerComponent } from '@well-known-components/interfaces'
+import { createHttpTracerComponent } from '../src'
+import { parseTraceParentHeader } from '../src/logic'
+
+let tracerComponentMock: ITracerComponent
+let serverComponentMock: IHttpServerComponent<IHttpServerComponent.DefaultContext<any>>
+let storedMiddleware: (
+  ctx: IHttpServerComponent.DefaultContext<object>,
+  next: () => Promise<IHttpServerComponent.IResponse>
+) => Promise<IHttpServerComponent.IResponse>
+let mockedContext: IHttpServerComponent.DefaultContext<object>
+let mockedNext: () => Promise<IHttpServerComponent.IResponse>
+let mockedGetHeader: jest.Mock
+let mockedGetTraceString: jest.Mock
+let mockedGetTraceStateString: jest.Mock
+
+beforeEach(() => {
+  mockedGetTraceString = jest.fn()
+  mockedGetTraceStateString = jest.fn()
+  tracerComponentMock = {
+    span: jest.fn().mockImplementation((_name, spanFunction) => spanFunction()),
+    isInsideOfTraceSpan: jest.fn(),
+    getSpanId: jest.fn(),
+    getTrace: jest.fn(),
+    getTraceString: mockedGetTraceString,
+    getTraceChild: jest.fn(),
+    getTraceChildString: jest.fn(),
+    getTraceState: jest.fn(),
+    getTraceStateString: mockedGetTraceStateString,
+    getContextData: jest.fn(),
+    setContextData: jest.fn(),
+    setTraceStateProperty: jest.fn(),
+    deleteTraceStateProperty: jest.fn()
+  }
+  serverComponentMock = {
+    use: jest.fn().mockImplementation(middleware => (storedMiddleware = middleware)),
+    setContext: jest.fn()
+  }
+  mockedGetHeader = jest.fn()
+  mockedContext = {
+    request: {
+      headers: {
+        get: mockedGetHeader
+      } as any
+    } as any,
+    url: new URL('http://localhost')
+  }
+  mockedNext = () => Promise.resolve({})
+  createHttpTracerComponent({ server: serverComponentMock, tracer: tracerComponentMock })
+})
+
+describe('when receiving a request with a traceparent header', () => {
+  let traceParentHeader: string
+
+  describe('and the header is correctly formatted', () => {
+    beforeEach(() => {
+      traceParentHeader = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+      mockedGetHeader.mockImplementation(header => (header === 'traceparent' ? traceParentHeader : null))
+    })
+
+    it('should store it in the span context', async () => {
+      await storedMiddleware(mockedContext, mockedNext)
+      expect(tracerComponentMock.span).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ ...parseTraceParentHeader(traceParentHeader) })
+      )
+    })
+  })
+
+  describe('and the header is not correctly formatted', () => {
+    beforeEach(() => {
+      traceParentHeader = '00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01'
+      mockedGetHeader.mockImplementation(header => (header === 'traceparent' ? traceParentHeader : null))
+    })
+
+    it('should not store it in the span context', async () => {
+      await storedMiddleware(mockedContext, mockedNext)
+      expect(tracerComponentMock.span).toHaveBeenCalledWith(expect.anything(), expect.anything(), undefined)
+    })
+  })
+})
+
+describe('when receiving a request with a tracestate header', () => {
+  let traceStateHeader: string
+
+  describe('without a traceparent header', () => {
+    beforeEach(() => {
+      traceStateHeader = 'aKey=aValue'
+      mockedGetHeader.mockImplementation(header => {
+        if (header === 'traceparent') {
+          return undefined
+        } else if (header === 'tracestate') {
+          return traceStateHeader
+        }
+        return undefined
+      })
+    })
+
+    it('should not store it in the span context', async () => {
+      await storedMiddleware(mockedContext, mockedNext)
+      expect(tracerComponentMock.span).toHaveBeenCalledWith(expect.anything(), expect.anything(), undefined)
+    })
+  })
+
+  describe('with a traceparent header', () => {
+    let traceParentHeader: string
+    beforeEach(() => {
+      traceParentHeader = '00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01'
+    })
+
+    describe('and the tracestate header is not well formatted', () => {
+      beforeEach(() => {
+        traceStateHeader = 'aKey=aValue'
+        mockedGetHeader.mockImplementation(header => {
+          if (header === 'traceparent') {
+            return traceParentHeader
+          } else if (header === 'tracestate') {
+            return traceStateHeader
+          }
+          return undefined
+        })
+      })
+
+      it('should not store it in the span context', async () => {
+        await storedMiddleware(mockedContext, mockedNext)
+        expect(tracerComponentMock.span).toHaveBeenCalledWith(expect.anything(), expect.anything(), undefined)
+      })
+    })
+
+    describe('and the tracestate header is well formatted', () => {
+      beforeEach(() => {
+        traceStateHeader = 'someBrokenValue'
+        mockedGetHeader.mockImplementation(header => {
+          if (header === 'traceparent') {
+            return traceParentHeader
+          } else if (header === 'tracestate') {
+            return traceStateHeader
+          }
+          return undefined
+        })
+      })
+
+      it('should store it in the span context', async () => {
+        await storedMiddleware(mockedContext, mockedNext)
+        expect(tracerComponentMock.span).toHaveBeenCalledWith(expect.anything(), expect.anything(), undefined)
+      })
+    })
+  })
+})
+
+describe('when responding a request', () => {
+  let traceStateHeader: string
+  let traceParentHeader: string
+
+  describe('having a trace but no trace state', () => {
+    beforeEach(() => {
+      traceParentHeader = '00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01'
+      mockedGetHeader.mockImplementation(header => {
+        if (header === 'traceparent') {
+          return traceParentHeader
+        } else if (header === 'tracestate') {
+          return undefined
+        }
+        return undefined
+      })
+      mockedGetTraceString.mockReturnValue('aTraceString')
+      mockedGetTraceStateString.mockReturnValue(undefined)
+    })
+
+    it('should return a response with the traceparent header', () => {
+      return expect(storedMiddleware(mockedContext, mockedNext)).resolves.toEqual(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            traceparent: 'aTraceString'
+          })
+        })
+      )
+    })
+  })
+
+  describe('having a trace and a trace state', () => {
+    beforeEach(() => {
+      traceParentHeader = '00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01'
+      traceStateHeader = 'aKey=aValue'
+      mockedGetHeader.mockImplementation(header => {
+        if (header === 'traceparent') {
+          return traceParentHeader
+        } else if (header === 'tracestate') {
+          return traceStateHeader
+        }
+        return undefined
+      })
+      mockedGetTraceString.mockReturnValue('aTraceString')
+      mockedGetTraceStateString.mockReturnValue('aTraceStateString')
+    })
+
+    it('should return a response with the traceparent and tracestate headers', () => {
+      return expect(storedMiddleware(mockedContext, mockedNext)).resolves.toEqual(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            traceparent: 'aTraceString',
+            tracestate: 'aTraceStateString'
+          })
+        })
+      )
+    })
+  })
+})

--- a/components/http-tracer/tests/logic.spec.ts
+++ b/components/http-tracer/tests/logic.spec.ts
@@ -1,0 +1,73 @@
+import { parseTraceParentHeader, parseTraceState } from '../src/logic'
+
+describe('when parsing the trace state header', () => {
+  describe('and it is empty', () => {
+    it('should return null', () => {
+      expect(parseTraceState('')).toBeNull()
+    })
+  })
+
+  describe('and it has a wrong value', () => {
+    it('should return null', () => {
+      expect(parseTraceState('somethingWrong')).toBeNull()
+    })
+  })
+
+  describe('and it has multiple values', () => {
+    it('should return an object containing the key value pair described in the header', () => {
+      expect(parseTraceState('aKey=aValue,anotherKey=anotherValue')).toEqual({
+        aKey: 'aValue',
+        anotherKey: 'anotherValue'
+      })
+    })
+  })
+})
+
+describe('when parsing the trace parent header', () => {
+  describe("and the header doesn't contain all of the properties", () => {
+    it('should return null', () => {
+      expect(parseTraceParentHeader('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7')).toBeNull()
+    })
+  })
+
+  describe('and the header has a version with a wrong size', () => {
+    it('should return null', () => {
+      expect(parseTraceParentHeader('0-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01')).toBeNull()
+    })
+  })
+
+  describe('and the header has a trace id with a wrong size', () => {
+    it('should return null', () => {
+      expect(parseTraceParentHeader('00-4bf92f3577b34da6a3ce929d0e0e-00f067aa0ba902b7-01')).toBeNull()
+    })
+  })
+
+  describe('and the header has a parent id with a wrong size', () => {
+    it('should return null', () => {
+      expect(parseTraceParentHeader('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba90-01')).toBeNull()
+    })
+  })
+
+  describe('and the header has an invalid trace id', () => {
+    it('should return null', () => {
+      expect(parseTraceParentHeader('00-00000000000000000000000000000000-00f067aa0ba902b7-01')).toBeNull()
+    })
+  })
+
+  describe('and the header has an invalid parent id', () => {
+    it('should return null', () => {
+      expect(parseTraceParentHeader('00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01')).toBeNull()
+    })
+  })
+
+  describe('and the header is well formatted', () => {
+    it('should return a trace object', () => {
+      expect(parseTraceParentHeader('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01')).toEqual({
+        version: 0,
+        traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+        parentId: '00f067aa0ba902b7',
+        traceFlags: 1
+      })
+    })
+  })
+})

--- a/components/http-tracer/tsconfig.json
+++ b/components/http-tracer/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,16 @@ importers:
         specifier: ^8.12.1
         version: 8.18.3
 
+  components/http-tracer:
+    dependencies:
+      '@well-known-components/interfaces':
+        specifier: ^1.5.2
+        version: 1.5.2
+    devDependencies:
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+
   components/job:
     dependencies:
       '@dcl/core-commons':


### PR DESCRIPTION
## what

moves `http-tracer-component` into the core-components monorepo as `@dcl/http-tracer-component` under `components/http-tracer`, ported from `@well-known-components/http-tracer-component`.

- component and logic are unchanged (parses incoming `traceparent`/`tracestate`, opens a trace span per request, injects trace headers into the response)
- adopts the monorepo build / jest / tsconfig setup; drops the `tslib` / `importHelpers` setup in favor of the shared root tsconfig
- two `component.spec.ts` assertions adjusted for **jest 30**, where `expect.not.objectContaining(...)` no longer matches an `undefined` argument — they now assert the absent trace context directly

## testing
- `pnpm --filter @dcl/http-tracer-component build` green
- tests pass: 17 (`component` + `logic`)

changeset included for `@dcl/http-tracer-component` (initial).

> [!NOTE]
> based on #99 (the fetch-component move). review/merge that first; this PR targets `feat/migrate-fetch-component` and the diff will narrow once the base lands.