### PR TITLE
fix: restore @dcl/metrics install and http-server metrics middleware after v2

### DIFF
--- a/.changeset/http-server-metrics-request-size.md
+++ b/.changeset/http-server-metrics-request-size.md
@@ -1,0 +1,5 @@
+---
+"@dcl/http-server": patch
+---
+
+fix the HTTP metrics middleware: derive the request size from the `Content-Length` header instead of the non-standard `node-fetch` `Request.size` property. After the native-fetch migration that property is `undefined` on the native `Request`, which made `prom-client` throw `Value is not a valid number` and return a `500` on every instrumented request.

--- a/.changeset/http-server-multiple-set-cookie.md
+++ b/.changeset/http-server-multiple-set-cookie.md
@@ -1,0 +1,5 @@
+---
+"@dcl/http-server": patch
+---
+
+fix multiple `Set-Cookie` response headers being collapsed to the last one. The response writer set each header with `res.setHeader('set-cookie', value)`, which overwrites by header name, so only the final cookie survived. Set-Cookie values are now emitted as an array (one `Set-Cookie` header per cookie).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        # Pinned by commit SHA (tags are mutable). Bump deliberately when reviewing a new release.
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -22,7 +23,8 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup node.js
-        uses: actions/setup-node@v4
+        # Pinned by commit SHA (tags are mutable). Bump deliberately when reviewing a new release.
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: 'pnpm'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,6 +63,12 @@ jobs:
         with:
           title: 'chore: version packages'
           commit: 'chore: version packages [skip ci]'
+          # `version-packages` runs `changeset version` AND refreshes the lockfile
+          # (`pnpm install --lockfile-only`). Without the refresh the bumped package.json
+          # files and pnpm-lock.yaml drift apart, and the next `pnpm install --frozen-lockfile`
+          # (CI default) fails with ERR_PNPM_OUTDATED_LOCKFILE. The action commits the updated
+          # lockfile alongside the version bumps into the "Version Packages" PR.
+          version: pnpm version-packages
           publish: pnpm ci:publish
           createGithubReleases: true
           commitMode: 'github-api'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,8 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        # Pinned by commit SHA (tags are mutable). Bump deliberately when reviewing a new release.
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup pnpm
         # Pinned to v6.0.8 by commit SHA. Tags on third-party actions are
@@ -30,7 +31,8 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup node.js
-        uses: actions/setup-node@v4
+        # Pinned by commit SHA (tags are mutable). Bump deliberately when reviewing a new release.
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: 'pnpm'
@@ -56,10 +58,10 @@ jobs:
 
       - name: Create Release Pull Request or Publish
         id: changesets
-        # Pinned to v1.8.0 by commit SHA. Tags on third-party actions are
+        # Pinned to v1.9.0 by commit SHA. Tags on third-party actions are
         # mutable; a SHA is not. Bump deliberately when reviewing a new
         # release rather than tracking a floating tag.
-        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           title: 'chore: version packages'
           commit: 'chore: version packages [skip ci]'

--- a/components/http-server/src/logic.ts
+++ b/components/http-server/src/logic.ts
@@ -66,10 +66,19 @@ export function success(data: NormalizedResponse, res: http.ServerResponse) {
   if (data.status) res.statusCode = data.status
 
   data.headers.forEach((value: string, key: string) => {
-    if (value !== undefined) {
+    // Set-Cookie is handled separately below. Multiple cookies must be emitted as distinct
+    // `Set-Cookie` headers; setting them one-by-one here would overwrite (res.setHeader replaces
+    // by name) and leave only the last cookie.
+    if (key !== 'set-cookie') {
       res.setHeader(key, value)
     }
   })
+
+  // `res.setHeader` accepts an array, which Node serializes as one `Set-Cookie` header per element.
+  const setCookies = typeof data.headers.getSetCookie === 'function' ? data.headers.getSetCookie() : []
+  if (setCookies.length > 0) {
+    res.setHeader('set-cookie', setCookies)
+  }
 
   const body = data.body
 

--- a/components/http-server/src/metrics.ts
+++ b/components/http-server/src/metrics.ts
@@ -121,7 +121,11 @@ export async function instrumentHttpServerWithPromClientRegistry<K extends strin
         labels.handler = (ctx as any).routerPath
       }
 
-      options.metrics.observe('http_request_size_bytes', labels, ctx.request.size)
+      // Derive the request size from the Content-Length header. The previous `ctx.request.size`
+      // relied on a non-standard `node-fetch` Request property that does not exist on the native
+      // `Request`, which made prom-client throw on every request ("Value is not a valid number").
+      const requestSize = Number(ctx.request.headers.get('content-length')) || 0
+      options.metrics.observe('http_request_size_bytes', labels, requestSize)
       options.metrics.increment('http_requests_total', labels)
       end(labels)
     }

--- a/components/http-server/test/integration.spec.ts
+++ b/components/http-server/test/integration.spec.ts
@@ -8,6 +8,7 @@ import FormData from 'form-data'
 import * as undici from 'undici'
 import nodeFetch from 'node-fetch'
 import { multipartParserWrapper } from './busboy'
+import { createCorsMiddleware } from '../src/cors'
 
 describeE2E('integration sanity tests using http backend', integrationSuite)
 describeTestE2E('integration sanity tests using test server', integrationSuite)
@@ -326,6 +327,31 @@ function integrationSuite({ components }: { components: TestComponents }) {
         }
       })
     }
+  })
+
+  it('handles a CORS preflight (OPTIONS) request', async () => {
+    const { fetch, server } = components
+    server.resetMiddlewares()
+    server.use(createCorsMiddleware({ origin: '*', methods: ['GET', 'POST'] }))
+
+    const res = await fetch.fetch(`/any-resource`, { method: 'OPTIONS' })
+    expect(res.status).toEqual(204)
+    expect(res.headers.get('access-control-allow-origin')).toEqual('*')
+  })
+
+  it('responds without hanging when the handler ignores the request body', async () => {
+    const { fetch, server } = components
+    server.resetMiddlewares()
+
+    const routes = new Router()
+    // Handler never reads ctx.request.body; the server must still respond (Node drains the
+    // unconsumed body). Guards the eager `Readable.toWeb(req)` body adaptation against hangs.
+    routes.post('/ignore-body', async () => ({ status: 200, body: 'handled' }))
+    server.use(routes.middleware())
+
+    const res = await fetch.fetch(`/ignore-body`, { method: 'POST', body: 'x'.repeat(4096) })
+    expect(res.status).toEqual(200)
+    expect(await res.text()).toEqual('handled')
   })
 
   it('unknown route should yield 404', async () => {

--- a/components/http-server/test/logic.spec.ts
+++ b/components/http-server/test/logic.spec.ts
@@ -1,4 +1,5 @@
-import { getRequestFromNodeMessage, normalizeResponseBody, NormalizedResponse } from '../src/logic'
+import { getRequestFromNodeMessage, normalizeResponseBody, NormalizedResponse, success } from '../src/logic'
+import type { ServerResponse } from 'http'
 import { Readable } from 'stream'
 
 describe('when normalizing a handler response that is already a native Response', () => {
@@ -44,6 +45,26 @@ describe('when normalizing a handler response that is already a native Response'
     it('should leave the normalized body undefined', () => {
       expect(normalized.body).toBeUndefined()
     })
+  })
+})
+
+describe('when writing a successful response with multiple Set-Cookie headers', () => {
+  let res: { statusCode?: number; statusMessage?: string; setHeader: jest.Mock; end: jest.Mock }
+
+  beforeEach(() => {
+    res = { setHeader: jest.fn(), end: jest.fn() }
+    const headers = new Headers()
+    headers.append('set-cookie', 'a=1; Path=/')
+    headers.append('set-cookie', 'b=2; Path=/')
+    success({ status: 200, headers }, res as unknown as ServerResponse)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should emit every cookie as a single array-valued Set-Cookie header', () => {
+    expect(res.setHeader).toHaveBeenCalledWith('set-cookie', ['a=1; Path=/', 'b=2; Path=/'])
   })
 })
 

--- a/components/metrics/package.json
+++ b/components/metrics/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@dcl/core-commons": "workspace:*",
-    "@dcl/http-server": "^2.0.0",
+    "@dcl/http-server": "workspace:*",
     "@types/node-fetch": "^2.6.12",
     "@well-known-components/env-config-provider": "^1.1.0",
     "@well-known-components/interfaces": "^1.4.3",

--- a/components/metrics/test/harness/test-helpers.ts
+++ b/components/metrics/test/harness/test-helpers.ts
@@ -1,10 +1,5 @@
-import {
-  IConfigComponent,
-  IHttpServerComponent,
-  ILoggerComponent,
-  IMetricsComponent
-} from "@well-known-components/interfaces"
-import { IFetchComponent } from "@dcl/core-commons"
+import { IConfigComponent, ILoggerComponent, IMetricsComponent } from "@well-known-components/interfaces"
+import { IFetchComponent, IHttpServerComponent } from "@dcl/core-commons"
 import { metricDeclarations } from "./defaultMetrics"
 
 export type TestComponents = {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "pnpm -r lint",
     "clean": "pnpm -r clean",
     "changeset": "changeset",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && pnpm install --no-frozen-lockfile --lockfile-only",
     "release": "pnpm build && changeset publish"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,8 +228,8 @@ importers:
         specifier: workspace:*
         version: link:../../shared/commons
       '@dcl/http-server':
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: workspace:*
+        version: link:../http-server
       '@types/node-fetch':
         specifier: ^2.6.12
         version: 2.6.12
@@ -1043,9 +1043,6 @@ packages:
 
   '@dcl/eslint-config@2.2.1':
     resolution: {integrity: sha512-9GBeC0+bzfAHsCtXGqgx5UnQDAzCym5lQGt0hysx3yNNcujcWswFaBU1iPMfp58qRFJangLonZmoP80SM3AMgg==}
-
-  '@dcl/http-server@1.0.0':
-    resolution: {integrity: sha512-Dq7hjrOfwUY2VztmZlk70OwOFkwiLO360BgJw4h2BFfYc0RACmw7TFI/uq/nHMJPNSs2Zi1htzuWQQsPAg1RQw==}
 
   '@dcl/schemas@26.1.0':
     resolution: {integrity: sha512-BrtZm/BNEpDde1U5yCfbRsp8IMajYiThNj5QCgilXCcqO2JYB6RL5FZj+9KRZPyW+/zzeYgLVDAnn/eiSW6dmA==}
@@ -6122,20 +6119,6 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
       - typescript
-
-  '@dcl/http-server@1.0.0':
-    dependencies:
-      '@types/http-errors': 2.0.5
-      destroy: 1.2.0
-      fp-future: 1.0.1
-      http-errors: 2.0.1
-      mitt: 3.0.1
-      node-fetch: 2.7.0
-      on-finished: 2.4.1
-      path-to-regexp: 6.3.0
-      reflect-metadata: 0.2.2
-    transitivePeerDependencies:
-      - encoding
 
   '@dcl/schemas@26.1.0':
     dependencies:


### PR DESCRIPTION
## What

Fixes the `ERR_PNPM_OUTDATED_LOCKFILE` failure on `main` and the `@dcl/metrics` breakage that surfaced after the `@dcl/http-server` v2 release (#106 + version-packages PR #107), and prevents the lockfile drift from recurring on future releases.

## Why it broke

`@dcl/http-server` was majored to `2.0.0`. Three things fell out of that:

1. **Lockfile (the reported error).** `@dcl/metrics` referenced `@dcl/http-server` from the **registry** via a caret range (unlike its `@dcl/core-commons` reference, which uses `workspace:*`). The version-packages step bumped that range to `^2.0.0`, but `2.0.0` isn't published and the lockfile wasn't regenerated — so `pnpm install --frozen-lockfile` fails with `specifiers in the lockfile don't match … @dcl/http-server (lockfile: ^1.0.0, manifest: ^2.0.0)`.
2. **Harness types.** The metrics test harness typed its `server` against `@well-known-components/interfaces`, which no longer matches http-server's native-fetch `IHttpServerComponent` (the e2e suites failed to compile).
3. **Runtime regression in the metrics middleware.** `instrumentHttpServerWithPromClientRegistry` observed `ctx.request.size` — a non-standard `node-fetch` `Request` property that is `undefined` on the native `Request` — so `prom-client` threw `Value is not a valid number` and returned **500 on every instrumented request**.

## Changes

- **`components/metrics/package.json`** — `@dcl/http-server` → `workspace:*` (links the local package, matching `@dcl/core-commons`), and regenerate `pnpm-lock.yaml`. `--frozen-lockfile` now passes.
- **`components/metrics/test/harness/test-helpers.ts`** — source `IHttpServerComponent` from `@dcl/core-commons`.
- **`components/http-server/src/metrics.ts`** — derive request size from the `Content-Length` header instead of `ctx.request.size`. Changeset: `@dcl/http-server` patch.
- **Prevention — `.github/workflows/publish.yml` + root `version-packages` script.** The changesets action's `version` step now runs `changeset version && pnpm install --no-frozen-lockfile --lockfile-only`, so the "Version Packages" PR commits a refreshed `pnpm-lock.yaml` alongside the version bumps. This is the root-cause fix for the drift — without it, every release that touches an internal dependency range would reproduce this failure.

## Testing

- `pnpm install --frozen-lockfile` ✅
- `@dcl/metrics`: **3 suites, 29 passed** (unit + both e2e harnesses now run against the local http-server@2.0.0; `/metrics` returns 200).
- `@dcl/http-server`: **8 suites, 304 passed** — no regression.
- `publish.yml` validated as well-formed YAML; the `--no-frozen-lockfile --lockfile-only` invocation verified locally (no-op against an up-to-date lockfile).

The metrics-middleware regression is now covered by `@dcl/metrics`'s e2e suites, which exercise `instrumentHttpServerWithPromClientRegistry` against the real server.


## CI hardening (follow-up commit)

Pinned every workflow action to an immutable commit SHA at its latest release (with the version in a trailing comment), so a moved tag can't silently change what runs in CI:

- `actions/checkout`: `@v4` → **v6.0.3**
- `actions/setup-node`: `@v4` → **v6.4.0**
- `changesets/action`: **v1.8.0 → v1.9.0**
- `pnpm/action-setup`: already pinned at the latest **v6.0.8** (unchanged)

Both workflows validated as well-formed YAML. The checkout/setup-node major bumps (v4→v6) are exercised by this PR's own CI run.


## Bug pass (follow-up commit)

A review of the migrated code turned up one genuine bug, now fixed:

- **Multiple `Set-Cookie` headers were collapsed to the last one.** `success()` wrote each header with `res.setHeader('set-cookie', value)`, which overwrites by name. Now Set-Cookie values are collected and emitted as an array (one header per cookie). Added a `success()` unit test. Changeset: `@dcl/http-server` patch.

Two other items checked and cleared:
- **Forbidden-header stripping** (`Content-Length`/`Origin`/`Host` on the native `Request`) — verified Node 24's undici does *not* strip them, so `metrics.ts`/`cors.ts` reads are correct (cors.spec confirms).
- **`Content-Length` fallback to 0** for chunked/bodyless requests in the metrics middleware — intended and acceptable.
