### PR TITLE
fix: type http-tracer & schema-validator servers against @dcl/core-commons for http-server v2

### DIFF
--- a/.changeset/http-tracer-native-fetch-types.md
+++ b/.changeset/http-tracer-native-fetch-types.md
@@ -1,0 +1,7 @@
+---
+"@dcl/http-tracer-component": major
+---
+
+source `IHttpServerComponent` from `@dcl/core-commons` instead of `@well-known-components/interfaces`, so the tracer accepts an `@dcl/http-server` v2 server (native-fetch request/response types) without a cast. The middleware behavior is unchanged — it only reads the request's headers/method/url, which are WHATWG-compatible.
+
+BREAKING CHANGE: the `server` argument is now typed against `@dcl/core-commons`' `IHttpServerComponent`; pair this component with `@dcl/http-server` v2.

--- a/.changeset/schema-validator-native-fetch-types.md
+++ b/.changeset/schema-validator-native-fetch-types.md
@@ -1,0 +1,5 @@
+---
+"@dcl/schema-validator-component": minor
+---
+
+source `IHttpServerComponent` from `@dcl/core-commons` instead of `@well-known-components/interfaces`, so the validation middleware's request handlers type against the native-fetch request/response types and pair with `@dcl/http-server` v2 without casts. Middleware behavior is unchanged — it only reads the `Content-Type` header and the cloned JSON body, both WHATWG-compatible.

--- a/.changeset/schema-validator-native-fetch-types.md
+++ b/.changeset/schema-validator-native-fetch-types.md
@@ -1,5 +1,7 @@
 ---
-"@dcl/schema-validator-component": minor
+"@dcl/schema-validator-component": major
 ---
 
 source `IHttpServerComponent` from `@dcl/core-commons` instead of `@well-known-components/interfaces`, so the validation middleware's request handlers type against the native-fetch request/response types and pair with `@dcl/http-server` v2 without casts. Middleware behavior is unchanged — it only reads the `Content-Type` header and the cloned JSON body, both WHATWG-compatible.
+
+BREAKING CHANGE: `withSchemaValidatorMiddleware`'s return type now uses `@dcl/core-commons`' `IHttpServerComponent`; pair this component with `@dcl/http-server` v2.

--- a/components/http-tracer/package.json
+++ b/components/http-tracer/package.json
@@ -20,6 +20,7 @@
     "lint": "echo \"No linting configured\""
   },
   "dependencies": {
+    "@dcl/core-commons": "workspace:*",
     "@well-known-components/interfaces": "^1.5.2"
   },
   "devDependencies": {

--- a/components/http-tracer/src/component.ts
+++ b/components/http-tracer/src/component.ts
@@ -1,4 +1,7 @@
-import type { IHttpServerComponent, ITracerComponent, TraceContext } from '@well-known-components/interfaces'
+import type { ITracerComponent, TraceContext } from '@well-known-components/interfaces'
+// Source IHttpServerComponent from @dcl/core-commons so this tracer accepts an @dcl/http-server v2
+// server (native-fetch request/response types) without casts.
+import type { IHttpServerComponent } from '@dcl/core-commons'
 import { parseTraceParentHeader, parseTraceState } from './logic'
 import { IHttpTracerComponent } from './types'
 

--- a/components/http-tracer/tests/component.spec.ts
+++ b/components/http-tracer/tests/component.spec.ts
@@ -1,4 +1,5 @@
-import type { ITracerComponent, IHttpServerComponent } from '@well-known-components/interfaces'
+import type { ITracerComponent } from '@well-known-components/interfaces'
+import type { IHttpServerComponent } from '@dcl/core-commons'
 import { createHttpTracerComponent } from '../src'
 import { parseTraceParentHeader } from '../src/logic'
 

--- a/components/schema-validator/src/component.ts
+++ b/components/schema-validator/src/component.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto'
 import Ajv, { Schema } from 'ajv'
 import addFormats from 'ajv-formats'
-import { IHttpServerComponent } from '@well-known-components/interfaces'
+import { IHttpServerComponent } from '@dcl/core-commons'
 import { ISchemaValidatorComponent, Validation } from './types'
 
 // RFC 6839 structured-suffix match: non-empty type and subtype separated by `/`,

--- a/components/schema-validator/src/types.ts
+++ b/components/schema-validator/src/types.ts
@@ -1,4 +1,4 @@
-import { IHttpServerComponent } from '@well-known-components/interfaces'
+import { IHttpServerComponent } from '@dcl/core-commons'
 import { ErrorObject, Schema } from 'ajv'
 
 export type Validation =

--- a/components/schema-validator/tests/schema-validator-component.spec.ts
+++ b/components/schema-validator/tests/schema-validator-component.spec.ts
@@ -1,4 +1,4 @@
-import { IHttpServerComponent } from '@well-known-components/interfaces'
+import { IHttpServerComponent } from '@dcl/core-commons'
 import { createSchemaValidatorComponent } from '../src'
 
 const testSchema = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
 
   components/http-tracer:
     dependencies:
+      '@dcl/core-commons':
+        specifier: workspace:*
+        version: link:../../shared/commons
       '@well-known-components/interfaces':
         specifier: ^1.5.2
         version: 1.5.2


### PR DESCRIPTION
## What

Types `@dcl/http-tracer-component` against the **native-fetch** `IHttpServerComponent` from `@dcl/core-commons` instead of `@well-known-components/interfaces`.

## Why

`@dcl/http-server` v2 serves native `Request`/`Response` (its `IHttpServerComponent` comes from `@dcl/core-commons`). `@dcl/http-tracer-component@1.0.0` still typed its `server` argument against `@well-known-components/interfaces`, so passing a v2 server required a cast at the call site (as catalyst currently does). This aligns the tracer with the rest of the `@dcl/*` HTTP stack so it accepts a v2 server directly.

The middleware itself is unchanged — it only reads `request.headers.get(...)`, `request.method`, and `url`, all WHATWG-compatible, so it was always runtime-safe with native requests; only the static type was wrong.

## Changes

- `src/component.ts` — `IHttpServerComponent` now from `@dcl/core-commons`; `ITracerComponent`/`TraceContext` stay from `@well-known-components/interfaces`.
- `package.json` — add `@dcl/core-commons` (`workspace:*`).
- `tests/component.spec.ts` — mock server typed via `@dcl/core-commons`.

## Breaking change

The `server` argument is now typed against `@dcl/core-commons`' `IHttpServerComponent`. Pair this component with `@dcl/http-server` v2. Changeset: `@dcl/http-tracer-component` major.

## Testing

- `tsc` clean; **17 tests pass** (2 suites).

## Follow-up

Once published, catalyst can switch from `@well-known-components/http-tracer-component` to this package and drop the boundary cast it currently has around `createHttpTracerComponent`.


---

## Also: `@dcl/schema-validator-component`

A monorepo audit for other components typing an `IHttpServerComponent` against `@well-known-components/interfaces` turned up one more: `@dcl/schema-validator-component`. Same fix — its `withSchemaValidatorMiddleware` request handlers now type against `@dcl/core-commons` (it already depended on it). The middleware only reads the `Content-Type` header and `request.clone().json()` (both WHATWG-compatible), so it's a type-only change. **14 tests pass.** Changeset: `@dcl/schema-validator-component` minor (0.x breaking convention).

The audit otherwise came back clean — `@dcl/http-server` already sources its types from `@dcl/core-commons`, and `shared/commons` is the definition itself.
