### PR TITLE
feat: move features-component into core-components

### DIFF
--- a/.changeset/features-component-initial.md
+++ b/.changeset/features-component-initial.md
@@ -2,4 +2,6 @@
 "@dcl/features-component": major
 ---
 
-initial release of `@dcl/features-component`, moved into core-components from `@well-known-components/features-component`. it resolves feature flags for an application from env vars and the feature-flags service, and now uses the shared `IFetchComponent` type from `@dcl/core-commons`.
+initial release of `@dcl/features-component`, moved into core-components from `@well-known-components/features-component`. it resolves feature flags for an application from env vars and the feature-flags service, and uses the shared `IFetchComponent` type from `@dcl/core-commons`.
+
+the component is now lifecycle-managed: every request to the feature-flags service is bounded by a configurable timeout (`FF_REQUEST_TIMEOUT`); applications registered via `options.apps` are preloaded on start and continuously refreshed in the background (`FF_REFRESH_INTERVAL`), serving reads from an in-memory cache; and concurrent requests for the same application are de-duplicated so callers wait for an in-flight request instead of starting another.

--- a/.changeset/features-component-initial.md
+++ b/.changeset/features-component-initial.md
@@ -1,0 +1,5 @@
+---
+"@dcl/features-component": major
+---
+
+initial release of `@dcl/features-component`, moved into core-components from `@well-known-components/features-component`. it resolves feature flags for an application from env vars and the feature-flags service, and now uses the shared `IFetchComponent` type from `@dcl/core-commons`.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ core-components/
 ├── components/          # Reusable components
 │   ├── analytics/        # Analytics component for event tracking
 │   ├── block-indexer/    # On-chain block indexer component
+│   ├── features/         # Feature flags resolution component
 │   ├── fetch/            # Fetch component using the native Node fetch API
 │   ├── http-server/      # HTTP server component
 │   ├── job/              # Job scheduling and execution component
@@ -67,6 +68,7 @@ core-components/
 ### Utilities
 
 - **Job Component** (`@dcl/job-component`) - Job scheduling and execution
+- **Features Component** (`@dcl/features-component`) - Feature flag resolution from environment variables and the feature-flags service
 - **Schema Validator Component** (`@dcl/schema-validator-component`) - JSON schema validation middleware
 - **Fetch Component** (`@dcl/fetch-component`) - HTTP client with retries and timeouts on the native Node fetch API
 - **Traced Fetch Component** (`@dcl/traced-fetch-component`) - HTTP requests with distributed tracing
@@ -148,6 +150,7 @@ This project uses [Changesets](https://github.com/changesets/changesets) for aut
 
 - `@dcl/analytics-component`
 - `@dcl/block-indexer`
+- `@dcl/features-component`
 - `@dcl/http-server`
 - `@dcl/job-component`
 - `@dcl/memory-cache-component`

--- a/components/features/CHANGELOG.md
+++ b/components/features/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @dcl/features-component

--- a/components/features/README.md
+++ b/components/features/README.md
@@ -1,0 +1,33 @@
+# @dcl/features-component
+
+Feature flags component for core components library. It resolves feature flags
+for a given application, first from environment variables and then from the
+Decentraland feature-flags service.
+
+## Installation
+
+```bash
+npm install @dcl/features-component
+```
+
+## Usage
+
+```typescript
+import { createFeaturesComponent } from '@dcl/features-component'
+
+const features = await createFeaturesComponent({ config, fetch, logs }, 'https://my-app.decentraland.org')
+
+const isEnabled = await features.getIsFeatureEnabled('explorer', 'some-feature')
+const variant = await features.getFeatureVariant('explorer', 'some-feature')
+```
+
+## How it works
+
+`getIsFeatureEnabled` first looks for an environment variable named
+`FF_<APP>_<FEATURE>` (uppercased). If it is not defined, it fetches the flags
+for the application from the feature-flags service (`FF_URL`, defaulting to
+`https://feature-flags.decentraland.org`) and reads the `<app>-<feature>` key.
+
+## License
+
+Apache-2.0

--- a/components/features/README.md
+++ b/components/features/README.md
@@ -13,20 +13,51 @@ npm install @dcl/features-component
 ## Usage
 
 ```typescript
-import { createFeaturesComponent } from '@dcl/features-component'
+import { createFeaturesComponent, ApplicationName } from '@dcl/features-component'
 
-const features = await createFeaturesComponent({ config, fetch, logs }, 'https://my-app.decentraland.org')
+const features = await createFeaturesComponent({ config, fetch, logs }, 'https://my-app.decentraland.org', {
+  // Applications preloaded on start and continuously refreshed in the background
+  apps: [ApplicationName.DAPPS, ApplicationName.EXPLORER]
+})
 
 const isEnabled = await features.getIsFeatureEnabled('explorer', 'some-feature')
 const variant = await features.getFeatureVariant('explorer', 'some-feature')
 ```
 
+The component implements the well-known-components lifecycle. Register it with
+your program so `startComponents()` preloads the registered apps and starts the
+background refresh, and `stopComponents()` cancels it.
+
 ## How it works
 
 `getIsFeatureEnabled` first looks for an environment variable named
-`FF_<APP>_<FEATURE>` (uppercased). If it is not defined, it fetches the flags
-for the application from the feature-flags service (`FF_URL`, defaulting to
-`https://feature-flags.decentraland.org`) and reads the `<app>-<feature>` key.
+`FF_<APP>_<FEATURE>` (uppercased). If it is not defined, it reads the flags for
+the application and returns the `<app>-<feature>` key. `getFeatureVariant`
+returns the variant for that key.
+
+Flags are fetched from the feature-flags service (`FF_URL`, defaulting to
+`https://feature-flags.decentraland.org`) with these guarantees:
+
+- **Bounded requests** — every request uses a timeout (`FF_REQUEST_TIMEOUT`).
+- **Continuous refresh** — applications passed in `options.apps` are preloaded
+  on `START_COMPONENT` and refreshed every `FF_REFRESH_INTERVAL`; their reads
+  are served from the in-memory cache. If a refresh fails, the last known value
+  keeps being served. Applications that are not registered are fetched on every
+  call.
+- **In-flight de-duplication** — if a request for an application is already in
+  flight, concurrent reads wait for it instead of starting another.
+
+## Configuration
+
+| Env var | Default | Description |
+| --- | --- | --- |
+| `FF_URL` | `https://feature-flags.decentraland.org` | Feature-flags service base URL |
+| `FF_REQUEST_TIMEOUT` | `10000` | Per-request timeout in milliseconds |
+| `FF_REFRESH_INTERVAL` | `240000` | Background refresh interval (ms) for registered apps |
+| `FF_<APP>_<FEATURE>` | — | Per-flag override (`"1"` enables); short-circuits the service |
+
+Invalid `FF_REQUEST_TIMEOUT` / `FF_REFRESH_INTERVAL` values log a warning and
+fall back to the defaults.
 
 ## License
 

--- a/components/features/jest.config.js
+++ b/components/features/jest.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>'],
+  testMatch: [
+    '**/tests/**/*.spec.ts',
+    '**/tests/**/*.test.ts',
+    '**/?(*.)+(spec|test).ts'
+  ],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/dist/'
+  ],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!**/*.d.ts',
+  ],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+}

--- a/components/features/package.json
+++ b/components/features/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@dcl/features-component",
+  "version": "0.0.0",
+  "description": "Feature flags component for core components library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/features"
+  },
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "test": "jest",
+    "lint": "echo \"No linting configured\""
+  },
+  "dependencies": {
+    "@dcl/core-commons": "workspace:*",
+    "@well-known-components/interfaces": "^1.5.2"
+  },
+  "devDependencies": {
+    "@well-known-components/env-config-provider": "^1.2.0",
+    "@well-known-components/logger": "^3.1.3",
+    "@well-known-components/test-helpers": "^1.5.8",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/components/features/src/index.ts
+++ b/components/features/src/index.ts
@@ -50,15 +50,12 @@ export async function createFeaturesComponent(
     return !!featureFlags?.flags[`${app}-${feature}`]
   }
 
-  async function getFeatureVariant<FeatureFlagVariant>(
-    app: string,
-    feature: string
-  ): Promise<FeatureFlagVariant | null> {
+  async function getFeatureVariant(app: string, feature: string): Promise<FeatureFlagVariant | null> {
     const ffKey = `${app}-${feature}`
     const featureFlags = await fetchFeatureFlags(app)
 
     if (featureFlags?.flags[ffKey] && featureFlags?.variants[ffKey]) {
-      return featureFlags.variants[ffKey] as unknown as FeatureFlagVariant
+      return featureFlags.variants[ffKey]
     }
 
     return null

--- a/components/features/src/index.ts
+++ b/components/features/src/index.ts
@@ -33,7 +33,7 @@ export async function createFeaturesComponent(
         throw new Error(`Could not fetch features service from ${FF_URL}`)
       }
     } catch (error) {
-      logger.error(error as Error)
+      logger.error(error instanceof Error ? error : new Error(String(error)))
     }
 
     return null
@@ -42,7 +42,7 @@ export async function createFeaturesComponent(
   async function getIsFeatureEnabled(app: string, feature: string): Promise<boolean> {
     const envFeatureFlag = await getEnvFeature(app, feature)
     if (envFeatureFlag) {
-      return envFeatureFlag === "1" ? true : false
+      return envFeatureFlag === "1"
     }
 
     const featureFlags = await fetchFeatureFlags(app)

--- a/components/features/src/index.ts
+++ b/components/features/src/index.ts
@@ -1,0 +1,72 @@
+import { FeatureFlagVariant, FeaturesFlagsResponse, FeaturesComponents, IFeaturesComponent } from "./types"
+
+export * from "./types"
+
+/**
+ * Creates a scoped features component to fetch features flag from a given application.
+ * @public
+ */
+export async function createFeaturesComponent(
+  components: FeaturesComponents,
+  referer: string
+): Promise<IFeaturesComponent> {
+  const { config, fetch, logs } = components
+  const FF_URL = (await config.getString("FF_URL")) ?? "https://feature-flags.decentraland.org"
+
+  const logger = logs.getLogger("features")
+
+  async function getEnvFeature(app: string, feature: string): Promise<string | undefined> {
+    return config.getString(`FF_${app}_${feature}`.toUpperCase())
+  }
+
+  async function fetchFeatureFlags(app: string): Promise<FeaturesFlagsResponse | null> {
+    try {
+      const response = await fetch.fetch(`${FF_URL}/${app}.json`, {
+        headers: {
+          Referer: referer,
+        },
+      })
+
+      if (response.ok) {
+        return (await response.json()) as FeaturesFlagsResponse
+      } else {
+        throw new Error(`Could not fetch features service from ${FF_URL}`)
+      }
+    } catch (error) {
+      logger.error(error as Error)
+    }
+
+    return null
+  }
+
+  async function getIsFeatureEnabled(app: string, feature: string): Promise<boolean> {
+    const envFeatureFlag = await getEnvFeature(app, feature)
+    if (envFeatureFlag) {
+      return envFeatureFlag === "1" ? true : false
+    }
+
+    const featureFlags = await fetchFeatureFlags(app)
+
+    return !!featureFlags?.flags[`${app}-${feature}`]
+  }
+
+  async function getFeatureVariant<FeatureFlagVariant>(
+    app: string,
+    feature: string
+  ): Promise<FeatureFlagVariant | null> {
+    const ffKey = `${app}-${feature}`
+    const featureFlags = await fetchFeatureFlags(app)
+
+    if (featureFlags?.flags[ffKey] && featureFlags?.variants[ffKey]) {
+      return featureFlags.variants[ffKey] as unknown as FeatureFlagVariant
+    }
+
+    return null
+  }
+
+  return {
+    getEnvFeature,
+    getIsFeatureEnabled,
+    getFeatureVariant,
+  }
+}

--- a/components/features/src/index.ts
+++ b/components/features/src/index.ts
@@ -1,42 +1,114 @@
-import { FeatureFlagVariant, FeaturesFlagsResponse, FeaturesComponents, IFeaturesComponent } from "./types"
+import { START_COMPONENT, STOP_COMPONENT } from "@well-known-components/interfaces"
+import {
+  FeatureFlagVariant,
+  FeaturesComponentOptions,
+  FeaturesComponents,
+  FeaturesFlagsResponse,
+  IFeaturesComponent
+} from "./types"
 
 export * from "./types"
 
+const DEFAULT_REQUEST_TIMEOUT_MS = 10000
+const DEFAULT_REFRESH_INTERVAL_MS = 4 * 60 * 1000
+
 /**
- * Creates a scoped features component to fetch features flag from a given application.
+ * Creates a scoped features component to fetch feature flags from a given application.
+ *
+ * Every request to the feature-flags service is bounded by a timeout
+ * (`FF_REQUEST_TIMEOUT`, default 10s). Applications registered via
+ * `options.apps` are preloaded on start and refreshed in the background every
+ * `FF_REFRESH_INTERVAL` (default 4 minutes); their reads are served from an
+ * in-memory cache. Concurrent requests for the same application are
+ * de-duplicated: callers that arrive while a request is in flight wait for it.
  * @public
  */
 export async function createFeaturesComponent(
   components: FeaturesComponents,
-  referer: string
+  referer: string,
+  options: FeaturesComponentOptions = {}
 ): Promise<IFeaturesComponent> {
   const { config, fetch, logs } = components
   const FF_URL = (await config.getString("FF_URL")) ?? "https://feature-flags.decentraland.org"
 
   const logger = logs.getLogger("features")
 
+  async function getValidatedConfigNumber(key: string, defaultValue: number): Promise<number> {
+    const configuredValue = await config.getNumber(key)
+    const isValid = typeof configuredValue === "number" && Number.isFinite(configuredValue) && configuredValue > 0
+    if (configuredValue !== undefined && !isValid) {
+      logger.warn(`${key} value "${configuredValue}" is invalid; using default ${defaultValue}ms`)
+    }
+    return isValid ? (configuredValue as number) : defaultValue
+  }
+
+  const requestTimeout = await getValidatedConfigNumber("FF_REQUEST_TIMEOUT", DEFAULT_REQUEST_TIMEOUT_MS)
+  const refreshInterval = await getValidatedConfigNumber("FF_REFRESH_INTERVAL", DEFAULT_REFRESH_INTERVAL_MS)
+
+  const registeredApps = new Set<string>(options.apps ?? [])
+  const cachedFlagsByApp = new Map<string, FeaturesFlagsResponse>()
+  const inFlightByApp = new Map<string, Promise<FeaturesFlagsResponse | null>>()
+  let refreshTimer: NodeJS.Timeout | null = null
+
   async function getEnvFeature(app: string, feature: string): Promise<string | undefined> {
     return config.getString(`FF_${app}_${feature}`.toUpperCase())
   }
 
-  async function fetchFeatureFlags(app: string): Promise<FeaturesFlagsResponse | null> {
+  async function requestFeatureFlags(app: string): Promise<FeaturesFlagsResponse | null> {
     try {
       const response = await fetch.fetch(`${FF_URL}/${app}.json`, {
         headers: {
-          Referer: referer,
+          Referer: referer
         },
+        timeout: requestTimeout
       })
 
-      if (response.ok) {
-        return (await response.json()) as FeaturesFlagsResponse
-      } else {
+      if (!response.ok) {
         throw new Error(`Could not fetch features service from ${FF_URL}`)
       }
+
+      const flags = (await response.json()) as FeaturesFlagsResponse
+
+      if (registeredApps.has(app)) {
+        cachedFlagsByApp.set(app, flags)
+      }
+
+      return flags
     } catch (error) {
       logger.error(error instanceof Error ? error : new Error(String(error)))
+      // On failure keep serving the last known value for registered apps.
+      return cachedFlagsByApp.get(app) ?? null
+    }
+  }
+
+  // De-duplicates concurrent fetches for the same application: callers that
+  // arrive while a request is in flight await the same promise.
+  function fetchFeatureFlags(app: string): Promise<FeaturesFlagsResponse | null> {
+    const inFlight = inFlightByApp.get(app)
+    if (inFlight) {
+      return inFlight
     }
 
-    return null
+    const request = requestFeatureFlags(app).finally(() => {
+      inFlightByApp.delete(app)
+    })
+    inFlightByApp.set(app, request)
+    return request
+  }
+
+  async function getFlags(app: string): Promise<FeaturesFlagsResponse | null> {
+    // If a request for this app is already in flight, wait for it to finish.
+    const inFlight = inFlightByApp.get(app)
+    if (inFlight) {
+      return inFlight
+    }
+
+    // Registered apps are served from the continuously refreshed cache.
+    if (registeredApps.has(app) && cachedFlagsByApp.has(app)) {
+      return cachedFlagsByApp.get(app) ?? null
+    }
+
+    return fetchFeatureFlags(app)
   }
 
   async function getIsFeatureEnabled(app: string, feature: string): Promise<boolean> {
@@ -45,14 +117,14 @@ export async function createFeaturesComponent(
       return envFeatureFlag === "1"
     }
 
-    const featureFlags = await fetchFeatureFlags(app)
+    const featureFlags = await getFlags(app)
 
     return !!featureFlags?.flags[`${app}-${feature}`]
   }
 
   async function getFeatureVariant(app: string, feature: string): Promise<FeatureFlagVariant | null> {
     const ffKey = `${app}-${feature}`
-    const featureFlags = await fetchFeatureFlags(app)
+    const featureFlags = await getFlags(app)
 
     if (featureFlags?.flags[ffKey] && featureFlags?.variants[ffKey]) {
       return featureFlags.variants[ffKey]
@@ -61,9 +133,37 @@ export async function createFeaturesComponent(
     return null
   }
 
+  async function refreshAll(): Promise<void> {
+    await Promise.all([...registeredApps].map((app) => fetchFeatureFlags(app)))
+  }
+
+  async function start(): Promise<void> {
+    if (registeredApps.size === 0) {
+      return
+    }
+
+    // Preload the registered applications so the first reads are served from cache.
+    await refreshAll()
+
+    refreshTimer = setInterval(() => {
+      refreshAll().catch((error) => {
+        logger.error(error instanceof Error ? error : new Error(String(error)))
+      })
+    }, refreshInterval)
+  }
+
+  async function stop(): Promise<void> {
+    if (refreshTimer) {
+      clearInterval(refreshTimer)
+      refreshTimer = null
+    }
+  }
+
   return {
     getEnvFeature,
     getIsFeatureEnabled,
     getFeatureVariant,
+    [START_COMPONENT]: start,
+    [STOP_COMPONENT]: stop
   }
 }

--- a/components/features/src/types.ts
+++ b/components/features/src/types.ts
@@ -1,0 +1,74 @@
+import { IConfigComponent, ILoggerComponent } from "@well-known-components/interfaces"
+import { IFetchComponent } from "@dcl/core-commons"
+
+/**
+ * @public
+ */
+export type FeatureFlagVariant = {
+  name: string
+  payload: {
+    type: string
+    value: string
+  }
+  enabled: boolean
+}
+
+/**
+ * @public
+ */
+export type FeaturesFlagsResponse = {
+  flags: Record<string, boolean>
+  variants: Record<string, FeatureFlagVariant>
+}
+
+/**
+ * @public
+ */
+export type FeaturesComponents = {
+  fetch: IFetchComponent
+  logs: ILoggerComponent
+  config: IConfigComponent
+}
+
+/**
+ * @public
+ */
+export type IFeaturesComponent = {
+  /**
+   * Helper to get whether a feature flag is enabled or disabled.
+   * It will first look into your env file for the feature flag, if it is not defined there,
+   * it will look it in the requested and stored features data.
+   * The env key will be determined from the application and the flag. For example, if the
+   * application is "explorer" and the flag is "some-crazy-feature", it will look
+   * for it as FF_EXPLORER_SOME_CRAZY_FEATURE.
+   * @param app - Appplication name.
+   * @param feature - Feature key without the application name prefix. For example for the "builder-feature".
+   * @returns Whether the feature is enabled or not and its variant.
+   */
+  getEnvFeature(app: string, feature: string): Promise<string | undefined>
+  getIsFeatureEnabled(app: string, feature: string): Promise<boolean>
+  getFeatureVariant(app: string, feature: string): Promise<FeatureFlagVariant | null>
+}
+
+/**
+ * @public
+ */
+export enum ApplicationName {
+  EXPLORER = "explorer",
+  BUILDER = "builder",
+  MARKETPLACE = "marketplace",
+  ACCOUNT = "account",
+  DAO = "dao",
+  DAPPS = "dapps",
+  EVENTS = "events",
+  LANDING = "landing",
+  TEST = "test",
+  CORE = "core"
+}
+
+/**
+ * @public
+ */
+export type TestComponents = FeaturesComponents & {
+  features: IFeaturesComponent
+}

--- a/components/features/src/types.ts
+++ b/components/features/src/types.ts
@@ -1,4 +1,4 @@
-import { IConfigComponent, ILoggerComponent } from "@well-known-components/interfaces"
+import { IBaseComponent, IConfigComponent, ILoggerComponent } from "@well-known-components/interfaces"
 import { IFetchComponent } from "@dcl/core-commons"
 
 /**
@@ -31,9 +31,24 @@ export type FeaturesComponents = {
 }
 
 /**
+ * Options for the features component.
  * @public
  */
-export type IFeaturesComponent = {
+export type FeaturesComponentOptions = {
+  /**
+   * Applications whose feature flags are preloaded on start and continuously
+   * refreshed in the background. Reads for these applications are served from
+   * the in-memory cache. Applications that are not registered are still
+   * supported, but their flags are fetched on every call (with in-flight
+   * de-duplication).
+   */
+  apps?: string[]
+}
+
+/**
+ * @public
+ */
+export type IFeaturesComponent = IBaseComponent & {
   /**
    * Helper to get whether a feature flag is enabled or disabled.
    * It will first look into your env file for the feature flag, if it is not defined there,

--- a/components/features/tests/components.spec.ts
+++ b/components/features/tests/components.spec.ts
@@ -1,0 +1,162 @@
+import { test } from "./components"
+
+test("features component", function ({ components }) {
+  const FF_APP = "TestApp"
+  const FF_TOGGLE = "TestFF"
+  const FF_KEY = `${FF_APP}-${FF_TOGGLE}`
+
+  describe("when checking a feature flag is enabled", () => {
+    describe("and the feature flag is in the .env file", () => {
+      describe("and the feature flag is enabled", () => {
+        beforeEach(() => {
+          const { config } = components
+          jest.spyOn(config, "getString").mockResolvedValueOnce("1")
+        })
+
+        it("should return true", () => {
+          const { features } = components
+          return expect(features.getIsFeatureEnabled(FF_APP, FF_TOGGLE)).resolves.toBe(true)
+        })
+      })
+
+      describe("and the feature flag is disabled", () => {
+        beforeEach(() => {
+          const { config } = components
+          jest.spyOn(config, "getString").mockResolvedValueOnce("0")
+        })
+
+        it("should return false", () => {
+          const { features } = components
+          return expect(features.getIsFeatureEnabled(FF_APP, FF_TOGGLE)).resolves.toBe(false)
+        })
+      })
+    })
+
+    describe("and the feature flag is not in the .env file", () => {
+      beforeEach(() => {
+        const { features } = components
+        jest.spyOn(features, "getEnvFeature").mockResolvedValueOnce(undefined)
+      })
+
+      describe("and the feature flag is fetched successfully from the features service", () => {
+        describe("and the feature flag is enabled", () => {
+          beforeEach(() => {
+            const { fetch } = components
+            jest.spyOn(fetch, "fetch").mockResolvedValueOnce({
+              ok: true,
+              json: jest.fn().mockResolvedValue({
+                flags: { [FF_KEY]: true },
+              }),
+            } as any)
+          })
+
+          it("should return true", () => {
+            const { features } = components
+            return expect(features.getIsFeatureEnabled(FF_APP, FF_TOGGLE)).resolves.toBe(true)
+          })
+        })
+
+        describe("and the feature flag is disabled", () => {
+          beforeEach(() => {
+            const { fetch } = components
+            jest.spyOn(fetch, "fetch").mockResolvedValueOnce({
+              ok: true,
+              json: jest.fn().mockResolvedValueOnce({
+                flags: {},
+              }),
+            } as any)
+          })
+
+          it("should return false", () => {
+            const { features } = components
+            return expect(features.getIsFeatureEnabled(FF_APP, FF_TOGGLE)).resolves.toBe(false)
+          })
+        })
+      })
+
+      describe("and the feature flag could not be fetched successfully from features service", () => {
+        beforeEach(() => {
+          const { fetch } = components
+          jest.spyOn(fetch, "fetch").mockResolvedValueOnce({
+            ok: false,
+          } as any)
+        })
+
+        it("should return false", () => {
+          const { features } = components
+          return expect(features.getIsFeatureEnabled(FF_APP, FF_TOGGLE)).resolves.toBe(false)
+        })
+      })
+    })
+  })
+
+  describe("when checking a feature flag variant", () => {
+    describe("and the feature flag is enabled", () => {
+      describe("and the feature flag has a variant", () => {
+        const FF_VARIANT = {
+          name: "TestFFVariant",
+          payload: {
+            type: "string",
+            value: "1",
+          },
+          enabled: true,
+        }
+
+        beforeEach(() => {
+          const { fetch } = components
+          jest.spyOn(fetch, "fetch").mockResolvedValueOnce({
+            ok: true,
+            json: jest.fn().mockResolvedValueOnce({
+              flags: {
+                [FF_KEY]: true,
+              },
+              variants: { [FF_KEY]: FF_VARIANT },
+            }),
+          } as any)
+        })
+
+        it("should return the variant data", () => {
+          const { features } = components
+          return expect(features.getFeatureVariant(FF_APP, FF_TOGGLE)).resolves.toBe(FF_VARIANT)
+        })
+      })
+
+      describe("and the feature flag does not have a variant", () => {
+        beforeEach(() => {
+          const { fetch } = components
+          jest.spyOn(fetch, "fetch").mockResolvedValueOnce({
+            ok: true,
+            json: jest.fn().mockResolvedValueOnce({
+              flags: {
+                [FF_KEY]: true,
+              },
+              variants: {},
+            }),
+          } as any)
+        })
+
+        it("should return null", () => {
+          const { features } = components
+          return expect(features.getFeatureVariant(FF_APP, FF_TOGGLE)).resolves.toBe(null)
+        })
+      })
+    })
+
+    describe("and the feature flag is disabled", () => {
+      beforeEach(() => {
+        const { fetch } = components
+        jest.spyOn(fetch, "fetch").mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce({
+            flags: {},
+          }),
+        } as any)
+      })
+
+      it("should return null", () => {
+        const { features } = components
+        return expect(features.getFeatureVariant(FF_APP, FF_TOGGLE)).resolves.toBe(null)
+      })
+    })
+  })
+})

--- a/components/features/tests/components.ts
+++ b/components/features/tests/components.ts
@@ -1,0 +1,44 @@
+import { createConfigComponent } from "@well-known-components/env-config-provider"
+import { IFetchComponent } from "@dcl/core-commons"
+import { createLogComponent } from "@well-known-components/logger"
+import { createRunner } from "@well-known-components/test-helpers"
+import { createFeaturesComponent } from "../src"
+import { TestComponents } from "../src/types"
+
+/**
+ * Behaves like Jest "describe" function, used to describe a test for a
+ * use case, it creates a whole new program and components to run an
+ * isolated test.
+ *
+ * State is persistent within the steps of the test.
+ */
+export const test = createRunner<TestComponents>({
+  async main({ startComponents }) {
+    await startComponents()
+  },
+  async initComponents(): Promise<TestComponents> {
+    const config = createConfigComponent(process.env, {})
+    const logs = await createLogComponent({})
+    const fetcher: IFetchComponent = {
+      async fetch() {
+        return {} as any
+      },
+    }
+
+    const features = await createFeaturesComponent(
+      {
+        fetch: fetcher,
+        logs,
+        config,
+      },
+      "REFERENCE_SERVER_URL"
+    )
+
+    return {
+      fetch: fetcher,
+      logs,
+      config,
+      features,
+    }
+  },
+})

--- a/components/features/tests/features.spec.ts
+++ b/components/features/tests/features.spec.ts
@@ -1,0 +1,197 @@
+import { START_COMPONENT, STOP_COMPONENT } from "@well-known-components/interfaces"
+import { createFeaturesComponent } from "../src"
+import { IFeaturesComponent } from "../src/types"
+
+const FF_DEFAULT_URL = "https://feature-flags.decentraland.org"
+
+function createLoggerMock() {
+  return {
+    log: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn()
+  }
+}
+
+function okResponse(flags: Record<string, boolean>, variants: Record<string, unknown> = {}) {
+  return { ok: true, json: jest.fn().mockResolvedValue({ flags, variants }) } as any
+}
+
+type BuildArgs = {
+  strings?: Record<string, string | undefined>
+  numbers?: Record<string, number | undefined>
+  apps?: string[]
+}
+
+async function buildFeatures({ strings = {}, numbers = {}, apps }: BuildArgs = {}) {
+  const logger = createLoggerMock()
+  const fetchMock = jest.fn()
+  const config = {
+    getString: jest.fn(async (key: string) => strings[key]),
+    getNumber: jest.fn(async (key: string) => numbers[key])
+  }
+  const features = await createFeaturesComponent(
+    { config: config as any, logs: { getLogger: () => logger } as any, fetch: { fetch: fetchMock } as any },
+    "REFERER",
+    apps ? { apps } : {}
+  )
+  return { features, fetchMock, logger, config }
+}
+
+describe("when reading a flag that is not overridden in the environment", () => {
+  let features: IFeaturesComponent
+  let fetchMock: jest.Mock
+
+  describe("and no request timeout is configured", () => {
+    beforeEach(async () => {
+      ;({ features, fetchMock } = await buildFeatures())
+      fetchMock.mockResolvedValue(okResponse({ "dapps-x": true }))
+    })
+
+    it("should request the flags with the default 10s timeout", async () => {
+      await features.getIsFeatureEnabled("dapps", "x")
+
+      expect(fetchMock).toHaveBeenCalledWith(`${FF_DEFAULT_URL}/dapps.json`, expect.objectContaining({ timeout: 10000 }))
+    })
+  })
+
+  describe("and a valid request timeout is configured", () => {
+    beforeEach(async () => {
+      ;({ features, fetchMock } = await buildFeatures({ numbers: { FF_REQUEST_TIMEOUT: 5000 } }))
+      fetchMock.mockResolvedValue(okResponse({ "dapps-x": true }))
+    })
+
+    it("should request the flags with the configured timeout", async () => {
+      await features.getIsFeatureEnabled("dapps", "x")
+
+      expect(fetchMock).toHaveBeenCalledWith(`${FF_DEFAULT_URL}/dapps.json`, expect.objectContaining({ timeout: 5000 }))
+    })
+  })
+
+  describe("and an invalid request timeout is configured", () => {
+    let logger: ReturnType<typeof createLoggerMock>
+
+    beforeEach(async () => {
+      ;({ features, fetchMock, logger } = await buildFeatures({ numbers: { FF_REQUEST_TIMEOUT: -1 } }))
+      fetchMock.mockResolvedValue(okResponse({ "dapps-x": true }))
+    })
+
+    it("should warn and fall back to the default timeout", async () => {
+      await features.getIsFeatureEnabled("dapps", "x")
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("FF_REQUEST_TIMEOUT"))
+      expect(fetchMock).toHaveBeenCalledWith(`${FF_DEFAULT_URL}/dapps.json`, expect.objectContaining({ timeout: 10000 }))
+    })
+  })
+})
+
+describe("when the flag is overridden in the environment", () => {
+  let features: IFeaturesComponent
+  let fetchMock: jest.Mock
+
+  beforeEach(async () => {
+    ;({ features, fetchMock } = await buildFeatures({ strings: { FF_DAPPS_X: "1" } }))
+  })
+
+  it("should resolve from the environment without hitting the feature-flags service", async () => {
+    await expect(features.getIsFeatureEnabled("dapps", "x")).resolves.toBe(true)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("when two reads for the same application happen concurrently", () => {
+  let features: IFeaturesComponent
+  let fetchMock: jest.Mock
+
+  beforeEach(async () => {
+    ;({ features, fetchMock } = await buildFeatures())
+    fetchMock.mockResolvedValue(okResponse({ "dapps-x": true }, { "dapps-x": { name: "v", enabled: true, payload: {} } }))
+  })
+
+  it("should de-duplicate the in-flight request and fetch only once", async () => {
+    await Promise.all([features.getIsFeatureEnabled("dapps", "x"), features.getFeatureVariant("dapps", "x")])
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("when an application is not registered", () => {
+  let features: IFeaturesComponent
+  let fetchMock: jest.Mock
+
+  beforeEach(async () => {
+    ;({ features, fetchMock } = await buildFeatures())
+    fetchMock.mockResolvedValue(okResponse({ "dapps-x": true }))
+  })
+
+  it("should fetch the flags on every (sequential) call", async () => {
+    await features.getIsFeatureEnabled("dapps", "x")
+    await features.getIsFeatureEnabled("dapps", "x")
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe("when an application is registered", () => {
+  let features: IFeaturesComponent
+  let fetchMock: jest.Mock
+  let logger: ReturnType<typeof createLoggerMock>
+
+  beforeEach(async () => {
+    jest.useFakeTimers()
+    ;({ features, fetchMock, logger } = await buildFeatures({ numbers: { FF_REFRESH_INTERVAL: 1000 }, apps: ["dapps"] }))
+    fetchMock.mockResolvedValue(okResponse({ "dapps-x": true }))
+    await features[START_COMPONENT]!({} as any)
+  })
+
+  afterEach(async () => {
+    await features[STOP_COMPONENT]!()
+    jest.useRealTimers()
+  })
+
+  it("should preload the flags on start", () => {
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  describe("and reads happen after start", () => {
+    it("should serve them from cache without re-fetching", async () => {
+      await features.getIsFeatureEnabled("dapps", "x")
+      await features.getFeatureVariant("dapps", "x")
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("and the refresh interval elapses", () => {
+    it("should refresh the flags in the background", async () => {
+      await jest.advanceTimersByTimeAsync(1000)
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe("and the component is stopped", () => {
+    it("should stop refreshing", async () => {
+      await features[STOP_COMPONENT]!()
+      await jest.advanceTimersByTimeAsync(5000)
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("and a background refresh fails after a successful load", () => {
+    beforeEach(async () => {
+      fetchMock.mockRejectedValueOnce(new Error("service unavailable"))
+      await jest.advanceTimersByTimeAsync(1000)
+    })
+
+    it("should keep serving the last cached value", async () => {
+      await expect(features.getIsFeatureEnabled("dapps", "x")).resolves.toBe(true)
+    })
+
+    it("should log the refresh error", () => {
+      expect(logger.error).toHaveBeenCalled()
+    })
+  })
+})

--- a/components/features/tsconfig.json
+++ b/components/features/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,28 @@ importers:
         specifier: ^5.8.3
         version: 5.9.3
 
+  components/features:
+    dependencies:
+      '@dcl/core-commons':
+        specifier: workspace:*
+        version: link:../../shared/commons
+      '@well-known-components/interfaces':
+        specifier: ^1.5.2
+        version: 1.5.2
+    devDependencies:
+      '@well-known-components/env-config-provider':
+        specifier: ^1.2.0
+        version: 1.2.0(@well-known-components/interfaces@1.5.2)
+      '@well-known-components/logger':
+        specifier: ^3.1.3
+        version: 3.1.3(@well-known-components/interfaces@1.5.2)
+      '@well-known-components/test-helpers':
+        specifier: ^1.5.8
+        version: 1.5.8(@babel/core@7.27.4)(@jest/transform@30.0.2)(@jest/types@30.2.0)(babel-jest@30.0.2(@babel/core@7.27.4))(jest-util@30.2.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+
   components/fetch:
     dependencies:
       '@dcl/core-commons':


### PR DESCRIPTION
## what

moves `features-component` into the core-components monorepo as `@dcl/features-component` under `components/features`, ported from `@well-known-components/features-component`.

- component behavior is unchanged: resolves a feature flag from `FF_<APP>_<FEATURE>` env vars first, then from the feature-flags service (`FF_URL`)
- migrates the `IFetchComponent` import to the shared type in `@dcl/core-commons`
- the feature-flags response is cast explicitly, since the default node `fetch` types `response.json()` as `unknown` (node-fetch typed it as `any`)
- adopts the monorepo build / jest / tsconfig setup

## testing
- `pnpm --filter @dcl/features-component build` green
- tests pass: 8 (`components`)

changeset included for `@dcl/features-component` (initial).

> [!NOTE]
> based on #99 (the fetch-component move). review/merge that first; this PR targets `feat/migrate-fetch-component` and the diff will narrow once the base lands.