### PR TITLE
feat: retry fetch requests on network errors

### DIFF
--- a/.changeset/fetch-retry-network-errors.md
+++ b/.changeset/fetch-retry-network-errors.md
@@ -1,0 +1,5 @@
+---
+"@dcl/fetch-component": minor
+---
+
+retry idempotent requests on network-level failures, not just on retryable status codes. a rejected `fetch` (dns resolution, connection refused/reset, socket hang up — including a severed keep-alive connection reused from undici's pool) previously escaped the retry loop and failed on the first attempt regardless of `attempts`. it is now caught and retried like a retryable status code for idempotent methods, re-throwing the last network error once the retries are exhausted. timeout/abort semantics are unchanged and non-idempotent methods are still never retried.

--- a/components/fetch/README.md
+++ b/components/fetch/README.md
@@ -33,6 +33,7 @@ const data = await response.json()
 
 - Backed by the default Node `fetch` API (no `cross-fetch`/`node-fetch` dependency)
 - Automatic retries for idempotent requests (`GET`, `HEAD`, `OPTIONS`, `PUT`, `DELETE`)
+- Retries both retryable status codes and network-level failures (DNS, connection refused/reset, socket hang up)
 - Configurable retry delay and timeout per request
 - Default headers and default request options shared across calls
 - Type-safe through the shared `IFetchComponent` type from `@dcl/core-commons`
@@ -47,7 +48,9 @@ In addition to the standard `RequestInit` options, `fetch` accepts:
 - `abortController` - an `AbortController` used to abort the request
 
 Non-retryable status codes (`400`, `401`, `403`, `404`) and non-idempotent
-methods are never retried.
+methods are never retried. Network-level failures (a rejected `fetch`) are
+retried for idempotent methods up to `attempts` times; once the retries are
+exhausted the last network error is re-thrown.
 
 ## License
 

--- a/components/fetch/src/fetcher.ts
+++ b/components/fetch/src/fetcher.ts
@@ -12,8 +12,14 @@ async function fetchWithRetriesAndTimeout(url: string | URL | Request, options: 
   let attempts = attemptsOption!
   let timer: NodeJS.Timeout | null = null
   let response: Response | undefined = undefined
+  let lastError: unknown = undefined
 
   do {
+    // Reset the per-attempt outcome so a previous attempt's value can't leak into
+    // the retry decision below.
+    response = undefined
+    lastError = undefined
+
     try {
       if (timeout) {
         timer = setTimeout(() => {
@@ -35,15 +41,35 @@ async function fetchWithRetriesAndTimeout(url: string | URL | Request, options: 
       --attempts
 
       response = await racePromise
+    } catch (error) {
+      // A rejected fetch means a network-level failure (DNS resolution, connection
+      // refused/reset, socket hang up). Capture it so the request can be retried
+      // like a retryable status code instead of failing on the first blip.
+      lastError = error
     } finally {
       // Clear the timeout timer on every exit (success, retryable failure or a
       // rejected fetch) so a pending timer can't later abort a controller that
       // is reused by the caller or by a subsequent retry.
       if (timer) clearTimeout(timer)
-      if (!!response && (response.ok || NON_RETRYABLE_STATUS_CODES.includes(response.status) || attempts === 0)) break
-      else await new Promise((resolve) => setTimeout(resolve, retryDelay))
     }
-  } while ((!response || !response.ok) && attempts > 0)
+
+    // Stop on a successful or non-retryable response.
+    if (response && (response.ok || NON_RETRYABLE_STATUS_CODES.includes(response.status))) break
+    // Stop when the request was aborted (timeout or external controller): retrying
+    // would reuse an already-aborted signal, and the caller turns this into the
+    // "Request aborted (timed out)" error after the loop.
+    if (timeoutSignal?.aborted) break
+    // Stop once the retries are exhausted, keeping the latest response/error around.
+    if (attempts === 0) break
+
+    await new Promise((resolve) => setTimeout(resolve, retryDelay))
+  } while (true)
+
+  // The retries were exhausted on network failures and no response was ever
+  // produced: surface the last network error to the caller.
+  if (!response && lastError !== undefined && !timeoutSignal?.aborted) {
+    throw lastError
+  }
 
   return response as Response
 }

--- a/components/fetch/src/fetcher.ts
+++ b/components/fetch/src/fetcher.ts
@@ -65,13 +65,25 @@ async function fetchWithRetriesAndTimeout(url: string | URL | Request, options: 
     await new Promise((resolve) => setTimeout(resolve, retryDelay))
   } while (true)
 
-  // The retries were exhausted on network failures and no response was ever
-  // produced: surface the last network error to the caller.
-  if (!response && lastError !== undefined && !timeoutSignal?.aborted) {
+  // The loop only stops on a usable/non-retryable response, an aborted signal or
+  // exhausted retries. Resolve those into a concrete `Response` or a thrown error
+  // below so the return type is sound without an `as Response` assertion.
+
+  // An aborted signal (timeout or external controller) takes precedence over any
+  // response gathered so far and surfaces the dedicated abort error.
+  if (timeoutSignal?.aborted) {
+    throw new Error('Request aborted (timed out)')
+  }
+
+  // No response means every attempt failed at the network level. "Last attempt
+  // wins": if an earlier attempt returned a retryable HTTP response (e.g. 503) but
+  // the final attempt was a network error, the network error is thrown rather than
+  // the earlier response returned.
+  if (!response) {
     throw lastError
   }
 
-  return response as Response
+  return response
 }
 
 /**
@@ -116,10 +128,8 @@ export function createFetchComponent(defaultOptions?: FetcherOptions): IFetchCom
       abortController: controller
     })
 
-    if (signal.aborted) {
-      throw new Error('Request aborted (timed out)')
-    }
-
+    // fetchWithRetriesAndTimeout resolves to a real Response or throws (on abort,
+    // timeout or exhausted network retries), so no further guarding is needed here.
     return response
   }
 

--- a/components/fetch/tests/fetch.spec.ts
+++ b/components/fetch/tests/fetch.spec.ts
@@ -81,6 +81,75 @@ describe('when fetching with the fetch component', () => {
     })
   })
 
+  describe('and the first attempt fails with a network error', () => {
+    const expectedResponseBody = { mock: 'successful' }
+
+    beforeEach(() => {
+      fetchMock.mockRejectedValueOnce(new Error('network error')).mockResolvedValueOnce(
+        new Response(JSON.stringify(expectedResponseBody), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      )
+    })
+
+    it('should retry and resolve the successful response from the second attempt', async () => {
+      const response = await (await sut.fetch('https://example.com', { attempts: 3, retryDelay: 10 })).json()
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(response).toEqual(expectedResponseBody)
+    })
+  })
+
+  describe('and every attempt fails with a network error', () => {
+    beforeEach(() => {
+      fetchMock.mockRejectedValue(new Error('network error'))
+    })
+
+    it('should exhaust the retries and re-throw the last network error', async () => {
+      await expect(sut.fetch('https://example.com', { attempts: 3, retryDelay: 10 })).rejects.toThrow('network error')
+
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('and a network error is followed by a retryable status', () => {
+    const expectedResponseBody = { mock: 'successful' }
+
+    beforeEach(() => {
+      fetchMock
+        .mockRejectedValueOnce(new Error('network error'))
+        .mockResolvedValueOnce(new Response('test error', { status: 503, headers: { 'Content-Type': 'text/plain' } }))
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify(expectedResponseBody), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          })
+        )
+    })
+
+    it('should keep retrying across both failure types and resolve the successful response', async () => {
+      const response = await (await sut.fetch('https://example.com', { attempts: 3, retryDelay: 10 })).json()
+
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+      expect(response).toEqual(expectedResponseBody)
+    })
+  })
+
+  describe('and a non-idempotent method fails with a network error', () => {
+    beforeEach(() => {
+      fetchMock.mockRejectedValue(new Error('network error'))
+    })
+
+    it('should not retry a POST request and re-throw the network error', async () => {
+      await expect(
+        sut.fetch('https://example.com', { method: 'POST', attempts: 3, retryDelay: 10 })
+      ).rejects.toThrow('network error')
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('and the request exceeds the configured timeout', () => {
     let timer: NodeJS.Timeout | undefined
 


### PR DESCRIPTION
## what

makes the `@dcl/fetch-component` retry mechanism kick in on network-level failures, not just on retryable status codes.

## why

network failures (dns resolution, connection refused/reset, socket hang up) reject the underlying `fetch` rather than resolving to a response. the retry loop had no `catch`, so a rejected fetch escaped on the first attempt and propagated immediately — regardless of the configured `attempts`. a transient network blip on an idempotent `GET` would fail even with `attempts: 3`.

## what changed

- `fetcher.ts`: a rejected `fetch` is now captured and fed back into the retry loop, so idempotent requests retry network errors the same way they retry a retryable status code. once the retries are exhausted with no response, the last network error is re-thrown.
- retry/stop decisions moved out of `finally` into explicit guards so "retry" and "re-throw" can be told apart.
- timeout / abort semantics preserved: an aborted signal stops the loop and the component still surfaces `Request aborted (timed out)`.
- non-idempotent methods (`POST`, ...) are still never retried.
- `README.md`: documents that network-level failures are retried for idempotent methods.

## tests

added cases to `fetch.spec.ts`:
- network error then success → retries and resolves on the second attempt
- every attempt a network error → exhausts retries and re-throws the last error
- network error → retryable `503` → success → retries across both failure types
- `POST` network error → not retried, throws once

all 20 tests pass; `tsc --noEmit` is clean.

## note

the default `attempts` is still `1`, so callers must pass `attempts > 1` to get retries — this change makes network errors *honor* that option, which they didn't before.