### PR TITLE
feat: add unfurl_links and unfurl_media passthrough to slack-component

### DIFF
--- a/.changeset/slack-unfurl-control.md
+++ b/.changeset/slack-unfurl-control.md
@@ -1,0 +1,5 @@
+---
+"@dcl/slack-component": minor
+---
+
+add optional `unfurl_links` and `unfurl_media` fields to `SlackMessage`, forwarded to `chat.postMessage`. Lets callers disable Slack link/media preview unfurling (e.g. set both to `false`) without changing existing behavior — when omitted, Slack's defaults apply.

--- a/components/slack/src/component.ts
+++ b/components/slack/src/component.ts
@@ -23,7 +23,9 @@ export function createSlackComponent(
         icon_emoji: message.icon_emoji,
         icon_url: message.icon_url,
         thread_ts: message.thread_ts,
-        reply_broadcast: message.reply_broadcast
+        reply_broadcast: message.reply_broadcast,
+        unfurl_links: message.unfurl_links,
+        unfurl_media: message.unfurl_media
       })
     } catch (error) {
       logger.debug(`Failed to send message: ${error}`)

--- a/components/slack/src/types.ts
+++ b/components/slack/src/types.ts
@@ -14,6 +14,8 @@ export interface SlackMessage {
   icon_url?: string
   thread_ts?: string
   reply_broadcast?: boolean
+  unfurl_links?: boolean
+  unfurl_media?: boolean
 }
 
 export interface ISlackComponent extends IBaseComponent {

--- a/components/slack/tests/slack-component.spec.ts
+++ b/components/slack/tests/slack-component.spec.ts
@@ -91,6 +91,27 @@ describe('when creating a slack component', () => {
     })
   })
 
+  describe('and omitting the unfurl options', () => {
+    let message: SlackMessage
+
+    beforeEach(() => {
+      token = 'xoxb-test-token'
+      slackComponent = createSlackComponent({ logs }, { token })
+      message = {
+        text: 'Test message',
+        channel: 'test-channel'
+      }
+    })
+
+    it('should not force a value, leaving Slack defaults to apply', async () => {
+      await slackComponent.sendMessage(message)
+
+      const sent = (mockClient.chat.postMessage as jest.Mock).mock.calls[0][0]
+      expect(sent.unfurl_links).toBeUndefined()
+      expect(sent.unfurl_media).toBeUndefined()
+    })
+  })
+
   describe('and API call fails', () => {
     let message: SlackMessage
 

--- a/components/slack/tests/slack-component.spec.ts
+++ b/components/slack/tests/slack-component.spec.ts
@@ -39,6 +39,8 @@ describe('when creating a slack component', () => {
         icon_url: 'https://example.com/icon.png',
         thread_ts: '1234567890.123456',
         reply_broadcast: true,
+        unfurl_links: true,
+        unfurl_media: true,
         blocks: [{ type: 'section', text: { type: 'mrkdwn', text: 'Test' } }],
         attachments: [{ color: '#36a64f', text: 'Attachment' }]
       }
@@ -55,9 +57,37 @@ describe('when creating a slack component', () => {
         icon_url: 'https://example.com/icon.png',
         thread_ts: '1234567890.123456',
         reply_broadcast: true,
+        unfurl_links: true,
+        unfurl_media: true,
         blocks: [{ type: 'section', text: { type: 'mrkdwn', text: 'Test' } }],
         attachments: [{ color: '#36a64f', text: 'Attachment' }]
       })
+    })
+  })
+
+  describe('and disabling link unfurling', () => {
+    let message: SlackMessage
+
+    beforeEach(() => {
+      token = 'xoxb-test-token'
+      slackComponent = createSlackComponent({ logs }, { token })
+      message = {
+        text: 'Test message',
+        channel: 'test-channel',
+        unfurl_links: false,
+        unfurl_media: false
+      }
+    })
+
+    it('should forward unfurl_links and unfurl_media as false to the API', async () => {
+      await slackComponent.sendMessage(message)
+
+      expect(mockClient.chat.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          unfurl_links: false,
+          unfurl_media: false
+        })
+      )
     })
   })
 


### PR DESCRIPTION
## @dcl/slack-component: control link/media unfurling

Adds optional `unfurl_links` and `unfurl_media` fields to `SlackMessage`,
forwarded verbatim to `chat.postMessage`.

### Why
Callers currently can't disable Slack's link/media preview unfurling — the
component forwards a fixed field list that omits both unfurl args. Messages
with links (e.g. registry/console links) render noisy preview cards.

### What
- `SlackMessage` gains `unfurl_links?: boolean` and `unfurl_media?: boolean`.
- `sendMessage` passes both through to `chat.postMessage`.
- When omitted, behavior is unchanged (Slack defaults apply) — fully
  backward-compatible, hence a `minor` changeset.

### Tests
- Existing all-fields test asserts both new fields are forwarded.
- New case verifies `unfurl_links: false` / `unfurl_media: false` reach the API.
- `pnpm test` 3/3 pass; `pnpm build` clean.
