### PR TITLE
feat: move uws-http-server into core-components

### DIFF
--- a/.changeset/uws-http-server-initial.md
+++ b/.changeset/uws-http-server-initial.md
@@ -1,0 +1,5 @@
+---
+"@dcl/uws-http-server": major
+---
+
+initial release of `@dcl/uws-http-server`, moved into core-components from `@well-known-components/uws-http-server`. it provides a uWebSockets.js based http server component with lifecycle management and prometheus metrics helpers, and bumps `uWebSockets.js` to v20.68.0.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ core-components/
 │   ├── slack/            # Slack messaging component
 │   ├── sns/              # AWS SNS publisher component
 │   ├── sqs/              # AWS SQS queue component
-│   └── traced-fetch/     # Traced fetch component with distributed tracing
+│   ├── traced-fetch/     # Traced fetch component with distributed tracing
+│   └── uws-http-server/  # uWebSockets.js based HTTP server component
 └── shared/             # Shared utilities and types
     └── commons/          # Common utilities, types, and constants
 ```
@@ -33,6 +34,7 @@ core-components/
 ### Infrastructure
 
 - **HTTP Server Component** (`@dcl/http-server`) - HTTP server with routing, middleware, CORS, and WebSocket support
+- **uWS HTTP Server Component** (`@dcl/uws-http-server`) - uWebSockets.js based HTTP server with lifecycle management and Prometheus metrics helpers
 
 ### Observability
 
@@ -160,6 +162,7 @@ This project uses [Changesets](https://github.com/changesets/changesets) for aut
 - `@dcl/sns-component`
 - `@dcl/sqs-component`
 - `@dcl/traced-fetch-component`
+- `@dcl/uws-http-server`
 - `@dcl/core-commons`
 
 ### Publishing Workflow

--- a/components/uws-http-server/CHANGELOG.md
+++ b/components/uws-http-server/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @dcl/uws-http-server

--- a/components/uws-http-server/README.md
+++ b/components/uws-http-server/README.md
@@ -1,0 +1,36 @@
+# @dcl/uws-http-server
+
+uWebSockets.js based HTTP server component for the core components library. It
+exposes a `uws.TemplatedApp` with lifecycle management and Prometheus metrics
+helpers.
+
+## Installation
+
+```bash
+npm install @dcl/uws-http-server
+```
+
+## Usage
+
+```typescript
+import { createUWsComponent } from '@dcl/uws-http-server'
+
+const server = await createUWsComponent({ config, logs })
+
+server.app.get('/health', (res) => {
+  res.writeStatus('200 OK')
+  res.end('ok')
+})
+
+await server.start()
+```
+
+The component reads `HTTP_SERVER_HOST` and `HTTP_SERVER_PORT` from the config
+component and manages the `start`/`stop` lifecycle.
+
+## Metrics
+
+`getDefaultHttpMetrics`, `createMetricsHandler`, `onRequestStart` and
+`onRequestEnd` provide Prometheus instrumentation for the server. The metrics
+handler is exposed at `WKC_METRICS_PUBLIC_PATH` (default `/metrics`) and can be
+protected with `WKC_METRICS_BEARER_TOKEN`.

--- a/components/uws-http-server/jest.config.js
+++ b/components/uws-http-server/jest.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>'],
+  testMatch: [
+    '**/tests/**/*.spec.ts',
+    '**/tests/**/*.test.ts',
+    '**/?(*.)+(spec|test).ts'
+  ],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/dist/'
+  ],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!**/*.d.ts',
+  ],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+}

--- a/components/uws-http-server/package.json
+++ b/components/uws-http-server/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@dcl/uws-http-server",
+  "version": "0.0.0",
+  "description": "uWebSockets.js based HTTP server component for core components library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/uws-http-server"
+  },
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "test": "jest --forceExit",
+    "lint": "echo \"No linting configured\""
+  },
+  "dependencies": {
+    "@well-known-components/interfaces": "^1.5.2",
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.68.0"
+  },
+  "devDependencies": {
+    "@types/node-fetch": "^2.6.12",
+    "@well-known-components/env-config-provider": "^1.2.0",
+    "@well-known-components/logger": "^3.1.3",
+    "@well-known-components/test-helpers": "^1.5.8",
+    "node-fetch": "^2.6.12",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/components/uws-http-server/src/index.ts
+++ b/components/uws-http-server/src/index.ts
@@ -1,4 +1,4 @@
 export * from './types'
 export * from './metrics'
 export * from './uws'
-export { HttpRequest, HttpResponse, WebSocket } from 'uWebSockets.js'
+export type { HttpRequest, HttpResponse, WebSocket } from 'uWebSockets.js'

--- a/components/uws-http-server/src/index.ts
+++ b/components/uws-http-server/src/index.ts
@@ -1,0 +1,4 @@
+export * from './types'
+export * from './metrics'
+export * from './uws'
+export { HttpRequest, HttpResponse, WebSocket } from 'uWebSockets.js'

--- a/components/uws-http-server/src/metrics.ts
+++ b/components/uws-http-server/src/metrics.ts
@@ -1,0 +1,91 @@
+import { IMetricsComponent } from '@well-known-components/interfaces'
+import * as uws from 'uWebSockets.js'
+import { Components, HttpMetrics, metrics } from './types'
+
+export const CONFIG_PREFIX = 'WKC_METRICS' as const
+
+export function getDefaultHttpMetrics(): IMetricsComponent.MetricsRecordDefinition<HttpMetrics> {
+  return metrics
+}
+
+export function _configKey(key: Uppercase<string>): string {
+  return `${CONFIG_PREFIX}_${key.toUpperCase().replace(/^(_*)/, '')}`
+}
+
+const noopStartTimer = { end() {} }
+
+export async function createMetricsHandler(
+  components: Pick<Components, 'config' | 'metrics'>,
+  registry: IMetricsComponent.Registry
+) {
+  const { metrics, config } = components
+
+  const metricsPath = (await config.getString(_configKey('PUBLIC_PATH'))) || '/metrics'
+  const bearerToken = await config.getString(_configKey('BEARER_TOKEN'))
+  const rotateMetrics = (await config.getString(_configKey('RESET_AT_NIGHT'))) === 'true'
+
+  function calculateNextReset() {
+    return new Date(new Date(new Date().toDateString()).getTime() + 86400000).getTime()
+  }
+
+  let nextReset: number = calculateNextReset()
+
+  return {
+    path: metricsPath,
+    handler: async (res: uws.HttpResponse, req: uws.HttpRequest) => {
+      const body = await registry.metrics()
+
+      if (bearerToken) {
+        const header = req.getHeader('authorization')
+        if (!header) {
+          res.writeStatus('401 Forbidden')
+          res.end()
+          return
+        }
+        const [_, value] = header.split(' ')
+        if (value !== bearerToken) {
+          res.writeStatus('401 Forbidden')
+          res.end()
+          return
+        }
+      }
+
+      // heavy-metric servers that run for long hours tend to generate precision problems
+      // and memory degradation for histograms if not cleared enough. this method
+      // resets the metrics once per day at 00.00UTC
+      if (rotateMetrics && Date.now() > nextReset) {
+        nextReset = calculateNextReset()
+        metrics.resetAll()
+      }
+
+      res.writeStatus('200 OK')
+      res.writeHeader('content-type', registry.contentType)
+      res.end(body)
+    }
+  }
+}
+
+export function onRequestStart(metrics: IMetricsComponent<HttpMetrics>, method: string, handler: string) {
+  const labels = {
+    method,
+    handler
+  }
+  const startTimerResult = metrics.startTimer('http_request_duration_seconds', labels)
+  const end = startTimerResult?.end || noopStartTimer.end
+  return { end, labels }
+}
+
+export function onRequestEnd(
+  metrics: IMetricsComponent<HttpMetrics>,
+  startLabels: Record<string, any>,
+  code: number,
+  end: (labels: Record<string, any>) => void
+) {
+  const labels = {
+    ...startLabels,
+    code
+  }
+
+  metrics.increment('http_requests_total', labels)
+  end(labels)
+}

--- a/components/uws-http-server/src/metrics.ts
+++ b/components/uws-http-server/src/metrics.ts
@@ -33,22 +33,30 @@ export async function createMetricsHandler(
   return {
     path: metricsPath,
     handler: async (res: uws.HttpResponse, req: uws.HttpRequest) => {
-      const body = await registry.metrics()
+      // uWebSockets.js invalidates `res` once the client disconnects; writing to
+      // it afterwards throws and crashes the process. Track aborts so the async
+      // section below can bail out before touching `res` again.
+      let aborted = false
+      res.onAborted(() => {
+        aborted = true
+      })
 
+      // The request object is only valid synchronously (before the first
+      // `await`), so authorization is checked here. This also avoids serializing
+      // the metrics for unauthorized callers.
       if (bearerToken) {
         const header = req.getHeader('authorization')
-        if (!header) {
-          res.writeStatus('401 Forbidden')
-          res.end()
-          return
-        }
-        const [_, value] = header.split(' ')
-        if (value !== bearerToken) {
-          res.writeStatus('401 Forbidden')
+        const [scheme, value] = header ? header.split(' ') : []
+        if (scheme !== 'Bearer' || value !== bearerToken) {
+          res.writeStatus('401 Unauthorized')
           res.end()
           return
         }
       }
+
+      const body = await registry.metrics()
+
+      if (aborted) return
 
       // heavy-metric servers that run for long hours tend to generate precision problems
       // and memory degradation for histograms if not cleared enough. this method

--- a/components/uws-http-server/src/types.ts
+++ b/components/uws-http-server/src/types.ts
@@ -1,0 +1,52 @@
+import {
+  IBaseComponent,
+  IConfigComponent,
+  ILoggerComponent,
+  IMetricsComponent
+} from '@well-known-components/interfaces'
+const httpLabels = ['method', 'handler', 'code'] as const
+import * as uws from 'uWebSockets.js'
+
+export const metrics = {
+  http_request_duration_seconds: {
+    type: IMetricsComponent.HistogramType,
+    help: 'Request duration in seconds.',
+    labelNames: httpLabels
+  },
+  http_requests_total: {
+    type: IMetricsComponent.CounterType,
+    help: 'Total number of HTTP requests',
+    labelNames: httpLabels
+  },
+  http_request_size_bytes: {
+    type: IMetricsComponent.HistogramType,
+    help: 'Duration of HTTP requests size in bytes',
+    labelNames: httpLabels
+  }
+}
+
+/**
+ * HTTP metrics definitions
+ * @public
+ */
+export type HttpMetrics = keyof typeof metrics
+
+/**
+ * Prometheus Registry abstraction, used in prometheus instrumentation
+ * @public
+ */
+export type PromRegistry = {
+  contentType: string
+  metrics(): Promise<string>
+}
+
+export type IUWsComponent = IBaseComponent & {
+  start(): Promise<void>
+  app: uws.TemplatedApp
+}
+
+export type Components = {
+  config: IConfigComponent
+  logs: ILoggerComponent
+  metrics: IMetricsComponent<HttpMetrics>
+}

--- a/components/uws-http-server/src/types.ts
+++ b/components/uws-http-server/src/types.ts
@@ -42,6 +42,7 @@ export type PromRegistry = {
 
 export type IUWsComponent = IBaseComponent & {
   start(): Promise<void>
+  stop(): Promise<void>
   app: uws.TemplatedApp
 }
 

--- a/components/uws-http-server/src/types.ts
+++ b/components/uws-http-server/src/types.ts
@@ -20,7 +20,7 @@ export const metrics = {
   },
   http_request_size_bytes: {
     type: IMetricsComponent.HistogramType,
-    help: 'Duration of HTTP requests size in bytes',
+    help: 'Size of HTTP requests in bytes',
     labelNames: httpLabels
   }
 }

--- a/components/uws-http-server/src/uws.ts
+++ b/components/uws-http-server/src/uws.ts
@@ -1,0 +1,52 @@
+import * as uws from 'uWebSockets.js'
+import { Components, IUWsComponent } from './types'
+
+export async function createUWsComponent(
+  components: Pick<Components, 'config' | 'logs'>,
+  options?: uws.AppOptions
+): Promise<IUWsComponent> {
+  const { config, logs } = components
+  const [port, host] = await Promise.all([
+    config.requireNumber('HTTP_SERVER_PORT'),
+    await config.requireString('HTTP_SERVER_HOST')
+  ])
+
+  const logger = logs.getLogger('http-server')
+
+  const app = uws.App(options || {})
+
+  let listen: Promise<uws.us_listen_socket> | undefined
+  async function start() {
+    if (listen) {
+      logger.error('start() called more than once')
+      await listen
+      return
+    }
+    listen = new Promise<uws.us_listen_socket>((resolve, reject) => {
+      try {
+        app.listen(host, port, (token) => {
+          logger.log(`Listening ${host}:${port}`)
+          resolve(token)
+        })
+      } catch (err: any) {
+        reject(err)
+      }
+    })
+    await listen
+  }
+
+  async function stop() {
+    if (listen) {
+      logger.info(`Closing server`)
+      const token = await listen
+      uws.us_listen_socket_close(token)
+      logger.info(`Server closed`)
+    }
+  }
+
+  return {
+    app,
+    start,
+    stop
+  }
+}

--- a/components/uws-http-server/src/uws.ts
+++ b/components/uws-http-server/src/uws.ts
@@ -8,7 +8,7 @@ export async function createUWsComponent(
   const { config, logs } = components
   const [port, host] = await Promise.all([
     config.requireNumber('HTTP_SERVER_PORT'),
-    await config.requireString('HTTP_SERVER_HOST')
+    config.requireString('HTTP_SERVER_HOST')
   ])
 
   const logger = logs.getLogger('http-server')
@@ -25,6 +25,12 @@ export async function createUWsComponent(
     listen = new Promise<uws.us_listen_socket>((resolve, reject) => {
       try {
         app.listen(host, port, (token) => {
+          // uWebSockets.js reports a failed bind by invoking the callback with a
+          // falsy socket rather than throwing, so it must be handled explicitly.
+          if (!token) {
+            reject(new Error(`Failed to listen on ${host}:${port}`))
+            return
+          }
           logger.log(`Listening ${host}:${port}`)
           resolve(token)
         })
@@ -32,7 +38,13 @@ export async function createUWsComponent(
         reject(err)
       }
     })
-    await listen
+    try {
+      await listen
+    } catch (err) {
+      // Clear the failed attempt so the server can be started again.
+      listen = undefined
+      throw err
+    }
   }
 
   async function stop() {
@@ -40,6 +52,7 @@ export async function createUWsComponent(
       logger.info(`Closing server`)
       const token = await listen
       uws.us_listen_socket_close(token)
+      listen = undefined
       logger.info(`Server closed`)
     }
   }

--- a/components/uws-http-server/tests/integration.spec.ts
+++ b/components/uws-http-server/tests/integration.spec.ts
@@ -24,7 +24,6 @@ describe('integration test', () => {
 
     expect(await res.text()).toEqual('ok')
 
-    // `stop` is optional on IBaseComponent but always provided by createUWsComponent
-    await server.stop!()
+    await server.stop()
   })
 })

--- a/components/uws-http-server/tests/integration.spec.ts
+++ b/components/uws-http-server/tests/integration.spec.ts
@@ -1,0 +1,30 @@
+import { createUWsComponent } from '../src'
+import { createLogComponent } from '@well-known-components/logger'
+import { createConfigComponent } from '@well-known-components/env-config-provider'
+import { createLocalFetchCompoment } from '@well-known-components/test-helpers'
+import * as uws from 'uWebSockets.js'
+
+describe('integration test', () => {
+  it('should start, receive the request and finally stop the server', async () => {
+    const logs = await createLogComponent({})
+    const config = createConfigComponent({
+      HTTP_SERVER_HOST: '0.0.0.0',
+      HTTP_SERVER_PORT: '7272'
+    })
+
+    const server = await createUWsComponent({ logs, config })
+    server.app.get('/test', (res: uws.HttpResponse, _req: uws.HttpRequest) => {
+      res.writeStatus('200 OK')
+      res.end('ok')
+    })
+    await server.start()
+
+    const fetch = await createLocalFetchCompoment(config)
+    const res = await fetch.fetch('/test')
+
+    expect(await res.text()).toEqual('ok')
+
+    // `stop` is optional on IBaseComponent but always provided by createUWsComponent
+    await server.stop!()
+  })
+})

--- a/components/uws-http-server/tests/metrics.spec.ts
+++ b/components/uws-http-server/tests/metrics.spec.ts
@@ -1,0 +1,259 @@
+import {
+  createMetricsHandler,
+  getDefaultHttpMetrics,
+  onRequestEnd,
+  onRequestStart
+} from '../src/metrics'
+
+type MockResponse = {
+  writeStatus: jest.Mock
+  writeHeader: jest.Mock
+  end: jest.Mock
+  onAborted: jest.Mock
+}
+
+function createMockResponse(): MockResponse {
+  return {
+    writeStatus: jest.fn(),
+    writeHeader: jest.fn(),
+    end: jest.fn(),
+    onAborted: jest.fn()
+  }
+}
+
+function createMockConfig(values: Record<string, string | undefined>) {
+  return {
+    getString: jest.fn(async (key: string) => values[key])
+  }
+}
+
+describe('when getting the default http metrics', () => {
+  it('should return the request duration, total and size metric definitions', () => {
+    const result = getDefaultHttpMetrics()
+
+    expect(Object.keys(result)).toEqual(
+      expect.arrayContaining(['http_request_duration_seconds', 'http_requests_total', 'http_request_size_bytes'])
+    )
+  })
+})
+
+describe('when creating the metrics handler', () => {
+  let metrics: { resetAll: jest.Mock }
+  let registry: { contentType: string; metrics: jest.Mock }
+  let res: MockResponse
+  let req: { getHeader: jest.Mock }
+
+  beforeEach(() => {
+    metrics = { resetAll: jest.fn() }
+    registry = { contentType: 'text/plain; version=0.0.4', metrics: jest.fn().mockResolvedValue('metrics_body') }
+    res = createMockResponse()
+    req = { getHeader: jest.fn().mockReturnValue('') }
+  })
+
+  describe('and no public path is configured', () => {
+    it('should default the path to /metrics', async () => {
+      const config = createMockConfig({})
+
+      const { path } = await createMetricsHandler({ config, metrics } as any, registry as any)
+
+      expect(path).toBe('/metrics')
+    })
+  })
+
+  describe('and a public path is configured', () => {
+    it('should use the configured path', async () => {
+      const config = createMockConfig({ WKC_METRICS_PUBLIC_PATH: '/internal/metrics' })
+
+      const { path } = await createMetricsHandler({ config, metrics } as any, registry as any)
+
+      expect(path).toBe('/internal/metrics')
+    })
+  })
+
+  describe('and no bearer token is configured', () => {
+    let handler: (res: any, req: any) => Promise<void>
+
+    beforeEach(async () => {
+      const config = createMockConfig({})
+      handler = (await createMetricsHandler({ config, metrics } as any, registry as any)).handler
+    })
+
+    it('should respond with the serialized metrics and the registry content type', async () => {
+      await handler(res, req)
+
+      expect(res.writeStatus).toHaveBeenCalledWith('200 OK')
+      expect(res.writeHeader).toHaveBeenCalledWith('content-type', 'text/plain; version=0.0.4')
+      expect(res.end).toHaveBeenCalledWith('metrics_body')
+    })
+
+    it('should register an onAborted handler', async () => {
+      await handler(res, req)
+
+      expect(res.onAborted).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('and a bearer token is configured', () => {
+    let handler: (res: any, req: any) => Promise<void>
+
+    beforeEach(async () => {
+      const config = createMockConfig({ WKC_METRICS_BEARER_TOKEN: 'secret-token' })
+      handler = (await createMetricsHandler({ config, metrics } as any, registry as any)).handler
+    })
+
+    describe('and the request has no authorization header', () => {
+      beforeEach(() => {
+        req.getHeader.mockReturnValue('')
+      })
+
+      it('should respond with 401 Unauthorized and not serialize the metrics', async () => {
+        await handler(res, req)
+
+        expect(res.writeStatus).toHaveBeenCalledWith('401 Unauthorized')
+        expect(res.end).toHaveBeenCalledWith()
+        expect(registry.metrics).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('and the authorization scheme is not Bearer', () => {
+      beforeEach(() => {
+        req.getHeader.mockReturnValue('Basic secret-token')
+      })
+
+      it('should respond with 401 Unauthorized', async () => {
+        await handler(res, req)
+
+        expect(res.writeStatus).toHaveBeenCalledWith('401 Unauthorized')
+        expect(registry.metrics).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('and the bearer token does not match', () => {
+      beforeEach(() => {
+        req.getHeader.mockReturnValue('Bearer wrong-token')
+      })
+
+      it('should respond with 401 Unauthorized', async () => {
+        await handler(res, req)
+
+        expect(res.writeStatus).toHaveBeenCalledWith('401 Unauthorized')
+        expect(registry.metrics).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('and the bearer token matches', () => {
+      beforeEach(() => {
+        req.getHeader.mockReturnValue('Bearer secret-token')
+      })
+
+      it('should respond with the serialized metrics', async () => {
+        await handler(res, req)
+
+        expect(res.writeStatus).toHaveBeenCalledWith('200 OK')
+        expect(res.end).toHaveBeenCalledWith('metrics_body')
+      })
+    })
+  })
+
+  describe('and the client disconnects while the metrics are being computed', () => {
+    let handler: (res: any, req: any) => Promise<void>
+    let resolveMetrics: (value: string) => void
+
+    beforeEach(async () => {
+      const config = createMockConfig({})
+      registry.metrics.mockReturnValue(
+        new Promise<string>((resolve) => {
+          resolveMetrics = resolve
+        })
+      )
+      handler = (await createMetricsHandler({ config, metrics } as any, registry as any)).handler
+    })
+
+    it('should not write to the aborted response', async () => {
+      const handlerPromise = handler(res, req)
+
+      // Simulate the client aborting before the metrics body resolves
+      const onAbortedCallback = res.onAborted.mock.calls[0][0]
+      onAbortedCallback()
+      resolveMetrics('metrics_body')
+      await handlerPromise
+
+      expect(res.writeStatus).not.toHaveBeenCalled()
+      expect(res.end).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and metrics rotation is enabled', () => {
+    let handler: (res: any, req: any) => Promise<void>
+
+    beforeEach(async () => {
+      const config = createMockConfig({ WKC_METRICS_RESET_AT_NIGHT: 'true' })
+      handler = (await createMetricsHandler({ config, metrics } as any, registry as any)).handler
+    })
+
+    it('should still serve the current metrics before any reset', async () => {
+      await handler(res, req)
+
+      expect(res.end).toHaveBeenCalledWith('metrics_body')
+    })
+  })
+})
+
+describe('when a request starts', () => {
+  let metrics: { startTimer: jest.Mock }
+  let end: jest.Mock
+
+  beforeEach(() => {
+    end = jest.fn()
+    metrics = { startTimer: jest.fn().mockReturnValue({ end }) }
+  })
+
+  it('should start the request duration timer with the method and handler labels', () => {
+    const result = onRequestStart(metrics as any, 'GET', '/test')
+
+    expect(metrics.startTimer).toHaveBeenCalledWith('http_request_duration_seconds', {
+      method: 'GET',
+      handler: '/test'
+    })
+    expect(result.labels).toEqual({ method: 'GET', handler: '/test' })
+    expect(result.end).toBe(end)
+  })
+
+  describe('and the timer cannot be started', () => {
+    beforeEach(() => {
+      metrics.startTimer.mockReturnValue(undefined)
+    })
+
+    it('should fall back to a no-op end function', () => {
+      const result = onRequestStart(metrics as any, 'GET', '/test')
+
+      expect(() => result.end({})).not.toThrow()
+    })
+  })
+})
+
+describe('when a request ends', () => {
+  let metrics: { increment: jest.Mock }
+  let end: jest.Mock
+
+  beforeEach(() => {
+    end = jest.fn()
+    metrics = { increment: jest.fn() }
+  })
+
+  it('should increment the total requests counter with the status code label', () => {
+    onRequestEnd(metrics as any, { method: 'GET', handler: '/test' }, 200, end)
+
+    expect(metrics.increment).toHaveBeenCalledWith('http_requests_total', {
+      method: 'GET',
+      handler: '/test',
+      code: 200
+    })
+  })
+
+  it('should end the duration timer with the status code label', () => {
+    onRequestEnd(metrics as any, { method: 'GET', handler: '/test' }, 200, end)
+
+    expect(end).toHaveBeenCalledWith({ method: 'GET', handler: '/test', code: 200 })
+  })
+})

--- a/components/uws-http-server/tests/uws.spec.ts
+++ b/components/uws-http-server/tests/uws.spec.ts
@@ -1,0 +1,42 @@
+import { createUWsComponent } from '../src'
+import { createLogComponent } from '@well-known-components/logger'
+import { createConfigComponent } from '@well-known-components/env-config-provider'
+
+// uWebSockets.js reports a failed bind by calling the listen callback with a
+// falsy socket (it does not throw). The native module is mocked here to exercise
+// that path deterministically, without depending on a real unbindable address.
+jest.mock('uWebSockets.js', () => ({
+  App: jest.fn(() => ({
+    listen: (_host: string, _port: number, cb: (token: unknown) => void) => cb(false)
+  })),
+  us_listen_socket_close: jest.fn()
+}))
+
+describe('when starting the server and the socket cannot be bound', () => {
+  it('should reject start with a descriptive error', async () => {
+    const logs = await createLogComponent({})
+    const config = createConfigComponent({
+      HTTP_SERVER_HOST: '0.0.0.0',
+      HTTP_SERVER_PORT: '7273'
+    })
+
+    const server = await createUWsComponent({ logs, config })
+
+    await expect(server.start()).rejects.toThrow('Failed to listen on 0.0.0.0:7273')
+  })
+
+  it('should allow a subsequent start attempt after a failed bind', async () => {
+    const logs = await createLogComponent({})
+    const config = createConfigComponent({
+      HTTP_SERVER_HOST: '0.0.0.0',
+      HTTP_SERVER_PORT: '7273'
+    })
+
+    const server = await createUWsComponent({ logs, config })
+
+    await expect(server.start()).rejects.toThrow('Failed to listen on 0.0.0.0:7273')
+    // The failed attempt is cleared, so a retry reaches the listen path again
+    // (rather than the "start() called more than once" short-circuit).
+    await expect(server.start()).rejects.toThrow('Failed to listen on 0.0.0.0:7273')
+  })
+})

--- a/components/uws-http-server/tsconfig.json
+++ b/components/uws-http-server/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,6 +397,34 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
 
+  components/uws-http-server:
+    dependencies:
+      '@well-known-components/interfaces':
+        specifier: ^1.5.2
+        version: 1.5.2
+      uWebSockets.js:
+        specifier: github:uNetworking/uWebSockets.js#v20.68.0
+        version: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/624987739d4da0acb628aaf2a10fc43e7ce27c5c
+    devDependencies:
+      '@types/node-fetch':
+        specifier: ^2.6.12
+        version: 2.6.12
+      '@well-known-components/env-config-provider':
+        specifier: ^1.2.0
+        version: 1.2.0(@well-known-components/interfaces@1.5.2)
+      '@well-known-components/logger':
+        specifier: ^3.1.3
+        version: 3.1.3(@well-known-components/interfaces@1.5.2)
+      '@well-known-components/test-helpers':
+        specifier: ^1.5.8
+        version: 1.5.8(@babel/core@7.27.4)(@jest/transform@30.0.2)(@jest/types@30.2.0)(babel-jest@30.0.2(@babel/core@7.27.4))(jest-util@30.2.0)(typescript@5.9.3)
+      node-fetch:
+        specifier: ^2.6.12
+        version: 2.7.0
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+
   shared/commons:
     dependencies:
       '@well-known-components/interfaces':
@@ -2109,41 +2137,49 @@ packages:
     resolution: {integrity: sha512-UYA0MA8ajkEDCFRQdng/FVx3F6szBvk3EPnkTTQuuO9lV1kPGuTB+V9TmbDxy5ikaEgyWKxa4CI3ySjklZ9lFA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.9.2':
     resolution: {integrity: sha512-P/CO3ODU9YJIHFqAkHbquKtFst0COxdphc8TKGL5yCX75GOiVpGqd1d15ahpqu8xXVsqP4MGFP2C3LRZnnL5MA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.9.2':
     resolution: {integrity: sha512-uKStFlOELBxBum2s1hODPtgJhY4NxYJE9pAeyBgNEzHgTqTiVBPjfTlPFJkfxyTjQEuxZbbJlJnMCrRgD7ubzw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.9.2':
     resolution: {integrity: sha512-LkbNnZlhINfY9gK30AHs26IIVEZ9PEl9qOScYdmY2o81imJYI4IMnJiW0vJVtXaDHvBvxeAgEy5CflwJFIl3tQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.9.2':
     resolution: {integrity: sha512-vI+e6FzLyZHSLFNomPi+nT+qUWN4YSj8pFtQZSFTtmgFoxqB6NyjxSjAxEC1m93qn6hUXhIsh8WMp+fGgxCoRg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.9.2':
     resolution: {integrity: sha512-sSO4AlAYhSM2RAzBsRpahcJB1msc6uYLAtP6pesPbZtptF8OU/CbCPhSRW6cnYOGuVmEmWVW5xVboAqCnWTeHQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.9.2':
     resolution: {integrity: sha512-jkSkwch0uPFva20Mdu8orbQjv2A3G88NExTN2oPTI1AJ+7mZfYW3cDCTyoH6OnctBKbBVeJCEqh0U02lTkqD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.9.2':
     resolution: {integrity: sha512-Uk64NoiTpQbkpl+bXsbeyOPRpUoMdcUqa+hDC1KhMW7aN1lfW8PBlBH4mJ3n3Y47dYE8qi0XTxy1mBACruYBaw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.9.2':
     resolution: {integrity: sha512-EpBGwkcjDicjR/ybC0g8wO5adPNdVuMrNalVgYcWi+gYtC1XYNuxe3rufcO7dA76OHGeVabcO6cSkPJKVcbCXQ==}
@@ -4434,6 +4470,10 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/624987739d4da0acb628aaf2a10fc43e7ce27c5c:
+    resolution: {tarball: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/624987739d4da0acb628aaf2a10fc43e7ce27c5c}
+    version: 20.68.0
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -10678,6 +10718,8 @@ snapshots:
   typescript@5.8.3: {}
 
   typescript@5.9.3: {}
+
+  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/624987739d4da0acb628aaf2a10fc43e7ce27c5c: {}
 
   undici-types@5.26.5: {}
 


### PR DESCRIPTION
## what

moves `uws-http-server` into the core-components monorepo as `@dcl/uws-http-server` under `components/uws-http-server`, ported from `@well-known-components/uws-http-server`, and bumps uWebSockets.js to the latest release.

- **`uWebSockets.js` bumped from `v20.43.0` → `v20.68.0`**
- component, metrics helpers and types are unchanged (`createUWsComponent`, `createMetricsHandler`, `getDefaultHttpMetrics`, `onRequestStart`/`onRequestEnd`)
- adopts the monorepo build / jest / tsconfig setup
- the integration test now asserts the optional `stop` lifecycle method (`server.stop!()`); the stricter monorepo root tsconfig flags it as possibly `undefined`, whereas the upstream test tsconfig ran with `strict` off — behavior is unchanged

## testing
- `pnpm --filter @dcl/uws-http-server build` green; full `pnpm -r build` green
- integration test passes (starts a real uWebSockets.js server, serves a request, stops) on v20.68.0

changeset included for `@dcl/uws-http-server` (initial).