### PR TITLE
feat(thegraph): migrate @dcl/thegraph-component to native-fetch IFetchComponent

### DIFF
--- a/.changeset/thegraph-component.md
+++ b/.changeset/thegraph-component.md
@@ -2,4 +2,4 @@
 "@dcl/thegraph-component": minor
 ---
 
-Add `@dcl/thegraph-component`: queries thegraph.com subgraphs over HTTP with per-query retries, an incremental timeout per attempt and `AbortController`-based cancellation (`createSubgraphComponent`). Migrated from `@well-known-components/thegraph-component` and switched to the native-fetch `IFetchComponent` from `@dcl/core-commons` (drops `node-fetch`). Exposes `metricDeclarations` for the request counter, error counter and query-duration histogram.
+Add `@dcl/thegraph-component`: queries thegraph.com subgraphs over HTTP with per-query retries, an incremental timeout per attempt and `AbortController`-based cancellation (`createSubgraphComponent`). Migrated from `@well-known-components/thegraph-component` and switched to the native-fetch `IFetchComponent` from `@dcl/core-commons` (drops `node-fetch`). Query timeouts now raise a deterministic `SubgraphQueryTimeoutError` and are classified as `timeout` in `subgraph_errors_total` regardless of how the injected fetch component surfaces an aborted request. Exposes `metricDeclarations` for the request counter, error counter and query-duration histogram.

--- a/.changeset/thegraph-component.md
+++ b/.changeset/thegraph-component.md
@@ -1,0 +1,5 @@
+---
+"@dcl/thegraph-component": minor
+---
+
+Add `@dcl/thegraph-component`: queries thegraph.com subgraphs over HTTP with per-query retries, an incremental timeout per attempt and `AbortController`-based cancellation (`createSubgraphComponent`). Migrated from `@well-known-components/thegraph-component` and switched to the native-fetch `IFetchComponent` from `@dcl/core-commons` (drops `node-fetch`). Exposes `metricDeclarations` for the request counter, error counter and query-duration histogram.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+coverage
 tsconfig.tsbuildinfo
 .cursor
 .pnpm-store

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ core-components/
 │   ├── slack/            # Slack messaging component
 │   ├── sns/              # AWS SNS publisher component
 │   ├── sqs/              # AWS SQS queue component
+│   ├── thegraph/         # thegraph subgraph GraphQL query component
 │   ├── traced-fetch/     # Traced fetch component with distributed tracing
 │   └── uws-http-server/  # uWebSockets.js based HTTP server component
 └── shared/             # Shared utilities and types
@@ -67,6 +68,7 @@ core-components/
 ### Blockchain
 
 - **Block Indexer** (`@dcl/block-indexer`) - On-chain block indexer that finds the block at the tip of the blockchain for a given timestamp
+- **TheGraph Component** (`@dcl/thegraph-component`) - Queries thegraph.com subgraphs over HTTP with per-query retries and timeouts
 
 ### Utilities
 
@@ -167,6 +169,7 @@ This project uses [Changesets](https://github.com/changesets/changesets) for aut
 - `@dcl/slack-component`
 - `@dcl/sns-component`
 - `@dcl/sqs-component`
+- `@dcl/thegraph-component`
 - `@dcl/traced-fetch-component`
 - `@dcl/uws-http-server`
 - `@dcl/core-commons`

--- a/components/thegraph/README.md
+++ b/components/thegraph/README.md
@@ -1,0 +1,64 @@
+# @dcl/thegraph-component
+
+A component used to query [thegraph](https://thegraph.com/)'s subgraphs over HTTP, with retries and timeouts.
+
+It relies on the native-fetch `IFetchComponent` from [`@dcl/core-commons`](../../shared/commons) (no `node-fetch`).
+
+## Installation
+
+```bash
+npm install @dcl/thegraph-component
+```
+
+## API
+
+### Create
+
+To create the component you'll have to supply the subgraph's url. You can get it from thegraph's site, for example: https://api.thegraph.com/subgraphs/name/decentraland/marketplace
+
+```ts
+import { createSubgraphComponent } from '@dcl/thegraph-component'
+
+const url = 'https://api.thegraph.com/subgraphs/name/decentraland/marketplace'
+await createSubgraphComponent({ config, logs, metrics, fetch }, url)
+```
+
+The `fetch` dependency is an `IFetchComponent` from `@dcl/core-commons` (e.g. created with `@dcl/fetch-component`). For the query timeout to abort the in-flight request, the fetch implementation must honor the `abortController` request option.
+
+### Query
+
+The main API is:
+
+```ts
+query: <T>(query: string, variables?: Variables, remainingAttempts?: number) => Promise<T>
+```
+
+So you can call it like this:
+
+```ts
+type Element = {
+  id: string
+  count: number
+}
+
+function getElementsQuery() {
+  return `query getCollection($count: Number!) {
+    elements(where: { count_gt: $count }) {
+      id
+      count
+    }
+  }`
+}
+
+await subgraph.query<{ elements: Element[] }>(getElementsQuery(), { count: 5 })
+```
+
+## Configuration
+
+It supports the following ENV variables:
+
+- `SUBGRAPH_COMPONENT_RETRIES`: How many retries per subgraph query. Defaults to `3`.
+- `SUBGRAPH_COMPONENT_QUERY_TIMEOUT`: How long to wait until a connection is timed-out. Defaults to `10000`ms or 10 seconds.
+- `SUBGRAPH_COMPONENT_TIMEOUT_INCREMENT`: How much time to add after each retry. The value will be multiplied for the attempt number. For example: if the increment is 10000, it'll wait 10s the first retry, 20s next, 30s, etc. Defaults to `10000`ms or 10 seconds.
+- `SUBGRAPH_COMPONENT_BACKOFF`: How long to wait until a new query is tried after an unsuccessful one (retrying). Defaults to `500`ms.
+- `SUBGRAPH_COMPONENT_AGENT_NAME`: The name of the agent that will be performing the graph requests. This agent name will be used to identify the graph requests using the user agent header. The crafted header will be: `Subgraph component / Agent Name`.

--- a/components/thegraph/jest.config.js
+++ b/components/thegraph/jest.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>'],
+  testMatch: [
+    '**/tests/**/*.spec.ts',
+    '**/tests/**/*.test.ts',
+    '**/?(*.)+(spec|test).ts'
+  ],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/dist/'
+  ],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!**/*.d.ts',
+  ],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+}

--- a/components/thegraph/package.json
+++ b/components/thegraph/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@dcl/thegraph-component",
+  "version": "0.0.0",
+  "description": "Component to query thegraph.com subgraphs over HTTP, with retries and timeouts.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/thegraph"
+  },
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "test": "jest",
+    "lint": "echo \"No linting configured\""
+  },
+  "dependencies": {
+    "@dcl/core-commons": "workspace:*",
+    "@well-known-components/interfaces": "^1.5.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/components/thegraph/src/component.ts
+++ b/components/thegraph/src/component.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'crypto'
 import { setTimeout } from 'timers/promises'
 import { ISubgraphComponent, PostQueryResponse, SubgraphResponse, Variables } from './types'
 import { metricDeclarations } from './metrics'
+import { SubgraphQueryTimeoutError } from './errors'
 import { UNKNOWN_SUBGRAPH_PROVIDER, withTimeout } from './utils'
 
 /**
@@ -27,18 +28,39 @@ export async function createSubgraphComponent(
     (await config.getString('SUBGRAPH_COMPONENT_AGENT_NAME')) ?? 'Unknown sender'
   }`
 
+  /**
+   * Public entry point for the component. Runs the query, retrying on failure up to
+   * `remainingAttempts` times on top of the initial attempt.
+   * @param query - The GraphQL query string.
+   * @param variables - The query variables, if any.
+   * @param remainingAttempts - How many retries to allow. Defaults to the configured RETRIES.
+   */
   async function executeQuery<T>(
     query: string,
     variables: Variables = {},
     remainingAttempts: number = RETRIES
   ): Promise<T> {
-    const attempt = RETRIES - remainingAttempts
-    const attempts = RETRIES + 1
+    return attemptQuery<T>(query, variables, remainingAttempts, 0)
+  }
+
+  /**
+   * Runs a single attempt and recurses on retry. `attempt` counts up from 0, independently of
+   * `remainingAttempts`, so the per-attempt timeout escalation stays correct regardless of the
+   * initial `remainingAttempts` the caller asks for — deriving the attempt number from `RETRIES`
+   * used to produce a negative (i.e. immediate) timeout when `remainingAttempts > RETRIES`.
+   */
+  async function attemptQuery<T>(
+    query: string,
+    variables: Variables,
+    remainingAttempts: number,
+    attempt: number
+  ): Promise<T> {
+    const totalAttempts = attempt + Math.max(remainingAttempts, 0) + 1
     const currentAttempt = attempt + 1
 
     const timeoutWait = TIMEOUT + attempt * TIMEOUT_INCREMENT
     const queryId = randomUUID()
-    const logData = { queryId, currentAttempt, attempts, timeoutWait, url }
+    const logData = { queryId, currentAttempt, attempts: totalAttempts, timeoutWait, url }
 
     const { end } = metrics.startTimer('subgraph_query_duration_seconds', { url })
     try {
@@ -59,31 +81,35 @@ export async function createSubgraphComponent(
 
       const hasInvalidData = !data || Object.keys(data).length === 0
       if (hasInvalidData) {
-        logger.warn('Invalid response', { query, variables, response } as any)
         throw new Error(`GraphQL Error: Invalid response. Provider: ${provider}`)
       }
 
       metrics.increment('subgraph_ok_total', { url })
 
       return data
-    } catch (error: any) {
-      const errorMessage = (error as Error).message
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
       logger.warn('Error:', { ...logData, errorMessage, query, variables: JSON.stringify(variables) })
 
       let kind = 'unknown'
       if (errorMessage.includes('Failed to decode `block.number`')) {
+        // An un-decodable block won't become decodable by retrying within the backoff window.
         kind = 'invalid_block'
+        remainingAttempts = 0
       } else if (errorMessage.includes('Unexpected `')) {
         kind = 'syntax_error'
         remainingAttempts = 0
-      } else if (error.name === 'AbortError') {
+      } else if (
+        error instanceof SubgraphQueryTimeoutError ||
+        (error instanceof Error && error.name === 'AbortError')
+      ) {
         kind = 'timeout'
       }
       metrics.increment('subgraph_errors_total', { url, kind })
 
       if (remainingAttempts > 0) {
         await setTimeout(BACKOFF)
-        return executeQuery<T>(query, variables, remainingAttempts - 1)
+        return attemptQuery<T>(query, variables, remainingAttempts - 1, attempt + 1)
       } else {
         throw error // bubble up
       }

--- a/components/thegraph/src/component.ts
+++ b/components/thegraph/src/component.ts
@@ -1,0 +1,128 @@
+import { IConfigComponent, ILoggerComponent, IMetricsComponent } from '@well-known-components/interfaces'
+import { IFetchComponent } from '@dcl/core-commons'
+import { randomUUID } from 'crypto'
+import { setTimeout } from 'timers/promises'
+import { ISubgraphComponent, PostQueryResponse, SubgraphResponse, Variables } from './types'
+import { metricDeclarations } from './metrics'
+import { UNKNOWN_SUBGRAPH_PROVIDER, withTimeout } from './utils'
+
+/**
+ * Query thegraph's (https://thegraph.com) subgraphs via HTTP.
+ * Connections will be retried and dropped after a timeout.
+ * For the connection to be properly aborted, the fetch component supplied via IFetchComponent should support AbortController signals
+ */
+export async function createSubgraphComponent(
+  components: createSubgraphComponent.NeededComponents,
+  url: string
+): Promise<ISubgraphComponent> {
+  const { logs, metrics, config, fetch } = components
+
+  const logger = logs.getLogger('thegraph-port')
+
+  const RETRIES = (await config.getNumber('SUBGRAPH_COMPONENT_RETRIES')) ?? 3
+  const TIMEOUT = (await config.getNumber('SUBGRAPH_COMPONENT_QUERY_TIMEOUT')) ?? 10000
+  const TIMEOUT_INCREMENT = (await config.getNumber('SUBGRAPH_COMPONENT_TIMEOUT_INCREMENT')) ?? 10000
+  const BACKOFF = (await config.getNumber('SUBGRAPH_COMPONENT_BACKOFF')) ?? 500
+  const USER_AGENT = `Subgraph component / ${
+    (await config.getString('SUBGRAPH_COMPONENT_AGENT_NAME')) ?? 'Unknown sender'
+  }`
+
+  async function executeQuery<T>(
+    query: string,
+    variables: Variables = {},
+    remainingAttempts: number = RETRIES
+  ): Promise<T> {
+    const attempt = RETRIES - remainingAttempts
+    const attempts = RETRIES + 1
+    const currentAttempt = attempt + 1
+
+    const timeoutWait = TIMEOUT + attempt * TIMEOUT_INCREMENT
+    const queryId = randomUUID()
+    const logData = { queryId, currentAttempt, attempts, timeoutWait, url }
+
+    const { end } = metrics.startTimer('subgraph_query_duration_seconds', { url })
+    try {
+      const [provider, response] = await withTimeout(
+        (abortController) => postQuery<T>(query, variables, abortController),
+        timeoutWait
+      )
+
+      const { data, errors } = response
+
+      const hasErrors = errors !== undefined
+      if (hasErrors) {
+        const errorMessages = Array.isArray(errors) ? errors.map((error) => error.message) : [errors.message]
+        throw new Error(
+          `GraphQL Error: Invalid response. Errors:\n- ${errorMessages.join('\n- ')}. Provider: ${provider}`
+        )
+      }
+
+      const hasInvalidData = !data || Object.keys(data).length === 0
+      if (hasInvalidData) {
+        logger.warn('Invalid response', { query, variables, response } as any)
+        throw new Error(`GraphQL Error: Invalid response. Provider: ${provider}`)
+      }
+
+      metrics.increment('subgraph_ok_total', { url })
+
+      return data
+    } catch (error: any) {
+      const errorMessage = (error as Error).message
+      logger.warn('Error:', { ...logData, errorMessage, query, variables: JSON.stringify(variables) })
+
+      let kind = 'unknown'
+      if (errorMessage.includes('Failed to decode `block.number`')) {
+        kind = 'invalid_block'
+      } else if (errorMessage.includes('Unexpected `')) {
+        kind = 'syntax_error'
+        remainingAttempts = 0
+      } else if (error.name === 'AbortError') {
+        kind = 'timeout'
+      }
+      metrics.increment('subgraph_errors_total', { url, kind })
+
+      if (remainingAttempts > 0) {
+        await setTimeout(BACKOFF)
+        return executeQuery<T>(query, variables, remainingAttempts - 1)
+      } else {
+        throw error // bubble up
+      }
+    } finally {
+      end({ url })
+    }
+  }
+
+  async function postQuery<T>(
+    query: string,
+    variables: Variables,
+    abortController: AbortController
+  ): Promise<PostQueryResponse<T>> {
+    const response = await fetch.fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-agent': USER_AGENT },
+      body: JSON.stringify({ query, variables }),
+      abortController
+    })
+
+    const provider = response.headers.get('X-Subgraph-Provider') ?? UNKNOWN_SUBGRAPH_PROVIDER
+
+    if (!response.ok) {
+      throw new Error(`Invalid request. Status: ${response.status}. Provider: ${provider}.`)
+    }
+
+    return [provider, (await response.json()) as SubgraphResponse<T>]
+  }
+
+  return {
+    query: executeQuery
+  }
+}
+
+export namespace createSubgraphComponent {
+  export type NeededComponents = {
+    logs: ILoggerComponent
+    config: IConfigComponent
+    fetch: IFetchComponent
+    metrics: IMetricsComponent<keyof typeof metricDeclarations>
+  }
+}

--- a/components/thegraph/src/errors.ts
+++ b/components/thegraph/src/errors.ts
@@ -1,0 +1,14 @@
+/**
+ * Thrown when a subgraph query is aborted because it exceeded its timeout.
+ *
+ * The component owns its own timeout (via `withTimeout`), so it raises this typed error
+ * rather than inferring a timeout from however the injected `IFetchComponent` reports an
+ * aborted request — e.g. `@dcl/fetch-component` rejects with a generic
+ * `Error('Request aborted (timed out)')`, not a native `AbortError`.
+ */
+export class SubgraphQueryTimeoutError extends Error {
+  constructor(public readonly timeout: number) {
+    super(`The subgraph query timed out after ${timeout}ms`)
+    this.name = 'SubgraphQueryTimeoutError'
+  }
+}

--- a/components/thegraph/src/index.ts
+++ b/components/thegraph/src/index.ts
@@ -1,0 +1,3 @@
+export * from './component'
+export * from './types'
+export { metricDeclarations } from './metrics'

--- a/components/thegraph/src/index.ts
+++ b/components/thegraph/src/index.ts
@@ -1,3 +1,4 @@
 export * from './component'
 export * from './types'
+export * from './errors'
 export { metricDeclarations } from './metrics'

--- a/components/thegraph/src/metrics.ts
+++ b/components/thegraph/src/metrics.ts
@@ -1,0 +1,22 @@
+import { IMetricsComponent } from '@well-known-components/interfaces'
+
+/**
+ * Metrics declarations, needed for your IMetricsComponent
+ */
+export const metricDeclarations: IMetricsComponent.MetricsRecordDefinition<string> = {
+  subgraph_ok_total: {
+    help: 'Subgraph request counter',
+    type: IMetricsComponent.CounterType,
+    labelNames: ['url']
+  },
+  subgraph_errors_total: {
+    help: 'Subgraph error counter',
+    type: IMetricsComponent.CounterType,
+    labelNames: ['url', 'kind']
+  },
+  subgraph_query_duration_seconds: {
+    type: IMetricsComponent.HistogramType,
+    help: 'Request duration in seconds.',
+    labelNames: ['url']
+  }
+}

--- a/components/thegraph/src/metrics.ts
+++ b/components/thegraph/src/metrics.ts
@@ -3,7 +3,7 @@ import { IMetricsComponent } from '@well-known-components/interfaces'
 /**
  * Metrics declarations, needed for your IMetricsComponent
  */
-export const metricDeclarations: IMetricsComponent.MetricsRecordDefinition<string> = {
+export const metricDeclarations = {
   subgraph_ok_total: {
     help: 'Subgraph request counter',
     type: IMetricsComponent.CounterType,
@@ -17,6 +17,8 @@ export const metricDeclarations: IMetricsComponent.MetricsRecordDefinition<strin
   subgraph_query_duration_seconds: {
     type: IMetricsComponent.HistogramType,
     help: 'Request duration in seconds.',
-    labelNames: ['url']
+    labelNames: ['url'],
+    // Buckets cover the escalating per-attempt timeouts (default 10s, +10s per retry).
+    buckets: [0.1, 0.3, 0.5, 1, 2, 5, 10, 20, 30, 60]
   }
-}
+} satisfies IMetricsComponent.MetricsRecordDefinition<string>

--- a/components/thegraph/src/types.ts
+++ b/components/thegraph/src/types.ts
@@ -1,8 +1,8 @@
 export type Variables = Record<string, string[] | string | number | boolean | undefined>
 
-export type Error = { message: string }
+export type GraphQLError = { message: string }
 
-export type SubgraphResponse<T> = { data: T; errors?: Error[] | Error }
+export type SubgraphResponse<T> = { data: T; errors?: GraphQLError[] | GraphQLError }
 
 export type SubgraphProvider = string
 

--- a/components/thegraph/src/types.ts
+++ b/components/thegraph/src/types.ts
@@ -1,0 +1,25 @@
+export type Variables = Record<string, string[] | string | number | boolean | undefined>
+
+export type Error = { message: string }
+
+export type SubgraphResponse<T> = { data: T; errors?: Error[] | Error }
+
+export type SubgraphProvider = string
+
+export type PostQueryResponse<T> = [SubgraphProvider, SubgraphResponse<T>]
+
+export interface ISubgraphComponent {
+  /**
+   * Query the subgraph using GraphQL
+   * @param query - String version of a GraphQL query
+   * @param variables - Any variables present on the query, if any
+   * @returns Query result
+   */
+  query: <T>(query: string, variables?: Variables, remainingAttempts?: number) => Promise<T>
+}
+
+export namespace ISubgraphComponent {
+  export type Composable = {
+    subgraph: ISubgraphComponent
+  }
+}

--- a/components/thegraph/src/utils.ts
+++ b/components/thegraph/src/utils.ts
@@ -1,0 +1,24 @@
+import { setTimeout } from 'timers/promises'
+import { SubgraphProvider } from './types'
+
+export const UNKNOWN_SUBGRAPH_PROVIDER: SubgraphProvider = 'UNKNOWN'
+
+export async function withTimeout<T>(
+  callback: (abortController: AbortController) => Promise<T>,
+  timeout: number
+): Promise<T> {
+  const callbackAbortController = new AbortController()
+  const timeoutAbortController = new AbortController()
+
+  const request = callback(callbackAbortController).finally(() => {
+    timeoutAbortController.abort()
+  })
+
+  setTimeout(timeout, 'Timeout', { signal: timeoutAbortController.signal })
+    .then(() => {
+      callbackAbortController.abort()
+    })
+    .catch(() => {})
+
+  return request
+}

--- a/components/thegraph/src/utils.ts
+++ b/components/thegraph/src/utils.ts
@@ -1,8 +1,19 @@
 import { setTimeout } from 'timers/promises'
+import { SubgraphQueryTimeoutError } from './errors'
 import { SubgraphProvider } from './types'
 
 export const UNKNOWN_SUBGRAPH_PROVIDER: SubgraphProvider = 'UNKNOWN'
 
+/**
+ * Runs `callback`, racing it against a `timeout` (ms). The callback receives an `AbortController`
+ * that is aborted when the timeout elapses, so it can cancel its in-flight work.
+ *
+ * Whichever settles first wins deterministically: if the callback settles first its result (or
+ * error) is returned/thrown unchanged; if the timeout elapses first a `SubgraphQueryTimeoutError`
+ * is thrown. Racing — rather than translating any post-abort rejection into a timeout — avoids
+ * misreporting an unrelated failure that merely coincides with the timeout, and avoids depending
+ * on how the injected fetch component surfaces an aborted request.
+ */
 export async function withTimeout<T>(
   callback: (abortController: AbortController) => Promise<T>,
   timeout: number
@@ -10,15 +21,22 @@ export async function withTimeout<T>(
   const callbackAbortController = new AbortController()
   const timeoutAbortController = new AbortController()
 
-  const request = callback(callbackAbortController).finally(() => {
-    timeoutAbortController.abort()
+  const request = callback(callbackAbortController)
+  // If the timeout wins the race we abort the request afterwards; swallow that late rejection so it
+  // never surfaces as an unhandled rejection.
+  request.catch(() => {})
+
+  const timeoutExpired = setTimeout(timeout, 'Timeout', { signal: timeoutAbortController.signal }).then(() => {
+    throw new SubgraphQueryTimeoutError(timeout)
   })
+  // If the request wins the race we cancel the timer, which rejects this promise with an AbortError.
+  timeoutExpired.catch(() => {})
 
-  setTimeout(timeout, 'Timeout', { signal: timeoutAbortController.signal })
-    .then(() => {
-      callbackAbortController.abort()
-    })
-    .catch(() => {})
-
-  return request
+  try {
+    return await Promise.race([request, timeoutExpired])
+  } finally {
+    // Cancel the pending timer and abort the in-flight request, whichever is still running.
+    timeoutAbortController.abort()
+    callbackAbortController.abort()
+  }
 }

--- a/components/thegraph/tests/component.spec.ts
+++ b/components/thegraph/tests/component.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '@dcl/core-commons'
 import { setTimeout } from 'timers/promises'
 import { createSubgraphComponent, ISubgraphComponent, SubgraphResponse, Variables } from '../src'
+import { SubgraphQueryTimeoutError } from '../src/errors'
 import { metricDeclarations } from '../src/metrics'
 import { UNKNOWN_SUBGRAPH_PROVIDER } from '../src/utils'
 
@@ -130,6 +131,13 @@ describe('when querying a subgraph', () => {
           body: JSON.stringify({ query, variables }),
           abortController: expect.any(AbortController)
         })
+      })
+    })
+
+    describe('and a remainingAttempts greater than the configured retries is supplied', () => {
+      it('should start the first attempt with the base timeout rather than a negative one', async () => {
+        await subgraph.query(query, variables, 10)
+        expect(setTimeoutMock).toHaveBeenCalledWith(10000, 'Timeout', expect.anything())
       })
     })
   })
@@ -307,30 +315,31 @@ describe('when querying a subgraph', () => {
       await expect(subgraph.query('query', {}, 0)).rejects.toThrow()
       expect(metrics.increment).toHaveBeenCalledWith('subgraph_errors_total', { url: SUBGRAPH_URL, kind: expectedKind })
     })
+
+    it('should not retry the query even when retries are available', async () => {
+      await expect(subgraph.query('query', {}, 5)).rejects.toThrow()
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('and the query times out', () => {
-    const errorMessage = 'Query timed out'
-
     beforeEach(() => {
-      let rejectFetch: (reason?: unknown) => void = () => undefined
-      const fetchPromise = new Promise<FetchResponse>((_resolve, reject) => {
-        rejectFetch = reject
-      })
-      fetchMock.mockReturnValue(fetchPromise)
-      // The `withTimeout` timer firing aborts the in-flight request, rejecting it with an AbortError.
-      setTimeoutMock.mockImplementation((_time: number, name?: string) => {
-        if (name === 'Timeout') {
-          const error = new Error(errorMessage)
-          error.name = 'AbortError'
-          rejectFetch(error)
-        }
-        return Promise.resolve()
-      })
+      // Simulate a fetch component like `@dcl/fetch-component`, which rejects an aborted request
+      // with a generic Error (not a native AbortError) once its abort controller fires.
+      fetchMock.mockImplementation(
+        (_url: string, options: { abortController: AbortController }) =>
+          new Promise((_resolve, reject) => {
+            options.abortController.signal.addEventListener('abort', () => {
+              reject(new Error('Request aborted (timed out)'))
+            })
+          })
+      )
+      // Fire the `withTimeout` timer immediately so the request is aborted; any other timer resolves.
+      setTimeoutMock.mockImplementation(() => Promise.resolve())
     })
 
-    it('should reject with the timeout error', async () => {
-      await expect(subgraph.query('query', {}, 0)).rejects.toThrow(errorMessage)
+    it('should reject with a SubgraphQueryTimeoutError', async () => {
+      await expect(subgraph.query('query', {}, 0)).rejects.toBeInstanceOf(SubgraphQueryTimeoutError)
     })
 
     it('should increment the subgraph_errors_total metric with a timeout kind', async () => {

--- a/components/thegraph/tests/component.spec.ts
+++ b/components/thegraph/tests/component.spec.ts
@@ -1,0 +1,341 @@
+import { IConfigComponent, ILoggerComponent, IMetricsComponent } from '@well-known-components/interfaces'
+import {
+  IFetchComponent,
+  createConfigMockedComponent,
+  createFetchMockedComponent,
+  createLoggerMockedComponent
+} from '@dcl/core-commons'
+import { setTimeout } from 'timers/promises'
+import { createSubgraphComponent, ISubgraphComponent, SubgraphResponse, Variables } from '../src'
+import { metricDeclarations } from '../src/metrics'
+import { UNKNOWN_SUBGRAPH_PROVIDER } from '../src/utils'
+
+jest.mock('timers/promises')
+
+type FetchResponse = Awaited<ReturnType<IFetchComponent['fetch']>>
+
+const SUBGRAPH_URL = 'https://mock-subgraph.url.com'
+
+function createMetricsMockedComponent(): jest.Mocked<IMetricsComponent<keyof typeof metricDeclarations>> {
+  return {
+    startTimer: jest.fn().mockReturnValue({ end: jest.fn() }),
+    increment: jest.fn(),
+    decrement: jest.fn(),
+    observe: jest.fn(),
+    reset: jest.fn(),
+    resetAll: jest.fn(),
+    getValue: jest.fn()
+  } as unknown as jest.Mocked<IMetricsComponent<keyof typeof metricDeclarations>>
+}
+
+let setTimeoutMock: jest.Mock
+let fetchMock: jest.Mock
+let warnLogMock: jest.Mock
+let logs: ILoggerComponent
+let config: IConfigComponent
+let metrics: jest.Mocked<IMetricsComponent<keyof typeof metricDeclarations>>
+let fetch: IFetchComponent
+let subgraph: ISubgraphComponent
+
+beforeEach(async () => {
+  setTimeoutMock = setTimeout as unknown as jest.Mock
+  // By default keep the `withTimeout` timer pending (it should never fire) and resolve any
+  // other timer (e.g. the retry backoff) immediately so tests don't wait on real time.
+  setTimeoutMock.mockImplementation((_time: number, name?: string) =>
+    name === 'Timeout' ? new Promise<void>(() => {}) : Promise.resolve()
+  )
+
+  fetchMock = jest.fn()
+  warnLogMock = jest.fn()
+  fetch = createFetchMockedComponent({ fetch: fetchMock })
+  logs = createLoggerMockedComponent({ warn: warnLogMock })
+  config = createConfigMockedComponent()
+  metrics = createMetricsMockedComponent()
+
+  subgraph = await createSubgraphComponent({ logs, config, metrics, fetch }, SUBGRAPH_URL)
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('when querying a subgraph', () => {
+  const query = 'query ThisIsAQuery() {}'
+  let variables: Variables
+
+  beforeEach(() => {
+    variables = { some: 'very interesting', variables: ['we have', 'here'] }
+  })
+
+  describe('and the request is ok', () => {
+    let response: FetchResponse
+    let okResponseData: { data: Record<string, unknown> }
+
+    beforeEach(() => {
+      okResponseData = { data: { elements: [1, 3, 4], someOther: 'data' } }
+      response = {
+        ok: true,
+        status: 200,
+        json: async () => okResponseData,
+        headers: new Map()
+      } as unknown as FetchResponse
+      fetchMock.mockResolvedValue(response)
+    })
+
+    it("should resolve with the response's data property", async () => {
+      const result = await subgraph.query('query')
+      expect(result).toEqual(okResponseData.data)
+    })
+
+    it('should increment the subgraph_ok_total metric for the url', async () => {
+      await subgraph.query('query')
+      expect(metrics.increment).toHaveBeenCalledWith('subgraph_ok_total', { url: SUBGRAPH_URL })
+    })
+
+    it('should forward the query and variables to the subgraph via the fetch component', async () => {
+      await subgraph.query(query, variables)
+      expect(fetchMock).toHaveBeenCalledWith(SUBGRAPH_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'User-agent': 'Subgraph component / Unknown sender' },
+        body: JSON.stringify({ query, variables }),
+        abortController: expect.any(AbortController)
+      })
+    })
+
+    describe('and the agent name is configured', () => {
+      beforeEach(async () => {
+        ;(config.getString as jest.Mock).mockImplementation(async (name: string) =>
+          name === 'SUBGRAPH_COMPONENT_AGENT_NAME' ? 'An agent' : ''
+        )
+        subgraph = await createSubgraphComponent({ logs, config, metrics, fetch }, SUBGRAPH_URL)
+      })
+
+      it('should send the configured agent name in the User-agent header', async () => {
+        await subgraph.query(query, variables)
+        expect(fetchMock).toHaveBeenCalledWith(SUBGRAPH_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'User-agent': 'Subgraph component / An agent' },
+          body: JSON.stringify({ query, variables }),
+          abortController: expect.any(AbortController)
+        })
+      })
+    })
+
+    describe('and the agent name is not configured', () => {
+      it('should send the default agent name in the User-agent header', async () => {
+        await subgraph.query(query, variables)
+        expect(fetchMock).toHaveBeenCalledWith(SUBGRAPH_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'User-agent': 'Subgraph component / Unknown sender' },
+          body: JSON.stringify({ query, variables }),
+          abortController: expect.any(AbortController)
+        })
+      })
+    })
+  })
+
+  describe('and the server responds with an internal error', () => {
+    let response: FetchResponse
+
+    beforeEach(() => {
+      response = { ok: false, status: 500, headers: new Map() } as unknown as FetchResponse
+      fetchMock.mockResolvedValue(response)
+    })
+
+    it('should reject with an invalid request error mentioning the status and unknown provider', async () => {
+      await expect(subgraph.query('query', {}, 0)).rejects.toThrow(
+        `Invalid request. Status: 500. Provider: ${UNKNOWN_SUBGRAPH_PROVIDER}`
+      )
+    })
+
+    it('should increment the subgraph_errors_total metric with an unknown kind', async () => {
+      await expect(subgraph.query('query', {}, 0)).rejects.toThrow()
+      expect(metrics.increment).toHaveBeenCalledWith('subgraph_errors_total', { url: SUBGRAPH_URL, kind: 'unknown' })
+    })
+
+    it('should log a warning with the error', async () => {
+      await expect(subgraph.query('query', {}, 0)).rejects.toThrow()
+      expect(warnLogMock).toHaveBeenCalled()
+    })
+
+    describe('and the response carries a subgraph provider header', () => {
+      beforeEach(() => {
+        ;(response.headers as unknown as Map<string, string>).set('X-Subgraph-Provider', 'SubgraphProvider')
+      })
+
+      it('should include the subgraph provider in the error message', async () => {
+        await expect(subgraph.query('query', {}, 0)).rejects.toThrow(
+          'Invalid request. Status: 500. Provider: SubgraphProvider'
+        )
+      })
+    })
+  })
+
+  describe('and the response contains GraphQL errors', () => {
+    let errorResponseData: SubgraphResponse<unknown>
+    let response: FetchResponse
+
+    beforeEach(() => {
+      errorResponseData = {
+        data: undefined as unknown as Record<string, unknown>,
+        errors: { message: 'No suitable indexer found for subgraph deployment' }
+      }
+      response = {
+        ok: true,
+        status: 400,
+        json: async () => errorResponseData,
+        headers: new Map()
+      } as unknown as FetchResponse
+      fetchMock.mockResolvedValue(response)
+    })
+
+    it('should increment the subgraph_errors_total metric with an unknown kind', async () => {
+      await expect(subgraph.query('query', {}, 0)).rejects.toThrow()
+      expect(metrics.increment).toHaveBeenCalledWith('subgraph_errors_total', { url: SUBGRAPH_URL, kind: 'unknown' })
+    })
+
+    describe('and the errors property is empty but the data is invalid', () => {
+      beforeEach(() => {
+        errorResponseData = { data: {} as Record<string, unknown>, errors: undefined }
+      })
+
+      it('should reject with an invalid response error for the unknown provider', async () => {
+        await expect(subgraph.query('query', {}, 0)).rejects.toThrow(
+          `GraphQL Error: Invalid response. Provider: ${UNKNOWN_SUBGRAPH_PROVIDER}`
+        )
+      })
+
+      describe('and the response carries a subgraph provider header', () => {
+        beforeEach(() => {
+          ;(response.headers as unknown as Map<string, string>).set('X-Subgraph-Provider', 'SubgraphProvider')
+        })
+
+        it('should include the subgraph provider in the error message', async () => {
+          await expect(subgraph.query('query', {}, 0)).rejects.toThrow(
+            'GraphQL Error: Invalid response. Provider: SubgraphProvider'
+          )
+        })
+      })
+    })
+
+    describe('and there are multiple GraphQL errors', () => {
+      beforeEach(() => {
+        errorResponseData = {
+          data: undefined as unknown as Record<string, unknown>,
+          errors: [{ message: 'some error' }, { message: 'happened' }]
+        }
+      })
+
+      it('should reject with all the error messages joined', async () => {
+        await expect(subgraph.query('query', {}, 0)).rejects.toThrow(
+          `GraphQL Error: Invalid response. Errors:\n- some error\n- happened. Provider: ${UNKNOWN_SUBGRAPH_PROVIDER}`
+        )
+      })
+
+      describe('and the response carries a subgraph provider header', () => {
+        beforeEach(() => {
+          ;(response.headers as unknown as Map<string, string>).set('X-Subgraph-Provider', 'SubgraphProvider')
+        })
+
+        it('should include the subgraph provider in the error message', async () => {
+          await expect(subgraph.query('query', {}, 0)).rejects.toThrow(
+            'GraphQL Error: Invalid response. Errors:\n- some error\n- happened. Provider: SubgraphProvider'
+          )
+        })
+      })
+    })
+
+    describe('and a number of retries is supplied', () => {
+      const retries = 2
+
+      it('should query the subgraph the supplied number of times plus the first attempt', async () => {
+        await expect(subgraph.query('query', {}, retries)).rejects.toThrow()
+        expect(fetchMock).toHaveBeenCalledTimes(retries + 1)
+      })
+
+      it('should increment the error metric on every attempt', async () => {
+        await expect(subgraph.query('query', {}, retries)).rejects.toThrow()
+        expect(metrics.increment).toHaveBeenCalledTimes(retries + 1)
+      })
+    })
+
+    describe('and no number of retries is supplied', () => {
+      const configuredRetries = 4
+
+      beforeEach(async () => {
+        ;(config.getNumber as jest.Mock).mockImplementation(async (name: string) => {
+          switch (name) {
+            case 'SUBGRAPH_COMPONENT_QUERY_TIMEOUT':
+              return 500
+            case 'SUBGRAPH_COMPONENT_TIMEOUT_INCREMENT':
+              return 1
+            case 'SUBGRAPH_COMPONENT_RETRIES':
+              return configuredRetries
+            default:
+              return 0
+          }
+        })
+        subgraph = await createSubgraphComponent({ logs, config, metrics, fetch }, SUBGRAPH_URL)
+      })
+
+      it('should query the subgraph the configured number of times plus the first attempt', async () => {
+        await expect(subgraph.query('query')).rejects.toThrow()
+        expect(fetchMock).toHaveBeenCalledTimes(configuredRetries + 1)
+      })
+    })
+  })
+
+  describe.each([
+    ['and the query is syntactically incorrect', 'Unexpected `{[Punctuator]`\\nExpected `', 'syntax_error'],
+    ['and the query is made over an invalid block', 'Failed to decode `block.number`', 'invalid_block']
+  ])('%s', (_name: string, errorMessage: string, expectedKind: string) => {
+    beforeEach(() => {
+      const errorResponseData: SubgraphResponse<unknown> = {
+        data: undefined as unknown as Record<string, unknown>,
+        errors: [{ message: errorMessage }]
+      }
+      const response = {
+        ok: true,
+        status: 200,
+        json: async () => errorResponseData,
+        headers: new Map()
+      } as unknown as FetchResponse
+      fetchMock.mockResolvedValue(response)
+    })
+
+    it(`should increment the subgraph_errors_total metric with the "${expectedKind}" kind`, async () => {
+      await expect(subgraph.query('query', {}, 0)).rejects.toThrow()
+      expect(metrics.increment).toHaveBeenCalledWith('subgraph_errors_total', { url: SUBGRAPH_URL, kind: expectedKind })
+    })
+  })
+
+  describe('and the query times out', () => {
+    const errorMessage = 'Query timed out'
+
+    beforeEach(() => {
+      let rejectFetch: (reason?: unknown) => void = () => undefined
+      const fetchPromise = new Promise<FetchResponse>((_resolve, reject) => {
+        rejectFetch = reject
+      })
+      fetchMock.mockReturnValue(fetchPromise)
+      // The `withTimeout` timer firing aborts the in-flight request, rejecting it with an AbortError.
+      setTimeoutMock.mockImplementation((_time: number, name?: string) => {
+        if (name === 'Timeout') {
+          const error = new Error(errorMessage)
+          error.name = 'AbortError'
+          rejectFetch(error)
+        }
+        return Promise.resolve()
+      })
+    })
+
+    it('should reject with the timeout error', async () => {
+      await expect(subgraph.query('query', {}, 0)).rejects.toThrow(errorMessage)
+    })
+
+    it('should increment the subgraph_errors_total metric with a timeout kind', async () => {
+      await expect(subgraph.query('query', {}, 0)).rejects.toThrow()
+      expect(metrics.increment).toHaveBeenCalledWith('subgraph_errors_total', { url: SUBGRAPH_URL, kind: 'timeout' })
+    })
+  })
+})

--- a/components/thegraph/tests/utils.spec.ts
+++ b/components/thegraph/tests/utils.spec.ts
@@ -1,0 +1,38 @@
+import { setTimeout } from 'timers/promises'
+import { withTimeout } from '../src/utils'
+
+describe('when running a callback with withTimeout', () => {
+  describe('and the callback resolves before the timeout is reached', () => {
+    let suppliedController: AbortController
+
+    beforeEach(async () => {
+      await withTimeout(async (abortController) => {
+        suppliedController = abortController
+      }, 100000)
+    })
+
+    it('should supply an AbortController to the callback', () => {
+      expect(suppliedController).toBeInstanceOf(AbortController)
+    })
+  })
+
+  describe('and the timeout is reached before the callback resolves', () => {
+    let suppliedController: AbortController
+    const timeout = 100
+
+    beforeEach(async () => {
+      try {
+        await withTimeout(async (abortController) => {
+          suppliedController = abortController
+          return setTimeout(timeout + 300, 'late', { signal: abortController.signal })
+        }, timeout)
+      } catch (error) {
+        // the callback is aborted once the timeout elapses, rejecting the inner setTimeout
+      }
+    })
+
+    it('should abort the controller supplied to the callback', () => {
+      expect(suppliedController.signal.aborted).toBe(true)
+    })
+  })
+})

--- a/components/thegraph/tests/utils.spec.ts
+++ b/components/thegraph/tests/utils.spec.ts
@@ -1,4 +1,5 @@
 import { setTimeout } from 'timers/promises'
+import { SubgraphQueryTimeoutError } from '../src/errors'
 import { withTimeout } from '../src/utils'
 
 describe('when running a callback with withTimeout', () => {
@@ -18,6 +19,7 @@ describe('when running a callback with withTimeout', () => {
 
   describe('and the timeout is reached before the callback resolves', () => {
     let suppliedController: AbortController
+    let thrownError: unknown
     const timeout = 100
 
     beforeEach(async () => {
@@ -27,12 +29,36 @@ describe('when running a callback with withTimeout', () => {
           return setTimeout(timeout + 300, 'late', { signal: abortController.signal })
         }, timeout)
       } catch (error) {
-        // the callback is aborted once the timeout elapses, rejecting the inner setTimeout
+        thrownError = error
       }
     })
 
     it('should abort the controller supplied to the callback', () => {
       expect(suppliedController.signal.aborted).toBe(true)
+    })
+
+    it('should throw a SubgraphQueryTimeoutError', () => {
+      expect(thrownError).toBeInstanceOf(SubgraphQueryTimeoutError)
+    })
+  })
+
+  describe('and the callback rejects with its own error before the timeout is reached', () => {
+    let thrownError: unknown
+    let callbackError: Error
+
+    beforeEach(async () => {
+      callbackError = new Error('Network error')
+      try {
+        await withTimeout(async () => {
+          throw callbackError
+        }, 100000)
+      } catch (error) {
+        thrownError = error
+      }
+    })
+
+    it("should rethrow the callback's original error rather than a SubgraphQueryTimeoutError", () => {
+      expect(thrownError).toBe(callbackError)
     })
   })
 })

--- a/components/thegraph/tsconfig.json
+++ b/components/thegraph/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "types": ["node", "jest"],
+    "declaration": true,
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "composite": true
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,6 +410,19 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
 
+  components/thegraph:
+    dependencies:
+      '@dcl/core-commons':
+        specifier: workspace:*
+        version: link:../../shared/commons
+      '@well-known-components/interfaces':
+        specifier: ^1.5.2
+        version: 1.5.2
+    devDependencies:
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+
   components/traced-fetch:
     dependencies:
       '@dcl/core-commons':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     { "path": "./components/analytics" },
     { "path": "./components/block-indexer" },
     { "path": "./components/job" },
-    { "path": "./components/slack" }
+    { "path": "./components/slack" },
+    { "path": "./components/thegraph" }
   ]
 }


### PR DESCRIPTION
## What

Migrates the subgraph query component from `@well-known-components/thegraph-component` into this monorepo as **`@dcl/thegraph-component`** (`components/thegraph`).

The key change: `createSubgraphComponent` now depends on the native-fetch `IFetchComponent` from `@dcl/core-commons` instead of the one from `@well-known-components/interfaces`, dropping the `node-fetch` coupling. `config`, `logs` and `metrics` still come from `@well-known-components/interfaces`.

## Details

- **`src`** ported as-is (`types.ts`, `utils.ts`, `metrics.ts`); the `createSubgraphComponent` factory moved into `component.ts` and is re-exported from `index.ts` to match the `analytics`/`traced-fetch` layout.
- The `postQuery` request already passes `abortController`, which `RequestOptions` in `@dcl/core-commons` supports, so the query timeout/abort behavior is preserved.
- **Public surface unchanged**: `createSubgraphComponent`, `metricDeclarations`, and the `ISubgraphComponent`/`Variables`/`SubgraphResponse`/`SubgraphProvider`/`PostQueryResponse` types.
- **Tests** rewritten for the `dcl-testing` Jest conventions (plain Jest + the `@dcl/core-commons` mock factories) instead of `@well-known-components/test-helpers`.
- Package wired into the pnpm workspace, listed in the root `README.md`, and a changeset added (`minor`).

## Notes

- The `IFetchComponent` that "drops node-fetch" lives in `@dcl/core-commons` (this repo's `shared/commons`); in `core-libs` the interface is still the `@well-known-components/interfaces` one, so the dependency points at `@dcl/core-commons`.
- The standalone `well-known-components/thegraph-component` repo is left untouched.

## Testing

- `pnpm --filter @dcl/thegraph-component build` — clean (tsc)
- `pnpm --filter @dcl/thegraph-component test` — 23/23 passing
