### PR TITLE
fix: harden metrics bearer comparison and memory-cache glob matching

### DIFF
--- a/.changeset/harden-metrics-token-and-cache-glob.md
+++ b/.changeset/harden-metrics-token-and-cache-glob.md
@@ -1,0 +1,10 @@
+---
+"@dcl/uws-http-server": patch
+"@dcl/http-server": patch
+"@dcl/memory-cache-component": patch
+---
+
+harden two security-sensitive comparisons in shared library code (#105):
+
+- compare the `/metrics` bearer token in constant time (sha-256 digest + `timingSafeEqual`) in `@dcl/uws-http-server` and `@dcl/http-server` instead of `!==`/`!=`, so the check no longer leaks timing or length information about the configured token.
+- in `@dcl/memory-cache-component` `keys(pattern)`, escape regex metacharacters before turning `*` globs into `.*` and anchor the result with `^`/`$`. this stops a caller-supplied pattern from injecting regex syntax (ReDoS) and makes the match whole-key rather than substring. patterns that relied on the previous unanchored substring matching will need an explicit leading/trailing `*`.

--- a/.changeset/harden-metrics-token-and-cache-glob.md
+++ b/.changeset/harden-metrics-token-and-cache-glob.md
@@ -6,5 +6,5 @@
 
 harden two security-sensitive comparisons in shared library code (#105):
 
-- compare the `/metrics` bearer token in constant time (sha-256 digest + `timingSafeEqual`) in `@dcl/uws-http-server` and `@dcl/http-server` instead of `!==`/`!=`, so the check no longer leaks timing or length information about the configured token.
+- compare the `/metrics` bearer token in constant time (sha-256 digest + `timingSafeEqual`) in `@dcl/uws-http-server` and `@dcl/http-server` instead of `!==`/`!=`, so the check no longer leaks timing or length information about the configured token. `@dcl/http-server` now also validates the `Bearer` authorization scheme (rejecting `Basic <token>` etc.) for parity with `@dcl/uws-http-server`.
 - in `@dcl/memory-cache-component` `keys(pattern)`, escape regex metacharacters before turning `*` globs into `.*` and anchor the result with `^`/`$`. this stops a caller-supplied pattern from injecting regex syntax (ReDoS) and makes the match whole-key rather than substring. patterns that relied on the previous unanchored substring matching will need an explicit leading/trailing `*`.

--- a/components/http-server/src/metrics.ts
+++ b/components/http-server/src/metrics.ts
@@ -4,16 +4,18 @@ import { IHttpServerComponent } from '@dcl/core-commons'
 import { Router } from './router'
 
 /**
- * Constant-time comparison of a candidate bearer token against the expected one.
- * Both values are hashed to a fixed-length digest first so `timingSafeEqual`
- * never throws on a length mismatch and the comparison does not leak the token
- * length through timing.
+ * Builds a constant-time comparator for the configured bearer token. The expected
+ * token is hashed once up front; each candidate is hashed and compared with
+ * `timingSafeEqual`. Hashing to fixed-length digests means the comparison never
+ * throws on a length mismatch and does not leak the token length through timing.
  */
-function safeTokenEquals(candidate: string | undefined, expected: string): boolean {
-  if (typeof candidate !== 'string') return false
-  const candidateHash = createHash('sha256').update(candidate).digest()
+function createBearerTokenComparator(expected: string): (candidate: string | undefined) => boolean {
   const expectedHash = createHash('sha256').update(expected).digest()
-  return timingSafeEqual(candidateHash, expectedHash)
+  return (candidate: string | undefined) => {
+    if (typeof candidate !== 'string') return false
+    const candidateHash = createHash('sha256').update(candidate).digest()
+    return timingSafeEqual(candidateHash, expectedHash)
+  }
 }
 
 const httpLabels = ['method', 'handler', 'code'] as const
@@ -76,6 +78,7 @@ export async function instrumentHttpServerWithPromClientRegistry<K extends strin
 
   const metricsPath = (await config.getString(_configKey('PUBLIC_PATH'))) || '/metrics'
   const bearerToken = await config.getString(_configKey('BEARER_TOKEN'))
+  const compareBearerToken = bearerToken ? createBearerTokenComparator(bearerToken) : undefined
   const resetEveryNight = (await config.getString(_configKey('RESET_AT_NIGHT'))) == 'true'
 
   const router = new Router<{}>()
@@ -88,11 +91,11 @@ export async function instrumentHttpServerWithPromClientRegistry<K extends strin
 
   // TODO: optional basic auth for /metrics
   router.get(metricsPath, async (ctx) => {
-    if (bearerToken) {
+    if (compareBearerToken) {
       const header = ctx.request.headers.get('authorization')
       if (!header) return { status: 401 }
-      const [, value] = header.split(' ')
-      if (!safeTokenEquals(value, bearerToken)) {
+      const [scheme, value] = header.split(' ')
+      if (scheme !== 'Bearer' || !compareBearerToken(value)) {
         return { status: 401 }
       }
     }

--- a/components/http-server/src/metrics.ts
+++ b/components/http-server/src/metrics.ts
@@ -1,6 +1,20 @@
+import { createHash, timingSafeEqual } from 'crypto'
 import { IConfigComponent, IMetricsComponent } from '@well-known-components/interfaces'
 import { IHttpServerComponent } from '@dcl/core-commons'
 import { Router } from './router'
+
+/**
+ * Constant-time comparison of a candidate bearer token against the expected one.
+ * Both values are hashed to a fixed-length digest first so `timingSafeEqual`
+ * never throws on a length mismatch and the comparison does not leak the token
+ * length through timing.
+ */
+function safeTokenEquals(candidate: string | undefined, expected: string): boolean {
+  if (typeof candidate !== 'string') return false
+  const candidateHash = createHash('sha256').update(candidate).digest()
+  const expectedHash = createHash('sha256').update(expected).digest()
+  return timingSafeEqual(candidateHash, expectedHash)
+}
 
 const httpLabels = ['method', 'handler', 'code'] as const
 
@@ -77,8 +91,8 @@ export async function instrumentHttpServerWithPromClientRegistry<K extends strin
     if (bearerToken) {
       const header = ctx.request.headers.get('authorization')
       if (!header) return { status: 401 }
-      const [_, value] = header.split(' ')
-      if (value != bearerToken) {
+      const [, value] = header.split(' ')
+      if (!safeTokenEquals(value, bearerToken)) {
         return { status: 401 }
       }
     }

--- a/components/http-server/test/metrics.spec.ts
+++ b/components/http-server/test/metrics.spec.ts
@@ -79,6 +79,15 @@ describe('when instrumenting the http server with the metrics endpoint', () => {
       })
     })
 
+    describe('and the authorization scheme is not Bearer', () => {
+      it('should respond with 401 and not serialize the metrics', async () => {
+        const response = await server.fetch('/metrics', { headers: { authorization: 'Basic secret-token' } })
+
+        expect(response.status).toBe(401)
+        expect(registry.metrics).not.toHaveBeenCalled()
+      })
+    })
+
     describe('and the provided token is a prefix of the expected token', () => {
       it('should respond with 401 without throwing on the length mismatch', async () => {
         const response = await server.fetch('/metrics', { headers: { authorization: 'Bearer secret' } })

--- a/components/http-server/test/metrics.spec.ts
+++ b/components/http-server/test/metrics.spec.ts
@@ -1,0 +1,100 @@
+import { createTestServerComponent } from '../src'
+import { instrumentHttpServerWithPromClientRegistry } from '../src/metrics'
+
+function createMockConfig(values: Record<string, string | undefined>) {
+  return { getString: jest.fn(async (key: string) => values[key]) } as any
+}
+
+function createMockMetrics() {
+  return {
+    startTimer: jest.fn().mockReturnValue({ end: jest.fn() }),
+    observe: jest.fn(),
+    increment: jest.fn(),
+    resetAll: jest.fn()
+  } as any
+}
+
+function createMockRegistry() {
+  return {
+    contentType: 'text/plain; version=0.0.4',
+    metrics: jest.fn().mockResolvedValue('metrics_body')
+  }
+}
+
+describe('when instrumenting the http server with the metrics endpoint', () => {
+  let server: ReturnType<typeof createTestServerComponent>
+  let metrics: ReturnType<typeof createMockMetrics>
+  let registry: ReturnType<typeof createMockRegistry>
+
+  beforeEach(() => {
+    server = createTestServerComponent()
+    metrics = createMockMetrics()
+    registry = createMockRegistry()
+  })
+
+  describe('and no bearer token is configured', () => {
+    beforeEach(async () => {
+      await instrumentHttpServerWithPromClientRegistry({
+        server,
+        config: createMockConfig({}),
+        metrics,
+        registry: registry as any
+      })
+    })
+
+    it('should respond with the serialized metrics and the registry content type', async () => {
+      const response = await server.fetch('/metrics')
+
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe('metrics_body')
+      expect(response.headers.get('content-type')).toBe('text/plain; version=0.0.4')
+    })
+  })
+
+  describe('and a bearer token is configured', () => {
+    beforeEach(async () => {
+      await instrumentHttpServerWithPromClientRegistry({
+        server,
+        config: createMockConfig({ WKC_METRICS_BEARER_TOKEN: 'secret-token' }),
+        metrics,
+        registry: registry as any
+      })
+    })
+
+    describe('and the request has no authorization header', () => {
+      it('should respond with 401 and not serialize the metrics', async () => {
+        const response = await server.fetch('/metrics')
+
+        expect(response.status).toBe(401)
+        expect(registry.metrics).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('and the bearer token does not match', () => {
+      it('should respond with 401 and not serialize the metrics', async () => {
+        const response = await server.fetch('/metrics', { headers: { authorization: 'Bearer wrong-token' } })
+
+        expect(response.status).toBe(401)
+        expect(registry.metrics).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('and the provided token is a prefix of the expected token', () => {
+      it('should respond with 401 without throwing on the length mismatch', async () => {
+        const response = await server.fetch('/metrics', { headers: { authorization: 'Bearer secret' } })
+
+        expect(response.status).toBe(401)
+        expect(registry.metrics).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('and the bearer token matches', () => {
+      it('should respond with the serialized metrics', async () => {
+        const response = await server.fetch('/metrics', { headers: { authorization: 'Bearer secret-token' } })
+
+        expect(response.status).toBe(200)
+        expect(await response.text()).toBe('metrics_body')
+      })
+    })
+  })
+})

--- a/components/memory-cache/src/component.ts
+++ b/components/memory-cache/src/component.ts
@@ -70,9 +70,13 @@ export function createInMemoryCacheComponent(options?: InMemoryCacheOptions): IC
       const allKeys = Array.from(cache.keys()) as string[]
       if (!pattern) return allKeys
 
-      // Simple pattern matching - convert glob-like pattern to regex
-      const regexPattern = pattern.replace(/\*/g, '.*')
-      const regex = new RegExp(regexPattern)
+      // Convert a glob-like pattern to a regex. Escape every regex metacharacter
+      // first so a caller-supplied pattern can't inject regex syntax (avoiding
+      // ReDoS), then turn the escaped `*` globs back into `.*` wildcards, and
+      // anchor with `^`/`$` so the pattern matches the whole key rather than a
+      // substring.
+      const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      const regex = new RegExp(`^${escaped.replace(/\\\*/g, '.*')}$`)
       return allKeys.filter((key: string) => regex.test(key))
     },
 

--- a/components/memory-cache/tests/memory-cache-component.spec.ts
+++ b/components/memory-cache/tests/memory-cache-component.spec.ts
@@ -303,6 +303,52 @@ describe('when scanning keys', () => {
       expect(result).toHaveLength(0)
     })
   })
+
+  describe('and scanning with a pattern that is a substring of stored keys', () => {
+    it('should not match keys by substring because the pattern is anchored', async () => {
+      const result = await component.keys('user')
+
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('and scanning with a pattern containing regex metacharacters', () => {
+    beforeEach(async () => {
+      await component.set('user.123', 'literal-dot')
+    })
+
+    it('should treat the dot literally instead of as a regex wildcard', async () => {
+      const result = await component.keys('user.123')
+
+      expect(result).toEqual(['user.123'])
+      expect(result).not.toContain('user:123')
+    })
+
+    it('should match a literal prefix followed by a wildcard', async () => {
+      const result = await component.keys('user.*')
+
+      expect(result).toContain('user.123')
+      expect(result).not.toContain('user:123')
+    })
+  })
+
+  describe('and scanning with a ReDoS-prone pattern against a key that would trigger backtracking', () => {
+    beforeEach(async () => {
+      // A long run of 'a's followed by a non-matching character is the classic
+      // input that makes a pattern like /(a+)+$/ backtrack catastrophically. If
+      // the metacharacters were not escaped, this scan would hang.
+      await component.set(`${'a'.repeat(50)}!`, 'value')
+    })
+
+    it('should evaluate quickly and match nothing because injected regex syntax is escaped', async () => {
+      const start = Date.now()
+      const result = await component.keys('(a+)+$')
+      const elapsed = Date.now() - start
+
+      expect(result).toHaveLength(0)
+      expect(elapsed).toBeLessThan(1000)
+    })
+  })
 })
 
 describe('when handling different data types', () => {

--- a/components/uws-http-server/src/metrics.ts
+++ b/components/uws-http-server/src/metrics.ts
@@ -1,8 +1,22 @@
+import { createHash, timingSafeEqual } from 'crypto'
 import { IMetricsComponent } from '@well-known-components/interfaces'
 import * as uws from 'uWebSockets.js'
 import { Components, HttpMetrics, metrics } from './types'
 
 export const CONFIG_PREFIX = 'WKC_METRICS' as const
+
+/**
+ * Constant-time comparison of a candidate bearer token against the expected one.
+ * Both values are hashed to a fixed-length digest first so `timingSafeEqual`
+ * never throws on a length mismatch and the comparison does not leak the token
+ * length through timing.
+ */
+function safeTokenEquals(candidate: string | undefined, expected: string): boolean {
+  if (typeof candidate !== 'string') return false
+  const candidateHash = createHash('sha256').update(candidate).digest()
+  const expectedHash = createHash('sha256').update(expected).digest()
+  return timingSafeEqual(candidateHash, expectedHash)
+}
 
 export function getDefaultHttpMetrics(): IMetricsComponent.MetricsRecordDefinition<HttpMetrics> {
   return metrics
@@ -47,7 +61,7 @@ export async function createMetricsHandler(
       if (bearerToken) {
         const header = req.getHeader('authorization')
         const [scheme, value] = header ? header.split(' ') : []
-        if (scheme !== 'Bearer' || value !== bearerToken) {
+        if (scheme !== 'Bearer' || !safeTokenEquals(value, bearerToken)) {
           res.writeStatus('401 Unauthorized')
           res.end()
           return

--- a/components/uws-http-server/src/metrics.ts
+++ b/components/uws-http-server/src/metrics.ts
@@ -6,16 +6,18 @@ import { Components, HttpMetrics, metrics } from './types'
 export const CONFIG_PREFIX = 'WKC_METRICS' as const
 
 /**
- * Constant-time comparison of a candidate bearer token against the expected one.
- * Both values are hashed to a fixed-length digest first so `timingSafeEqual`
- * never throws on a length mismatch and the comparison does not leak the token
- * length through timing.
+ * Builds a constant-time comparator for the configured bearer token. The expected
+ * token is hashed once up front; each candidate is hashed and compared with
+ * `timingSafeEqual`. Hashing to fixed-length digests means the comparison never
+ * throws on a length mismatch and does not leak the token length through timing.
  */
-function safeTokenEquals(candidate: string | undefined, expected: string): boolean {
-  if (typeof candidate !== 'string') return false
-  const candidateHash = createHash('sha256').update(candidate).digest()
+function createBearerTokenComparator(expected: string): (candidate: string | undefined) => boolean {
   const expectedHash = createHash('sha256').update(expected).digest()
-  return timingSafeEqual(candidateHash, expectedHash)
+  return (candidate: string | undefined) => {
+    if (typeof candidate !== 'string') return false
+    const candidateHash = createHash('sha256').update(candidate).digest()
+    return timingSafeEqual(candidateHash, expectedHash)
+  }
 }
 
 export function getDefaultHttpMetrics(): IMetricsComponent.MetricsRecordDefinition<HttpMetrics> {
@@ -36,6 +38,7 @@ export async function createMetricsHandler(
 
   const metricsPath = (await config.getString(_configKey('PUBLIC_PATH'))) || '/metrics'
   const bearerToken = await config.getString(_configKey('BEARER_TOKEN'))
+  const compareBearerToken = bearerToken ? createBearerTokenComparator(bearerToken) : undefined
   const rotateMetrics = (await config.getString(_configKey('RESET_AT_NIGHT'))) === 'true'
 
   function calculateNextReset() {
@@ -58,10 +61,10 @@ export async function createMetricsHandler(
       // The request object is only valid synchronously (before the first
       // `await`), so authorization is checked here. This also avoids serializing
       // the metrics for unauthorized callers.
-      if (bearerToken) {
+      if (compareBearerToken) {
         const header = req.getHeader('authorization')
         const [scheme, value] = header ? header.split(' ') : []
-        if (scheme !== 'Bearer' || !safeTokenEquals(value, bearerToken)) {
+        if (scheme !== 'Bearer' || !compareBearerToken(value)) {
           res.writeStatus('401 Unauthorized')
           res.end()
           return

--- a/components/uws-http-server/tests/metrics.spec.ts
+++ b/components/uws-http-server/tests/metrics.spec.ts
@@ -141,6 +141,19 @@ describe('when creating the metrics handler', () => {
       })
     })
 
+    describe('and the bearer token is a prefix of the expected token', () => {
+      beforeEach(() => {
+        req.getHeader.mockReturnValue('Bearer secret')
+      })
+
+      it('should respond with 401 Unauthorized without throwing on the length mismatch', async () => {
+        await handler(res, req)
+
+        expect(res.writeStatus).toHaveBeenCalledWith('401 Unauthorized')
+        expect(registry.metrics).not.toHaveBeenCalled()
+      })
+    })
+
     describe('and the bearer token matches', () => {
       beforeEach(() => {
         req.getHeader.mockReturnValue('Bearer secret-token')


### PR DESCRIPTION
closes #105

## what

hardens two security-sensitive comparisons in shared library code flagged in #105.

## why

- `components/uws-http-server/src/metrics.ts` and `components/http-server/src/metrics.ts` compared the `/metrics` bearer token with `!==` / `!=` (non-constant-time, and loose equality in the http-server case).
- `components/memory-cache/src/component.ts` built a regex from a glob via `replace(/\*/g, '.*')` with no escaping and no anchoring — a caller-supplied pattern could inject regex syntax (ReDoS) and matching was by substring rather than whole-key.

impact today is low / defense-in-depth (the token attack is impractical over the network; the only production `keys()` caller builds the pattern from a validated EthAddress behind a bearer-gated endpoint), but this is shared library code so it's worth hardening for future consumers.

## what changed

- **constant-time token compare**: a small private `safeTokenEquals` helper in both metrics files hashes each side to a sha-256 digest and compares with `crypto.timingSafeEqual`. hashing to a fixed length avoids the `RangeError` that `timingSafeEqual` throws on differing lengths and stops the comparison leaking the token length. a missing token resolves to `false`.
- **memory-cache glob**: escape every regex metacharacter, then turn the escaped `*` globs back into `.*`, then anchor with `^`/`$`. existing `*` globs (e.g. `user:*`) keep working; matching is now whole-key instead of substring.

## tests

- **memory-cache**: added anchoring, literal-metacharacter and a ReDoS regression test (stores `aaaa…!` and queries `(a+)+$` — instant now, would time out if the escaping is reverted).
- **uws-http-server**: added an explicit prefix-token 401 case (the existing wrong-token case already exercises a length mismatch).
- **http-server**: the metrics endpoint had no coverage, so added `test/metrics.spec.ts` driving the real router (no-token / missing / wrong / prefix / matching token).
- `tsc --noEmit` clean and full suites green across all three packages.

## notes

- memory-cache is bumped **patch**, but the substring → whole-key change is technically a behavior change: patterns that relied on the old unanchored substring matching now need an explicit leading/trailing `*`.
- `safeTokenEquals` is duplicated (~6 lines) per package rather than centralized in `@dcl/core-commons`, to avoid a cross-package release for a tiny helper. happy to centralize if preferred.