### PR TITLE
refactor(http-server): use native fetch types and drop node-fetch dependency

### DIFF
--- a/.changeset/http-server-native-fetch.md
+++ b/.changeset/http-server-native-fetch.md
@@ -1,0 +1,10 @@
+---
+"@dcl/http-server": major
+"@dcl/core-commons": minor
+---
+
+remove the `node-fetch` runtime dependency from `@dcl/http-server` by moving its request/response pipeline onto the native Node `fetch` API.
+
+`@dcl/core-commons` now exports an `IHttpServerComponent` whose `IRequest`/`IResponse` are bound to the global (undici) `Request`/`Response` shipped with Node instead of `node-fetch`, and `@dcl/http-server` builds requests and responses with those native types. Internally the server normalizes a handler response into a plain transport object that keeps `Buffer`/Node-stream bodies and informational statuses such as `101` (WebSocket upgrade), rather than round-tripping through a `Response` — the native constructor cannot represent a streamed body or a 1xx status. `node-fetch` is now a dev-only dependency used by the test HTTP clients.
+
+BREAKING CHANGE: `IHttpServerComponent.IRequest` is now the native `Request`, so `request.body` is a web `ReadableStream` instead of a Node `Readable`. Consumers that piped the request body (e.g. `request.body.pipe(...)`) must adapt it with `Readable.fromWeb(request.body)`.

--- a/components/http-server/package.json
+++ b/components/http-server/package.json
@@ -20,18 +20,17 @@
     "lint": "echo \"No linting configured\""
   },
   "dependencies": {
+    "@dcl/core-commons": "workspace:*",
     "@types/http-errors": "^2.0.4",
     "destroy": "^1.2.0",
     "fp-future": "^1.0.1",
     "http-errors": "^2.0.0",
     "mitt": "^3.0.0",
-    "node-fetch": "^2.6.9",
     "on-finished": "^2.4.1",
     "path-to-regexp": "^6.3.0",
     "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {
-    "@dcl/core-commons": "workspace:*",
     "@types/busboy": "^1.5.4",
     "@types/destroy": "^1.0.0",
     "@types/jest": "^30.0.0",
@@ -47,6 +46,7 @@
     "busboy": "^1.6.0",
     "form-data": "^4.0.0",
     "jest": "^30.0.2",
+    "node-fetch": "^2.6.9",
     "ts-jest": "^29.4.0",
     "typescript": "^5.8.2",
     "undici": "^7.4.0",

--- a/components/http-server/package.json
+++ b/components/http-server/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@dcl/core-commons": "workspace:*",
-    "@types/http-errors": "^2.0.4",
+    "@well-known-components/interfaces": "^1.5.1",
     "destroy": "^1.2.0",
     "fp-future": "^1.0.1",
     "http-errors": "^2.0.0",
@@ -33,13 +33,13 @@
   "devDependencies": {
     "@types/busboy": "^1.5.4",
     "@types/destroy": "^1.0.0",
+    "@types/http-errors": "^2.0.4",
     "@types/jest": "^30.0.0",
     "@types/node": "^20.3.2",
     "@types/node-fetch": "^2.6.12",
     "@types/on-finished": "^2.3.4",
     "@types/ws": "^8.5.4",
     "@well-known-components/env-config-provider": "^1.1.1",
-    "@well-known-components/interfaces": "^1.5.1",
     "@well-known-components/logger": "^3.1.2",
     "@well-known-components/test-helpers": "^1.3.0",
     "@jest/test-sequencer": "^30.0.2",

--- a/components/http-server/src/benchmark.ts
+++ b/components/http-server/src/benchmark.ts
@@ -1,6 +1,7 @@
 // this server shuts down after 10100 requests.
 
-import { IConfigComponent, IHttpServerComponent, ILoggerComponent, Lifecycle } from '@well-known-components/interfaces'
+import { IConfigComponent, ILoggerComponent, Lifecycle } from '@well-known-components/interfaces'
+import { IHttpServerComponent } from '@dcl/core-commons'
 import { createConfigComponent } from '@well-known-components/env-config-provider'
 import { createServerComponent } from './index'
 import { createLogComponent } from '@well-known-components/logger'

--- a/components/http-server/src/cors.ts
+++ b/components/http-server/src/cors.ts
@@ -1,7 +1,7 @@
 // Temporary fix to enable local develoment until this CORS module is merged into http-server
 
-import { Headers, Request, Response } from 'node-fetch'
-import { IHttpServerComponent } from '@well-known-components/interfaces'
+// `Headers`, `Request` and `Response` are the native (undici) globals provided by Node.
+import { IHttpServerComponent } from '@dcl/core-commons'
 
 export const corsHeaders = {
   'Access-Control-Allow-Origin': '*',

--- a/components/http-server/src/injectors.ts
+++ b/components/http-server/src/injectors.ts
@@ -1,4 +1,4 @@
-import type { IHttpServerComponent } from '@well-known-components/interfaces'
+import type { IHttpServerComponent } from '@dcl/core-commons'
 
 const underlyingServerKey = Symbol('real-server')
 

--- a/components/http-server/src/layer.ts
+++ b/components/http-server/src/layer.ts
@@ -1,4 +1,4 @@
-import { IHttpServerComponent as http } from '@well-known-components/interfaces'
+import { IHttpServerComponent as http } from '@dcl/core-commons'
 import { pathToRegexp, Key } from 'path-to-regexp'
 import { Middleware } from './middleware'
 import { RoutedContext } from './router'

--- a/components/http-server/src/logic.ts
+++ b/components/http-server/src/logic.ts
@@ -1,14 +1,27 @@
-import * as fetch from 'node-fetch'
-import { Stream } from 'stream'
+import { Readable, Stream } from 'stream'
 import * as http from 'http'
 import * as https from 'https'
 import destroy from 'destroy'
 import onFinished from 'on-finished'
-import type { IHttpServerComponent } from '@well-known-components/interfaces'
+import type { IHttpServerComponent } from '@dcl/core-commons'
 import type { IHttpServerOptions } from './types'
 import { HttpError } from 'http-errors'
 import { Middleware } from './middleware'
 import { getWebSocketCallback, upgradeWebSocketResponse, withWebSocketCallback } from './ws'
+
+/**
+ * @internal
+ * The normalized, transport-ready form of a handler response. Unlike a web `Response` it keeps the
+ * body as a Node `Buffer`/`Readable` so it can be written or piped straight to the Node
+ * `http.ServerResponse`, and it can represent informational statuses such as `101` (WebSocket
+ * upgrade) that the native `Response` constructor rejects.
+ */
+export type NormalizedResponse = {
+  status?: number
+  statusText?: string
+  headers: Headers
+  body?: Buffer | Readable
+}
 
 /**
  * @internal
@@ -48,38 +61,25 @@ export const isBlob = (object: any): object is Blob => {
 /**
  * @internal
  */
-export function success(data: fetch.Response, res: http.ServerResponse) {
+export function success(data: NormalizedResponse, res: http.ServerResponse) {
   if (data.statusText) res.statusMessage = data.statusText
   if (data.status) res.statusCode = data.status
 
-  if (data.headers) {
-    const headers = new fetch.Headers(data.headers as any)
-    headers.forEach((value: string | undefined, key: string) => {
-      if (value !== undefined) {
-        res.setHeader(key, value)
-      }
-    })
-  }
+  data.headers.forEach((value: string, key: string) => {
+    if (value !== undefined) {
+      res.setHeader(key, value)
+    }
+  })
 
   const body = data.body
 
   if (Buffer.isBuffer(body)) {
     res.end(body)
-  } else if (isBlob(body)) {
-    // const blob = body as Blob
-    // const stream = blob.stream()
-    // if (stream.pipeTo) {
-    //   stream.pipeTo(res as any)
-    // } else {
-    //   ;(blob.stream() as any).pipe(res)
-    // }
-    throw new Error('Unknown response body (Blob)')
-  } else if (body && body.pipe) {
+  } else if (body && typeof (body as Readable).pipe === 'function') {
     body.on('error', (err) => res.destroy(err))
     body.pipe(res)
 
     // Note: for context about why this is necessary, check https://github.com/nodejs/node/issues/1180
-    // @ts-expect-error - body.pipe check ensures this is a Node.js Stream, not web ReadableStream
     onFinished(res, () => destroy(body))
   } else if (body !== undefined && body !== null) {
     throw new Error('Unknown response body')
@@ -97,7 +97,7 @@ export const getRequestFromNodeMessage = <T extends http.IncomingMessage & { ori
   request: T,
   host: string
 ): IHttpServerComponent.IRequest => {
-  const headers = new fetch.Headers()
+  const headers = new Headers()
 
   for (let key in request.headers) {
     if (request.headers.hasOwnProperty(key)) {
@@ -110,13 +110,17 @@ export const getRequestFromNodeMessage = <T extends http.IncomingMessage & { ori
     }
   }
 
-  const requestInit: fetch.RequestInit = {
-    headers: headers,
-    method: request.method!.toUpperCase()
+  const method = request.method!.toUpperCase()
+  const requestInit: RequestInit & { duplex?: 'half' } = {
+    headers,
+    method
   }
 
-  if (requestInit.method != 'GET' && requestInit.method != 'HEAD') {
-    requestInit.body = request
+  if (method != 'GET' && method != 'HEAD') {
+    // The native `Request` body must be a web `ReadableStream`. Adapt the incoming Node message
+    // stream; `duplex: 'half'` is required by the fetch spec when streaming a request body.
+    requestInit.body = Readable.toWeb(request) as unknown as ReadableStream
+    requestInit.duplex = 'half'
   }
 
   const protocol = headers.get('X-Forwarded-Proto') == 'https' ? 'https' : 'http'
@@ -130,7 +134,7 @@ export const getRequestFromNodeMessage = <T extends http.IncomingMessage & { ori
   try {
     url = new URL(originalUrl, baseUrl)
   } catch {}
-  const ret = new fetch.Request(url.toString(), requestInit)
+  const ret = new Request(url.toString(), requestInit)
 
   return ret
 }
@@ -154,23 +158,21 @@ export const coerceErrorsMiddleware: Middleware<any> = async (_, next) => {
 }
 
 function respondBuffer(
-  buffer: ArrayBuffer,
+  buffer: ArrayBuffer | Uint8Array | Buffer,
   response: IHttpServerComponent.IResponse,
-  mutableHeaders: fetch.Headers
-): fetch.Response {
+  mutableHeaders: Headers
+): NormalizedResponse {
   // TODO: test
-  mutableHeaders.set('Content-Length', buffer.byteLength.toFixed())
-  return new fetch.Response(buffer, {
-    ...(response as fetch.ResponseInit),
-    headers: mutableHeaders
-  })
+  const body = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer as ArrayBuffer)
+  mutableHeaders.set('Content-Length', body.byteLength.toFixed())
+  return { status: response.status, statusText: response.statusText, headers: mutableHeaders, body }
 }
 
 function respondJson(
   json: any,
   response: IHttpServerComponent.IResponse,
-  mutableHeaders: fetch.Headers
-): fetch.Response {
+  mutableHeaders: Headers
+): NormalizedResponse {
   // TODO: test
   if (!mutableHeaders.has('content-type')) {
     mutableHeaders.set('content-type', 'application/json')
@@ -181,8 +183,8 @@ function respondJson(
 function respondString(
   txt: string,
   response: IHttpServerComponent.IResponse,
-  mutableHeaders: fetch.Headers
-): fetch.Response {
+  mutableHeaders: Headers
+): NormalizedResponse {
   // TODO: test
   // TODO: accept encoding
   const returnEncoding = 'utf-8'
@@ -212,23 +214,27 @@ export async function defaultHandler(): Promise<IHttpServerComponent.IResponse> 
 export function normalizeResponseBody(
   request: IHttpServerComponent.IRequest,
   response: IHttpServerComponent.IResponse
-): fetch.Response {
+): NormalizedResponse {
   if (!response) {
     // Not Implemented
-    return new fetch.Response(undefined, { status: 501, statusText: 'Server did not produce a valid response' })
+    return { status: 501, statusText: 'Server did not produce a valid response', headers: new Headers() }
   }
 
   if (response.status == 101) {
     const cb = getWebSocketCallback(response)
-    return withWebSocketCallback(new fetch.Response(void 0, { ...response, body: undefined } as any), cb!)
+    return withWebSocketCallback(
+      { status: 101, headers: new Headers(response.headers as HeadersInit) } as NormalizedResponse,
+      cb!
+    )
   }
 
-  if (response instanceof fetch.Response) {
-    return new fetch.Response(response.body, {
-      headers: response.headers,
+  if (response instanceof Response) {
+    return {
       status: response.status,
-      statusText: response.statusText
-    })
+      statusText: response.statusText,
+      headers: new Headers(response.headers),
+      body: response.body ? (Readable.fromWeb(response.body as any) as Readable) : undefined
+    }
   }
 
   const is1xx = response.status && response.status >= 100 && response.status < 200
@@ -236,7 +242,7 @@ export function normalizeResponseBody(
   const is304 = response.status == 304
   const isHEAD = request.method == 'HEAD'
 
-  const mutableHeaders = new fetch.Headers(response.headers as fetch.HeadersInit)
+  const mutableHeaders = new Headers(response.headers as HeadersInit)
 
   if (is204 || is304) {
     // TODO: TEST this code path
@@ -249,7 +255,7 @@ export function normalizeResponseBody(
   // the following responses must not contain any content nor content-length
   if (is1xx || is204 || is304 || isHEAD) {
     // TODO: TEST this code path
-    return new fetch.Response(undefined, { ...response, headers: mutableHeaders, body: undefined } as any)
+    return { status: response.status, statusText: response.statusText, headers: mutableHeaders }
   }
 
   if (Buffer.isBuffer(response.body)) {
@@ -259,7 +265,12 @@ export function normalizeResponseBody(
   } else if (typeof response.body == 'string') {
     return respondString(response.body, response, mutableHeaders)
   } else if (response.body instanceof Stream) {
-    return new fetch.Response(response.body, response as fetch.ResponseInit)
+    return {
+      status: response.status,
+      statusText: response.statusText,
+      headers: mutableHeaders,
+      body: response.body as Readable
+    }
   } else if (response.body != undefined) {
     // TODO: test
     return respondJson(response.body, response, mutableHeaders)
@@ -272,7 +283,7 @@ export function normalizeResponseBody(
     mutableHeaders.set('content-length', '0')
   }
 
-  return new fetch.Response(undefined, { ...(response as fetch.ResponseInit), headers: mutableHeaders })
+  return { status: response.status, statusText: response.statusText, headers: mutableHeaders }
 }
 
 /**

--- a/components/http-server/src/logic.ts
+++ b/components/http-server/src/logic.ts
@@ -224,7 +224,7 @@ export function normalizeResponseBody(
     const cb = getWebSocketCallback(response)
     return withWebSocketCallback(
       { status: 101, headers: new Headers(response.headers as HeadersInit) } as NormalizedResponse,
-      cb!
+      cb
     )
   }
 
@@ -233,7 +233,7 @@ export function normalizeResponseBody(
       status: response.status,
       statusText: response.statusText,
       headers: new Headers(response.headers),
-      body: response.body ? (Readable.fromWeb(response.body as any) as Readable) : undefined
+      body: response.body && !response.bodyUsed ? (Readable.fromWeb(response.body as any) as Readable) : undefined
     }
   }
 
@@ -292,7 +292,7 @@ export function normalizeResponseBody(
 export function contextFromRequest<Ctx extends object>(baseCtx: Ctx, request: IHttpServerComponent.IRequest) {
   const newContext: IHttpServerComponent.DefaultContext<Ctx> = Object.create(baseCtx)
 
-  // hidrate context with the request
+  // hydrate context with the request
   newContext.request = request
   newContext.url = new URL(request.url)
 

--- a/components/http-server/src/methods.ts
+++ b/components/http-server/src/methods.ts
@@ -1,4 +1,4 @@
-import { IHttpServerComponent as http } from '@well-known-components/interfaces'
+import { IHttpServerComponent as http } from '@dcl/core-commons'
 
 export type MethodsMapType = {
   [key in http.HTTPMethod]: key

--- a/components/http-server/src/metrics.ts
+++ b/components/http-server/src/metrics.ts
@@ -1,4 +1,5 @@
-import { IConfigComponent, IHttpServerComponent, IMetricsComponent } from '@well-known-components/interfaces'
+import { IConfigComponent, IMetricsComponent } from '@well-known-components/interfaces'
+import { IHttpServerComponent } from '@dcl/core-commons'
 import { Router } from './router'
 
 const httpLabels = ['method', 'handler', 'code'] as const

--- a/components/http-server/src/middleware.ts
+++ b/components/http-server/src/middleware.ts
@@ -1,4 +1,5 @@
-import { IHttpServerComponent as http, IMiddlewareAdapterHandler } from '@well-known-components/interfaces'
+import { IMiddlewareAdapterHandler } from '@well-known-components/interfaces'
+import { IHttpServerComponent as http } from '@dcl/core-commons'
 
 /**
  * @public

--- a/components/http-server/src/middleware.ts
+++ b/components/http-server/src/middleware.ts
@@ -1,5 +1,5 @@
-import { IMiddlewareAdapterHandler } from '@well-known-components/interfaces'
-import { IHttpServerComponent as http } from '@dcl/core-commons'
+import type { IMiddlewareAdapterHandler } from '@well-known-components/interfaces'
+import type { IHttpServerComponent as http } from '@dcl/core-commons'
 
 /**
  * @public

--- a/components/http-server/src/router.ts
+++ b/components/http-server/src/router.ts
@@ -1,7 +1,7 @@
 import HttpError from 'http-errors'
 import { Layer, LayerOptions } from './layer'
 import { Key, pathToRegexp } from 'path-to-regexp'
-import type { IHttpServerComponent } from '@well-known-components/interfaces'
+import type { IHttpServerComponent } from '@dcl/core-commons'
 import { compose, Middleware } from './middleware'
 import { methodsList } from './methods'
 

--- a/components/http-server/src/server-handler.ts
+++ b/components/http-server/src/server-handler.ts
@@ -1,7 +1,6 @@
-import { contextFromRequest, defaultHandler, getDefaultMiddlewares, normalizeResponseBody } from './logic'
+import { contextFromRequest, defaultHandler, getDefaultMiddlewares, normalizeResponseBody, NormalizedResponse } from './logic'
 import { Middleware, compose } from './middleware'
-import * as fetch from 'node-fetch'
-import { IHttpServerComponent as http } from '@well-known-components/interfaces'
+import { IHttpServerComponent as http } from '@dcl/core-commons'
 
 // @internal
 export function createServerHandler<Context extends object>() {
@@ -25,7 +24,7 @@ export function createServerHandler<Context extends object>() {
     doMiddlewareComposition()
   }
 
-  async function processRequest(currentContext: Context, req: http.IRequest): Promise<fetch.Response> {
+  async function processRequest(currentContext: Context, req: http.IRequest): Promise<NormalizedResponse> {
     const ctx = contextFromRequest(currentContext, req)
     const res = await theFinalHandler(ctx, defaultHandler)
     return normalizeResponseBody(req, res)

--- a/components/http-server/src/server.ts
+++ b/components/http-server/src/server.ts
@@ -2,9 +2,9 @@ import {
   START_COMPONENT,
   STOP_COMPONENT,
   type IBaseComponent,
-  type IHttpServerComponent,
   type IStatusCheckCapableComponent
 } from '@well-known-components/interfaces'
+import type { IHttpServerComponent } from '@dcl/core-commons'
 import { _setUnderlyingServer } from './injectors'
 import { getServer, success, getRequestFromNodeMessage } from './logic'
 import type { ServerComponents, IHttpServerOptions } from './types'

--- a/components/http-server/src/status-checks.ts
+++ b/components/http-server/src/status-checks.ts
@@ -1,9 +1,5 @@
-import {
-  IBaseComponent,
-  IConfigComponent,
-  IHttpServerComponent,
-  IStatusCheckCapableComponent
-} from '@well-known-components/interfaces'
+import { IBaseComponent, IConfigComponent, IStatusCheckCapableComponent } from '@well-known-components/interfaces'
+import { IHttpServerComponent } from '@dcl/core-commons'
 import { Router } from './router'
 
 /**

--- a/components/http-server/src/test-component.ts
+++ b/components/http-server/src/test-component.ts
@@ -1,9 +1,41 @@
-import type { IHttpServerComponent } from '@well-known-components/interfaces'
-import * as fetch from 'node-fetch'
+import type { IFetchComponent, IHttpServerComponent } from '@dcl/core-commons'
 import { createServerHandler } from './server-handler'
-import { PassThrough, pipeline, Stream } from 'stream'
-import { IFetchComponent } from '@well-known-components/interfaces'
+import { NormalizedResponse } from './logic'
+import { PassThrough, pipeline, Readable } from 'stream'
 import type { WebSocket as WS } from 'ws'
+
+/**
+ * Converts the server's internal {@link NormalizedResponse} into a native `Response` for test callers.
+ *
+ * Informational statuses (e.g. `101` from a WebSocket upgrade) cannot be represented by the native
+ * `Response` constructor (it only accepts 200–599), so we build a placeholder and shadow `status` to
+ * preserve the value tests assert on.
+ */
+function toFetchResponse(res: NormalizedResponse): Response {
+  const status = res.status ?? 200
+  const isNullBodyStatus = status === 204 || status === 205 || status === 304
+  let body: BodyInit | null = null
+  if (status >= 200 && !isNullBodyStatus && res.body != null) {
+    if (Buffer.isBuffer(res.body)) {
+      body = res.body
+    } else {
+      // Node Readable -> web stream. Decouple via PassThrough (parity with a socket-backed body) and
+      // route through `pipeline` so a source error destroys the PassThrough and surfaces to the body
+      // reader instead of becoming an unhandled error.
+      const passthrough = new PassThrough()
+      pipeline(res.body, passthrough, () => undefined)
+      body = Readable.toWeb(passthrough) as unknown as ReadableStream
+    }
+  }
+
+  if (status < 200) {
+    const response = new Response(null, { statusText: res.statusText, headers: res.headers })
+    Object.defineProperty(response, 'status', { value: status, configurable: true })
+    return response
+  }
+
+  return new Response(body, { status, statusText: res.statusText, headers: res.headers })
+}
 
 /** @alpha */
 export type IWebSocketComponent<W = WS> = {
@@ -34,36 +66,36 @@ export function createTestServerComponent<Context extends object = {}>(): ITestH
 
   const ret: ITestHttpServerComponent<Context> = {
     async fetch(url: any, initRequest?: any) {
-      let req: fetch.Request
+      let req: Request
 
-      if (url instanceof fetch.Request) {
+      if (url instanceof Request) {
         req = url
       } else {
-        const tempHeaders = new fetch.Headers(initRequest?.headers)
+        const tempHeaders = new Headers(initRequest?.headers)
         const hostname = tempHeaders.get('X-Forwarded-Host') || tempHeaders.get('host') || '0.0.0.0'
         const protocol = tempHeaders.get('X-Forwarded-Proto') == 'https' ? 'https' : 'http'
         let newUrl = new URL(protocol + '://' + hostname + url)
         try {
           newUrl = new URL(url, protocol + '://' + hostname)
         } catch {}
-        req = new fetch.Request(newUrl.toString(), initRequest)
+
+        let init = initRequest
+        // The native `Request` constructor doesn't understand the `form-data` package (it would set a
+        // `text/plain` body). Serialize it to a buffer and merge its multipart headers, the way
+        // node-fetch used to, so multipart requests keep working against the in-memory test server.
+        const maybeForm = initRequest?.body
+        if (maybeForm && typeof maybeForm.getHeaders === 'function' && typeof maybeForm.getBuffer === 'function') {
+          init = { ...initRequest, body: maybeForm.getBuffer(), headers: { ...maybeForm.getHeaders(), ...initRequest.headers } }
+        }
+        req = new Request(newUrl.toString(), init)
       }
 
       try {
         const res = await serverHandler.processRequest(currentContext, req)
-        if (res.body instanceof Stream) {
-          // since we have no server and actual socket pipes, what we receive here
-          // is a readable stream that needs to be decoupled from it's original
-          // stream to ensure a consistent behavior with real servers
-          return new Promise<fetch.Response>((resolve, reject) => {
-            resolve(new fetch.Response(pipeline(res.body!, new PassThrough(), reject), res))
-          })
-        }
-
-        return res
+        return toFetchResponse(res)
       } catch (error: any) {
         console.error(error)
-        return new fetch.Response('DEV-SERVER-ERROR: ' + (error.stack || error.toString()), { status: 500 })
+        return new Response('DEV-SERVER-ERROR: ' + (error.stack || error.toString()), { status: 500 })
       }
     },
     use: serverHandler.use,

--- a/components/http-server/src/test-server.ts
+++ b/components/http-server/src/test-server.ts
@@ -1,8 +1,9 @@
 import { createConfigComponent } from '@well-known-components/env-config-provider'
-import { IConfigComponent, IHttpServerComponent, ILoggerComponent } from '@well-known-components/interfaces'
+import { IConfigComponent, ILoggerComponent } from '@well-known-components/interfaces'
+import { IHttpServerComponent } from '@dcl/core-commons'
 import { createLogComponent } from '@well-known-components/logger'
 import { defaultServerConfig } from '@well-known-components/test-helpers'
-import { Headers } from 'node-fetch'
+// `Headers` is the native (undici) global provided by Node.
 import { Readable } from 'stream'
 import { createServerComponent, Router } from '.'
 

--- a/components/http-server/src/ws.ts
+++ b/components/http-server/src/ws.ts
@@ -22,7 +22,7 @@ export function upgradeWebSocketResponse(cb: WebSocketCallback): IHttpServerComp
  * @internal
  * @deprecated Not stable
  */
-export function withWebSocketCallback<T extends object>(obj: T, cb: WebSocketCallback): T {
+export function withWebSocketCallback<T extends object>(obj: T, cb: WebSocketCallback | null): T {
   ;(obj as any)[wsSymbol] = cb
   return obj
 }

--- a/components/http-server/src/ws.ts
+++ b/components/http-server/src/ws.ts
@@ -1,4 +1,4 @@
-import { IHttpServerComponent } from '@well-known-components/interfaces'
+import { IHttpServerComponent } from '@dcl/core-commons'
 import type { WebSocket as WS } from 'ws'
 
 const wsSymbol = Symbol('WebSocketResponse')

--- a/components/http-server/test/busboy.ts
+++ b/components/http-server/test/busboy.ts
@@ -1,4 +1,4 @@
-import { IHttpServerComponent } from '@well-known-components/interfaces'
+import { IHttpServerComponent } from '@dcl/core-commons'
 import busboy, { FieldInfo, FileInfo } from 'busboy'
 import { Readable } from 'stream'
 
@@ -63,7 +63,12 @@ export function multipartParserWrapper<Ctx extends FormDataContext, T extends IH
       })
     })
 
-    ctx.request.body.pipe(formDataParser)
+    // The native `Request` body is a web `ReadableStream`; adapt it to a Node stream to pipe to busboy.
+    if (ctx.request.body) {
+      Readable.fromWeb(ctx.request.body as unknown as Parameters<typeof Readable.fromWeb>[0]).pipe(formDataParser)
+    } else {
+      formDataParser.end()
+    }
 
     const newContext: Ctx = Object.assign(Object.create(ctx), { formData: { fields, files } })
 

--- a/components/http-server/test/cors.spec.ts
+++ b/components/http-server/test/cors.spec.ts
@@ -1,0 +1,219 @@
+import { corsHeaders, createCorsMiddleware, handleOptions } from '../src/cors'
+import { IHttpServerComponent } from '@dcl/core-commons'
+
+function contextForRequest(request: Request): IHttpServerComponent.DefaultContext {
+  return { request, url: new URL(request.url) } as IHttpServerComponent.DefaultContext
+}
+
+describe('when handling a request through the CORS middleware', () => {
+  let next: jest.MockedFunction<() => Promise<IHttpServerComponent.IResponse>>
+
+  beforeEach(() => {
+    next = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('and it is an OPTIONS preflight while preflightContinue is disabled', () => {
+    let handler: IHttpServerComponent.IRequestHandler<{}>
+    let context: IHttpServerComponent.DefaultContext
+
+    beforeEach(() => {
+      handler = createCorsMiddleware<{}>({ origin: '*', methods: ['GET', 'POST'], maxAge: 600 })
+      context = contextForRequest(
+        new Request('http://localhost/resource', { method: 'OPTIONS', headers: { origin: 'http://example.com' } })
+      )
+    })
+
+    it('should respond with the default 204 success status', async () => {
+      const response = await handler(context, next)
+      expect(response.status).toBe(204)
+    })
+
+    it('should not delegate to the next handler', async () => {
+      await handler(context, next)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('should allow the configured methods', async () => {
+      const response = await handler(context, next)
+      expect((response.headers as Headers).get('Access-Control-Allow-Methods')).toBe('GET,POST')
+    })
+
+    it('should advertise the configured max age', async () => {
+      const response = await handler(context, next)
+      expect((response.headers as Headers).get('Access-Control-Max-Age')).toBe('600')
+    })
+  })
+
+  describe('and it is an OPTIONS preflight while preflightContinue is enabled', () => {
+    let handler: IHttpServerComponent.IRequestHandler<{}>
+    let context: IHttpServerComponent.DefaultContext
+
+    beforeEach(() => {
+      handler = createCorsMiddleware<{}>({ preflightContinue: true })
+      context = contextForRequest(new Request('http://localhost/resource', { method: 'OPTIONS' }))
+      next.mockResolvedValueOnce({ status: 200 })
+    })
+
+    it('should delegate to the next handler', async () => {
+      await handler(context, next)
+      expect(next).toHaveBeenCalled()
+    })
+  })
+
+  describe('and it is a non-OPTIONS request carrying an Origin header', () => {
+    let handler: IHttpServerComponent.IRequestHandler<{}>
+    let context: IHttpServerComponent.DefaultContext
+
+    beforeEach(() => {
+      handler = createCorsMiddleware<{}>({ origin: '*', credentials: true })
+      context = contextForRequest(
+        new Request('http://localhost/data', { method: 'GET', headers: { origin: 'http://example.com' } })
+      )
+      next.mockResolvedValueOnce({ status: 201, headers: new Headers({ 'content-type': 'application/json' }) })
+    })
+
+    it('should delegate to the next handler', async () => {
+      await handler(context, next)
+      expect(next).toHaveBeenCalled()
+    })
+
+    it('should preserve the status returned by the next handler', async () => {
+      const response = await handler(context, next)
+      expect(response.status).toBe(201)
+    })
+
+    it('should allow the requesting origin', async () => {
+      const response = await handler(context, next)
+      expect((response.headers as Headers).get('Access-Control-Allow-Origin')).toBe('*')
+    })
+
+    it('should allow credentials when configured', async () => {
+      const response = await handler(context, next)
+      expect((response.headers as Headers).get('Access-Control-Allow-Credentials')).toBe('true')
+    })
+  })
+})
+
+describe('when resolving the allowed origin for an actual request', () => {
+  let next: jest.MockedFunction<() => Promise<IHttpServerComponent.IResponse>>
+
+  beforeEach(() => {
+    next = jest.fn()
+    next.mockResolvedValue({ status: 200, headers: new Headers() })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('and the origin is configured as a fixed string', () => {
+    let handler: IHttpServerComponent.IRequestHandler<{}>
+    let context: IHttpServerComponent.DefaultContext
+
+    beforeEach(() => {
+      handler = createCorsMiddleware<{}>({ origin: 'http://allowed.example' })
+      context = contextForRequest(
+        new Request('http://localhost/', { headers: { origin: 'http://allowed.example' } })
+      )
+    })
+
+    it('should echo the configured origin', async () => {
+      const response = await handler(context, next)
+      expect((response.headers as Headers).get('Access-Control-Allow-Origin')).toBe('http://allowed.example')
+    })
+  })
+
+  describe('and the origin is in the configured allow-list', () => {
+    let handler: IHttpServerComponent.IRequestHandler<{}>
+    let context: IHttpServerComponent.DefaultContext
+
+    beforeEach(() => {
+      handler = createCorsMiddleware<{}>({ origin: ['http://a.example', /\.b\.example$/] })
+      context = contextForRequest(new Request('http://localhost/', { headers: { origin: 'http://a.example' } }))
+    })
+
+    it('should reflect the requesting origin', async () => {
+      const response = await handler(context, next)
+      expect((response.headers as Headers).get('Access-Control-Allow-Origin')).toBe('http://a.example')
+    })
+  })
+
+  describe('and the origin matches a configured pattern', () => {
+    let handler: IHttpServerComponent.IRequestHandler<{}>
+    let context: IHttpServerComponent.DefaultContext
+
+    beforeEach(() => {
+      handler = createCorsMiddleware<{}>({ origin: [/\.b\.example$/] })
+      context = contextForRequest(new Request('http://localhost/', { headers: { origin: 'http://sub.b.example' } }))
+    })
+
+    it('should reflect the requesting origin', async () => {
+      const response = await handler(context, next)
+      expect((response.headers as Headers).get('Access-Control-Allow-Origin')).toBe('http://sub.b.example')
+    })
+  })
+
+  describe('and the origin is not allowed', () => {
+    let handler: IHttpServerComponent.IRequestHandler<{}>
+    let context: IHttpServerComponent.DefaultContext
+
+    beforeEach(() => {
+      handler = createCorsMiddleware<{}>({ origin: ['http://a.example'] })
+      context = contextForRequest(new Request('http://localhost/', { headers: { origin: 'http://evil.example' } }))
+    })
+
+    it('should reject the requesting origin', async () => {
+      const response = await handler(context, next)
+      expect((response.headers as Headers).get('Access-Control-Allow-Origin')).toBe('false')
+    })
+  })
+
+  describe('and exposed headers are configured', () => {
+    let handler: IHttpServerComponent.IRequestHandler<{}>
+    let context: IHttpServerComponent.DefaultContext
+
+    beforeEach(() => {
+      handler = createCorsMiddleware<{}>({ origin: '*', exposedHeaders: ['ETag', 'X-Total'] })
+      context = contextForRequest(new Request('http://localhost/', { headers: { origin: 'http://x.example' } }))
+    })
+
+    it('should expose the configured headers', async () => {
+      const response = await handler(context, next)
+      expect((response.headers as Headers).get('Access-Control-Expose-Headers')).toBe('ETag,X-Total')
+    })
+  })
+})
+
+describe('when configuring allowed headers on a preflight request', () => {
+  let next: jest.MockedFunction<() => Promise<IHttpServerComponent.IResponse>>
+  let handler: IHttpServerComponent.IRequestHandler<{}>
+  let context: IHttpServerComponent.DefaultContext
+
+  beforeEach(() => {
+    next = jest.fn()
+    handler = createCorsMiddleware<{}>({ origin: '*', allowedHeaders: ['X-Custom', 'X-Other'] })
+    context = contextForRequest(
+      new Request('http://localhost/', { method: 'OPTIONS', headers: { origin: 'http://x.example' } })
+    )
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should allow the configured request headers', async () => {
+    const response = await handler(context, next)
+    expect((response.headers as Headers).get('Access-Control-Allow-Headers')).toBe('X-Custom,X-Other')
+  })
+})
+
+describe('when building an OPTIONS response directly', () => {
+  it('should carry the default permissive Access-Control-Allow-Origin header', () => {
+    const response = handleOptions()
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(corsHeaders['Access-Control-Allow-Origin'])
+  })
+})

--- a/components/http-server/test/logic.spec.ts
+++ b/components/http-server/test/logic.spec.ts
@@ -1,0 +1,80 @@
+import { getRequestFromNodeMessage, normalizeResponseBody, NormalizedResponse } from '../src/logic'
+import { Readable } from 'stream'
+
+describe('when normalizing a handler response that is already a native Response', () => {
+  let request: Request
+  let normalized: NormalizedResponse
+
+  describe('and the Response has a body', () => {
+    beforeEach(() => {
+      request = new Request('http://localhost/resource', { method: 'GET' })
+      normalized = normalizeResponseBody(
+        request,
+        new Response('hello body', { status: 418, headers: { 'x-test': 'yes' } }) as any
+      )
+    })
+
+    it('should carry over the status code', () => {
+      expect(normalized.status).toBe(418)
+    })
+
+    it('should carry over the response headers', () => {
+      expect(normalized.headers.get('x-test')).toBe('yes')
+    })
+
+    it('should expose the body as a Node Readable', () => {
+      expect(normalized.body).toBeInstanceOf(Readable)
+    })
+
+    it('should preserve the body contents', async () => {
+      const chunks: Buffer[] = []
+      for await (const chunk of normalized.body as Readable) {
+        chunks.push(Buffer.from(chunk))
+      }
+      expect(Buffer.concat(chunks).toString()).toBe('hello body')
+    })
+  })
+
+  describe('and the Response has no body', () => {
+    beforeEach(() => {
+      request = new Request('http://localhost/resource', { method: 'GET' })
+      normalized = normalizeResponseBody(request, new Response(null, { status: 204 }) as any)
+    })
+
+    it('should leave the normalized body undefined', () => {
+      expect(normalized.body).toBeUndefined()
+    })
+  })
+})
+
+describe('when building a request from a Node message', () => {
+  describe('and a header carries multiple values', () => {
+    let nodeMessage: any
+
+    beforeEach(() => {
+      nodeMessage = { method: 'GET', url: '/resource', headers: { 'x-multi': ['one', 'two'] } }
+    })
+
+    it('should append every value into the request headers', () => {
+      const request = getRequestFromNodeMessage(nodeMessage, '0.0.0.0')
+      expect(request.headers.get('x-multi')).toBe('one, two')
+    })
+  })
+
+  describe('and the request method allows a body', () => {
+    let nodeMessage: any
+
+    beforeEach(() => {
+      nodeMessage = Object.assign(Readable.from([Buffer.from('payload')]), {
+        method: 'POST',
+        url: '/resource',
+        headers: {}
+      })
+    })
+
+    it('should attach a streaming request body', () => {
+      const request = getRequestFromNodeMessage(nodeMessage, '0.0.0.0')
+      expect(request.body).not.toBeNull()
+    })
+  })
+})

--- a/components/http-server/test/router.spec.ts
+++ b/components/http-server/test/router.spec.ts
@@ -7,7 +7,7 @@ import path from 'path'
 import { createTestServerComponent, Router } from '../src'
 import { Layer } from '../src/layer'
 import { methodsList } from '../src/methods'
-import { IHttpServerComponent } from '@well-known-components/interfaces'
+import { IHttpServerComponent } from '@dcl/core-commons'
 const methods: Lowercase<IHttpServerComponent.HTTPMethod>[] = methodsList.map(($) => $.toLowerCase()) as any
 
 describe('Router', function () {

--- a/components/http-server/test/test-helpers.ts
+++ b/components/http-server/test/test-helpers.ts
@@ -1,11 +1,10 @@
 import {
   IBaseComponent,
   IConfigComponent,
-  IHttpServerComponent,
   ILoggerComponent,
   IStatusCheckCapableComponent
 } from '@well-known-components/interfaces'
-import { IFetchComponent } from '@dcl/core-commons'
+import { IFetchComponent, IHttpServerComponent } from '@dcl/core-commons'
 import { IWebSocketComponent } from '../src'
 import wsLib from 'ws'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
 
   components/http-server:
     dependencies:
+      '@dcl/core-commons':
+        specifier: workspace:*
+        version: link:../../shared/commons
       '@types/http-errors':
         specifier: ^2.0.4
         version: 2.0.5
@@ -92,9 +95,6 @@ importers:
       mitt:
         specifier: ^3.0.0
         version: 3.0.1
-      node-fetch:
-        specifier: ^2.6.9
-        version: 2.7.0
       on-finished:
         specifier: ^2.4.1
         version: 2.4.1
@@ -105,9 +105,6 @@ importers:
         specifier: ^0.2.2
         version: 0.2.2
     devDependencies:
-      '@dcl/core-commons':
-        specifier: workspace:*
-        version: link:../../shared/commons
       '@jest/test-sequencer':
         specifier: ^30.0.2
         version: 30.0.2
@@ -153,6 +150,9 @@ importers:
       jest:
         specifier: ^30.0.2
         version: 30.0.2(@types/node@20.19.1)
+      node-fetch:
+        specifier: ^2.6.9
+        version: 2.7.0
       ts-jest:
         specifier: ^29.4.0
         version: 29.4.0(@babel/core@7.27.4)(@jest/transform@30.0.2)(@jest/types@30.2.0)(babel-jest@30.0.2(@babel/core@7.27.4))(jest-util@30.2.0)(jest@30.0.2(@types/node@20.19.1))(typescript@5.8.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,9 +80,9 @@ importers:
       '@dcl/core-commons':
         specifier: workspace:*
         version: link:../../shared/commons
-      '@types/http-errors':
-        specifier: ^2.0.4
-        version: 2.0.5
+      '@well-known-components/interfaces':
+        specifier: ^1.5.1
+        version: 1.5.2
       destroy:
         specifier: ^1.2.0
         version: 1.2.0
@@ -114,6 +114,9 @@ importers:
       '@types/destroy':
         specifier: ^1.0.0
         version: 1.0.3
+      '@types/http-errors':
+        specifier: ^2.0.4
+        version: 2.0.5
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -132,9 +135,6 @@ importers:
       '@well-known-components/env-config-provider':
         specifier: ^1.1.1
         version: 1.2.0(@well-known-components/interfaces@1.5.2)
-      '@well-known-components/interfaces':
-        specifier: ^1.5.1
-        version: 1.5.2
       '@well-known-components/logger':
         specifier: ^3.1.2
         version: 3.1.3(@well-known-components/interfaces@1.5.2)

--- a/shared/commons/src/types.ts
+++ b/shared/commons/src/types.ts
@@ -1,8 +1,95 @@
 // Shared types for core components
-import { IBaseComponent } from '@well-known-components/interfaces'
+import type * as stream from 'stream'
+import {
+  IBaseComponent,
+  IMiddlewareAdapterHandler,
+  IHttpServerComponent as WkcHttpServerComponent
+} from '@well-known-components/interfaces'
 
 export interface ASharedType {
   a: string
+}
+
+// HTTP server component types
+//
+// This mirrors `@well-known-components/interfaces`' `IHttpServerComponent` but binds the
+// request/response types to the **native Node `fetch` API** (`Request`/`Response`/`ResponseInit`
+// provided by `@types/node`) instead of `node-fetch`. Consumers (e.g. `@dcl/http-server`) can
+// therefore implement the component without depending on `node-fetch`. `ParseUrlParams` and
+// `IMiddlewareAdapterHandler` are pure type-level helpers re-used from the interfaces package
+// (they carry no `node-fetch` coupling).
+
+/**
+ * @public
+ */
+export namespace IHttpServerComponent {
+  export type JsonBody = Record<string, any>
+  export type ResponseBody = JsonBody | stream.Readable | Uint8Array | Buffer | string
+  export type QueryParams = Record<string, any>
+  export type UrlParams = Record<string, string | string[]>
+
+  /** The incoming request. This is the global (undici) `Request` shipped with Node, not `node-fetch`. */
+  export type IRequest = Request
+
+  /** A handler response. `ResponseInit` is the global (undici) type shipped with Node. */
+  export type IResponse = ResponseInit & {
+    body?: ResponseBody
+  }
+
+  export type DefaultContext<Context = {}> = Context & {
+    request: IRequest
+    url: URL
+  }
+
+  export type PathAwareContext<Context = {}, Path extends string = string> = Context & {
+    params: string extends Path ? any : IHttpServerComponent.ParseUrlParams<Path>
+  }
+
+  export type IRequestHandler<Context = {}> = IMiddlewareAdapterHandler<DefaultContext<Context>, IResponse>
+
+  export type ParseUrlParams<State extends string, Memo extends Record<string, any> = {}> =
+    WkcHttpServerComponent.ParseUrlParams<State, Memo>
+
+  /**
+   * HTTP request methods.
+   * @public
+   */
+  export type HTTPMethod =
+    | 'CONNECT'
+    | 'DELETE'
+    | 'GET'
+    | 'HEAD'
+    | 'OPTIONS'
+    | 'PATCH'
+    | 'POST'
+    | 'PUT'
+    | 'TRACE'
+
+  export interface PathAwareHandler<Context> {
+    <Path extends string>(
+      path: Path,
+      handler: IHttpServerComponent.IRequestHandler<PathAwareContext<Context, Path>>
+    ): void
+  }
+
+  export type MethodHandlers<Context> = {
+    [key in Lowercase<HTTPMethod>]: PathAwareHandler<Context>
+  }
+}
+
+/**
+ * @public
+ */
+export interface IHttpServerComponent<Context extends object> {
+  /**
+   * Register a route handler.
+   */
+  use: (handler: IHttpServerComponent.IRequestHandler<Context>) => void
+  /**
+   * Sets a context to be passed on to the handlers. The original context should
+   * remain untouched after handler execution.
+   */
+  setContext(ctx: Context): void
 }
 
 // Fetch component types


### PR DESCRIPTION
## What

Removes the `node-fetch` **runtime** dependency from `@dcl/http-server` by moving its request/response pipeline onto the native Node `fetch` API (undici globals).

## Why

`@dcl/http-server`'s public contract typed `IHttpServerComponent.IRequest` as `node-fetch`'s `Request` (via `@well-known-components/interfaces`), which forced the server to construct `node-fetch` objects at runtime and kept `node-fetch` in the dependency tree of every consumer. Since the supported runtime is Node 18+, the native `fetch`/`Request`/`Response` are always available and `node-fetch` is redundant.

## Changes

- **`@dcl/core-commons`** now exports an `IHttpServerComponent` whose `IRequest`/`IResponse` are bound to the global (undici) `Request`/`Response`/`ResponseInit` instead of `node-fetch`. `ParseUrlParams` / `IMiddlewareAdapterHandler` are re-used from `@well-known-components/interfaces` as pure type-level helpers (no `node-fetch` coupling).
- **`@dcl/http-server`** builds requests/responses with the native types and sources `IHttpServerComponent` from `@dcl/core-commons`. Internally it normalizes a handler response into a plain transport object that preserves `Buffer`/Node-stream bodies and informational statuses such as `101` (WebSocket upgrade) — the native `Response` constructor can represent neither a streamed body nor a 1xx status. The incoming Node request stream is adapted to the native `Request` body via `Readable.toWeb(...)`.
- `node-fetch` moves to `devDependencies` (used only by the test HTTP clients); `@dcl/core-commons` becomes a runtime dependency (its types are part of the public `.d.ts`).

## Breaking change

`IHttpServerComponent.IRequest` is now the native `Request`, so `request.body` is a web `ReadableStream` rather than a Node `Readable`. Consumers that piped the request body must adapt it:

```ts
// before
ctx.request.body.pipe(parser)
// after
Readable.fromWeb(ctx.request.body).pipe(parser)
```

The bundled `multipartParserWrapper` test helper has been updated to show the pattern.

## Testing

- `@dcl/core-commons` and `@dcl/http-server` type-check cleanly.
- Full `@dcl/http-server` test suite passes: **6 suites, 281 passed, 5 skipped** — including the e2e suites that exercise both `undici` and `node-fetch` clients, WebSocket upgrades (status 101), streaming responses, and multipart form-data parsing.
