### PR TITLE
feat: move tracer-component and http-requests-logger-component into core-components

### DIFF
--- a/.changeset/http-requests-logger-component-initial.md
+++ b/.changeset/http-requests-logger-component-initial.md
@@ -1,0 +1,5 @@
+---
+"@dcl/http-requests-logger-component": major
+---
+
+initial release of `@dcl/http-requests-logger-component`, moved into core-components from `@well-known-components/http-requests-logger-component`. logs each http request and response with configurable verbosity, custom log formats, and endpoint skipping. the `server` argument is typed against `@dcl/core-commons`' `IHttpServerComponent`, so it pairs with `@dcl/http-server` v2 without a cast.

--- a/.changeset/http-requests-logger-component-initial.md
+++ b/.changeset/http-requests-logger-component-initial.md
@@ -3,3 +3,5 @@
 ---
 
 initial release of `@dcl/http-requests-logger-component`, moved into core-components from `@well-known-components/http-requests-logger-component`. logs each http request and response with configurable verbosity, custom log formats, and endpoint skipping. the `server` argument is typed against `@dcl/core-commons`' `IHttpServerComponent`, so it pairs with `@dcl/http-server` v2 without a cast.
+
+an error that escapes the handler chain without a `status` / `statusCode` is now logged as `500` instead of `200`.

--- a/.changeset/http-requests-logger-component-initial.md
+++ b/.changeset/http-requests-logger-component-initial.md
@@ -4,4 +4,8 @@
 
 initial release of `@dcl/http-requests-logger-component`, moved into core-components from `@well-known-components/http-requests-logger-component`. logs each http request and response with configurable verbosity, custom log formats, and endpoint skipping. the `server` argument is typed against `@dcl/core-commons`' `IHttpServerComponent`, so it pairs with `@dcl/http-server` v2 without a cast.
 
-an error that escapes the handler chain without a `status` / `statusCode` is now logged as `500` instead of `200`.
+includes fixes relative to the original component:
+
+- an error that escapes the handler chain is now logged at error level with status `500` (it was logged at the configured verbosity with status `200`).
+- `skip` regexes carrying the global/sticky flag now match consistently across requests (the reused regex's `lastIndex` previously made matches alternate).
+- a custom `inputLog` callback is no longer invoked for requests whose input log is skipped.

--- a/.changeset/tracer-component-initial.md
+++ b/.changeset/tracer-component-initial.md
@@ -1,0 +1,5 @@
+---
+"@dcl/tracer-component": major
+---
+
+initial release of `@dcl/tracer-component`, moved into core-components from `@well-known-components/tracer-component`. creates trace spans over an execution and exposes the w3c trace context (`traceparent` / `tracestate`) to the traced code.

--- a/.changeset/tracer-component-initial.md
+++ b/.changeset/tracer-component-initial.md
@@ -9,5 +9,6 @@ includes fixes relative to the original component:
 - `getTraceStateString()` now formats the trace state as `key=value` pairs joined by commas (it previously emitted malformed output such as `=a,1,=b,2`).
 - `getTraceState()` / `getContextData()` now freeze a shallow copy instead of the live value, so reading the trace state no longer makes later `setTraceStateProperty` / `deleteTraceStateProperty` calls throw.
 - nested spans now set the child `parentId` to the parent span id rather than the trace id, preserving the span hierarchy.
+- nested spans now copy the inherited trace state, so a child span's `setTraceStateProperty` / `deleteTraceStateProperty` calls no longer leak back into the parent and sibling spans.
 - `buildTraceString()` now zero-pads the version and trace flags to two hex digits, matching the w3c `traceparent` format.
 - `NotInSpanError` and `INVALID_SPAN_ID` are now exported from the package entry point.

--- a/.changeset/tracer-component-initial.md
+++ b/.changeset/tracer-component-initial.md
@@ -3,3 +3,11 @@
 ---
 
 initial release of `@dcl/tracer-component`, moved into core-components from `@well-known-components/tracer-component`. creates trace spans over an execution and exposes the w3c trace context (`traceparent` / `tracestate`) to the traced code.
+
+includes fixes relative to the original component:
+
+- `getTraceStateString()` now formats the trace state as `key=value` pairs joined by commas (it previously emitted malformed output such as `=a,1,=b,2`).
+- `getTraceState()` / `getContextData()` now freeze a shallow copy instead of the live value, so reading the trace state no longer makes later `setTraceStateProperty` / `deleteTraceStateProperty` calls throw.
+- nested spans now set the child `parentId` to the parent span id rather than the trace id, preserving the span hierarchy.
+- `buildTraceString()` now zero-pads the version and trace flags to two hex digits, matching the w3c `traceparent` format.
+- `NotInSpanError` and `INVALID_SPAN_ID` are now exported from the package entry point.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ core-components/
 │   ├── block-indexer/    # On-chain block indexer component
 │   ├── features/         # Feature flags resolution component
 │   ├── fetch/            # Fetch component using the native Node fetch API
+│   ├── http-requests-logger/ # HTTP request/response logging middleware component
 │   ├── http-server/      # HTTP server component
 │   ├── http-tracer/      # HTTP tracer component (W3C trace context propagation)
 │   ├── job/              # Job scheduling and execution component
@@ -28,6 +29,7 @@ core-components/
 │   ├── sqs/              # AWS SQS queue component
 │   ├── thegraph/         # thegraph subgraph GraphQL query component
 │   ├── traced-fetch/     # Traced fetch component with distributed tracing
+│   ├── tracer/           # Execution trace span component (W3C trace context)
 │   └── uws-http-server/  # uWebSockets.js based HTTP server component
 └── shared/             # Shared utilities and types
     └── commons/          # Common utilities, types, and constants
@@ -43,7 +45,9 @@ core-components/
 ### Observability
 
 - **Metrics Component** (`@dcl/metrics`) - Prometheus metrics collection and instrumentation
+- **Tracer Component** (`@dcl/tracer-component`) - Creates trace spans over an execution and exposes the W3C trace context to the traced code
 - **HTTP Tracer Component** (`@dcl/http-tracer-component`) - Adds tracing spans to request handlers and propagates W3C trace context headers
+- **HTTP Requests Logger Component** (`@dcl/http-requests-logger-component`) - Logs each HTTP request and response with configurable verbosity and endpoint skipping
 
 ### Communication & Messaging
 
@@ -157,6 +161,7 @@ This project uses [Changesets](https://github.com/changesets/changesets) for aut
 - `@dcl/analytics-component`
 - `@dcl/block-indexer`
 - `@dcl/features-component`
+- `@dcl/http-requests-logger-component`
 - `@dcl/http-server`
 - `@dcl/http-tracer-component`
 - `@dcl/job-component`
@@ -174,6 +179,7 @@ This project uses [Changesets](https://github.com/changesets/changesets) for aut
 - `@dcl/sqs-component`
 - `@dcl/thegraph-component`
 - `@dcl/traced-fetch-component`
+- `@dcl/tracer-component`
 - `@dcl/uws-http-server`
 - `@dcl/core-commons`
 

--- a/components/http-requests-logger/CHANGELOG.md
+++ b/components/http-requests-logger/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @dcl/http-requests-logger-component

--- a/components/http-requests-logger/README.md
+++ b/components/http-requests-logger/README.md
@@ -1,0 +1,51 @@
+# @dcl/http-requests-logger-component
+
+Logs each HTTP request and response handled by the server, with configurable
+verbosity, custom log formats, and endpoint skipping.
+
+## Installation
+
+```bash
+npm install @dcl/http-requests-logger-component
+```
+
+## Usage
+
+Instrument the server with the request logger, passing the `server` and a
+`logger` component:
+
+```typescript
+import { instrumentHttpServerWithRequestLogger } from '@dcl/http-requests-logger-component'
+
+instrumentHttpServerWithRequestLogger({ server, logger })
+```
+
+It registers a middleware that logs an input line when a request comes in and an
+output line (including the response status) once it is handled. Health-check
+endpoints (`/health/live` and `/health/ready`) are skipped by default.
+
+### Configuration
+
+An optional second argument customizes the behavior:
+
+```typescript
+import { instrumentHttpServerWithRequestLogger, Verbosity } from '@dcl/http-requests-logger-component'
+
+instrumentHttpServerWithRequestLogger(
+  { server, logger },
+  {
+    verbosity: Verbosity.DEBUG,
+    skipInput: false,
+    skipOutput: false,
+    skip: ['/health/live', '/health/ready'],
+    inputLog: req => `--> ${req.method} ${req.url}`,
+    outputLog: (req, res) => `<-- ${req.method} ${req.url} ${res.status}`
+  }
+)
+```
+
+- **`verbosity`** - log level used for the request logs. Defaults to `Verbosity.INFO`.
+- **`inputLog`** / **`outputLog`** - functions to customize the logged messages.
+- **`skipInput`** / **`skipOutput`** - disable the input or output log line.
+- **`skip`** - a string, array of strings, `RegExp`, or predicate over the request
+  to decide which endpoints to skip. Defaults to skipping `/health/live` and `/health/ready`.

--- a/components/http-requests-logger/jest.config.js
+++ b/components/http-requests-logger/jest.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>'],
+  testMatch: [
+    '**/tests/**/*.spec.ts',
+    '**/tests/**/*.test.ts',
+    '**/?(*.)+(spec|test).ts'
+  ],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/dist/'
+  ],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!**/*.d.ts',
+  ],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+}

--- a/components/http-requests-logger/package.json
+++ b/components/http-requests-logger/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@dcl/http-requests-logger-component",
+  "version": "0.0.0",
+  "description": "Logs each http request for core components library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/http-requests-logger"
+  },
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "test": "jest",
+    "lint": "echo \"No linting configured\""
+  },
+  "dependencies": {
+    "@dcl/core-commons": "workspace:*",
+    "@well-known-components/interfaces": "^1.5.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/components/http-requests-logger/src/component.ts
+++ b/components/http-requests-logger/src/component.ts
@@ -6,6 +6,9 @@ import { HEALTH_LIVE, HEALTH_READY } from './constants'
 import { shouldSkip } from './logic'
 import { RequestLoggerConfigurations, Verbosity } from './types'
 
+// Endpoints whose request/response logs are skipped unless the caller overrides `skip`.
+const DEFAULT_SKIP_ENDPOINTS = [HEALTH_LIVE, HEALTH_READY]
+
 export function instrumentHttpServerWithRequestLogger(
   components: {
     server: IHttpServerComponent<object>
@@ -22,20 +25,23 @@ export function instrumentHttpServerWithRequestLogger(
     const skipInput = config?.skipInput
     const skipOutput = config?.skipOutput
     // Skip health checks by default
-    const skip = shouldSkip(ctx, config?.skip ?? [HEALTH_LIVE, HEALTH_READY])
+    const skip = shouldSkip(ctx, config?.skip ?? DEFAULT_SKIP_ENDPOINTS)
 
-    const inLog = config?.inputLog
-      ? config.inputLog(ctx.request)
-      : `[${ctx.request.method}: ${ctx.url.pathname}${ctx.url.search}${ctx.url.hash}]`
     if (!skipInput && !skip) {
+      // Build the input log lazily so a custom inputLog callback isn't invoked for skipped requests.
+      const inLog = config?.inputLog
+        ? config.inputLog(ctx.request)
+        : `[${ctx.request.method}: ${ctx.url.pathname}${ctx.url.search}${ctx.url.hash}]`
       inLogger[verbosity](inLog)
     }
     let response: IHttpServerComponent.IResponse | undefined = undefined
+    let errored = false
 
     try {
       response = await next()
       return response
     } catch (e) {
+      errored = true
       // Craft a custom response with the purpose of printing the log. Default to 500
       // since reaching here means an error escaped the handler chain.
       let statusCode = 500
@@ -52,7 +58,9 @@ export function instrumentHttpServerWithRequestLogger(
       throw e
     } finally {
       if (!skipOutput && !skip && response) {
-        outLogger[verbosity](
+        // Surface failures at error level regardless of the configured verbosity.
+        const outVerbosity = errored ? Verbosity.ERROR : verbosity
+        outLogger[outVerbosity](
           config?.outputLog
             ? config.outputLog(ctx.request, response)
             : `[${ctx.request.method}: ${ctx.url.pathname}${ctx.url.search}${ctx.url.hash}][${response.status}]`

--- a/components/http-requests-logger/src/component.ts
+++ b/components/http-requests-logger/src/component.ts
@@ -36,8 +36,9 @@ export function instrumentHttpServerWithRequestLogger(
       response = await next()
       return response
     } catch (e) {
-      // Craft a custom response with the purpose of printing the log
-      let statusCode = 200
+      // Craft a custom response with the purpose of printing the log. Default to 500
+      // since reaching here means an error escaped the handler chain.
+      let statusCode = 500
       if (typeof e === 'object' && e !== null && e !== undefined) {
         if ('status' in e && typeof e.status == 'number') {
           statusCode = e.status

--- a/components/http-requests-logger/src/component.ts
+++ b/components/http-requests-logger/src/component.ts
@@ -1,0 +1,62 @@
+import { ILoggerComponent } from '@well-known-components/interfaces'
+// Source IHttpServerComponent from @dcl/core-commons so this logger accepts an @dcl/http-server v2
+// server (native-fetch request/response types) without casts.
+import { IHttpServerComponent } from '@dcl/core-commons'
+import { HEALTH_LIVE, HEALTH_READY } from './constants'
+import { shouldSkip } from './logic'
+import { RequestLoggerConfigurations, Verbosity } from './types'
+
+export function instrumentHttpServerWithRequestLogger(
+  components: {
+    server: IHttpServerComponent<object>
+    logger: ILoggerComponent
+  },
+  config?: RequestLoggerConfigurations
+): void {
+  const { server, logger } = components
+  const verbosity = config?.verbosity ?? Verbosity.INFO
+  const inLogger = logger.getLogger('http-in')
+  const outLogger = logger.getLogger('http-out')
+
+  server.use(async (ctx: IHttpServerComponent.DefaultContext<object>, next) => {
+    const skipInput = config?.skipInput
+    const skipOutput = config?.skipOutput
+    // Skip health checks by default
+    const skip = shouldSkip(ctx, config?.skip ?? [HEALTH_LIVE, HEALTH_READY])
+
+    const inLog = config?.inputLog
+      ? config.inputLog(ctx.request)
+      : `[${ctx.request.method}: ${ctx.url.pathname}${ctx.url.search}${ctx.url.hash}]`
+    if (!skipInput && !skip) {
+      inLogger[verbosity](inLog)
+    }
+    let response: IHttpServerComponent.IResponse | undefined = undefined
+
+    try {
+      response = await next()
+      return response
+    } catch (e) {
+      // Craft a custom response with the purpose of printing the log
+      let statusCode = 200
+      if (typeof e === 'object' && e !== null && e !== undefined) {
+        if ('status' in e && typeof e.status == 'number') {
+          statusCode = e.status
+        } else if ('statusCode' in e && typeof e.statusCode == 'number') {
+          statusCode = e.statusCode
+        }
+      }
+      response = {
+        status: statusCode
+      }
+      throw e
+    } finally {
+      if (!skipOutput && !skip && response) {
+        outLogger[verbosity](
+          config?.outputLog
+            ? config.outputLog(ctx.request, response)
+            : `[${ctx.request.method}: ${ctx.url.pathname}${ctx.url.search}${ctx.url.hash}][${response.status}]`
+        )
+      }
+    }
+  })
+}

--- a/components/http-requests-logger/src/constants.ts
+++ b/components/http-requests-logger/src/constants.ts
@@ -1,0 +1,2 @@
+export const HEALTH_LIVE = '/health/live'
+export const HEALTH_READY = '/health/ready'

--- a/components/http-requests-logger/src/index.ts
+++ b/components/http-requests-logger/src/index.ts
@@ -1,0 +1,2 @@
+export * from './component'
+export * from './types'

--- a/components/http-requests-logger/src/logic.ts
+++ b/components/http-requests-logger/src/logic.ts
@@ -11,5 +11,10 @@ export function shouldSkip(
   } else if (typeof skipper === 'function') {
     return skipper(ctx.request)
   }
-  return (skipper as RegExp).test(ctx.url.pathname)
+  const regExp = skipper as RegExp
+  // Strip the global/sticky flags: the same regex is reused across requests, and `.test()`
+  // on a global/sticky regex advances `lastIndex`, which would make matches alternate per call.
+  const statelessRegExp =
+    regExp.global || regExp.sticky ? new RegExp(regExp.source, regExp.flags.replace(/[gy]/g, '')) : regExp
+  return statelessRegExp.test(ctx.url.pathname)
 }

--- a/components/http-requests-logger/src/logic.ts
+++ b/components/http-requests-logger/src/logic.ts
@@ -1,0 +1,15 @@
+import { IHttpServerComponent } from '@dcl/core-commons'
+
+export function shouldSkip(
+  ctx: IHttpServerComponent.DefaultContext<object>,
+  skipper: ((req: IHttpServerComponent.DefaultContext<object>['request']) => boolean) | string[] | string | RegExp
+) {
+  if (typeof skipper === 'string') {
+    return skipper === ctx.url.pathname
+  } else if (Array.isArray(skipper)) {
+    return skipper.some(urlToSkip => urlToSkip === ctx.url.pathname)
+  } else if (typeof skipper === 'function') {
+    return skipper(ctx.request)
+  }
+  return (skipper as RegExp).test(ctx.url.pathname)
+}

--- a/components/http-requests-logger/src/types.ts
+++ b/components/http-requests-logger/src/types.ts
@@ -20,6 +20,6 @@ export type RequestLoggerConfigurations = {
   skipInput?: boolean
   /** A flag to disable the outputting of the output log. */
   skipOutput?: boolean
-  /** A flexible parameter to define how to skip the logging of endpoints. Defaults to skipping the /health/live endpoint. */
+  /** A flexible parameter to define how to skip the logging of endpoints. Defaults to skipping the /health/live and /health/ready endpoints. */
   skip?: ((req: IHttpServerComponent.DefaultContext<object>['request']) => boolean) | string[] | string | RegExp
 }

--- a/components/http-requests-logger/src/types.ts
+++ b/components/http-requests-logger/src/types.ts
@@ -1,0 +1,25 @@
+// Source IHttpServerComponent from @dcl/core-commons so this logger accepts an @dcl/http-server v2
+// server (native-fetch request/response types) without casts.
+import { IHttpServerComponent } from '@dcl/core-commons'
+
+export enum Verbosity {
+  INFO = 'info',
+  DEBUG = 'debug',
+  ERROR = 'error',
+  WARN = 'warn'
+}
+
+export type RequestLoggerConfigurations = {
+  /** The verbosity on which the logs will be outputted. Defaults to INFO. */
+  verbosity?: Verbosity
+  /** A customizable function that defines how the input log will be outputted. Defaults to outputting [$method: $path]. */
+  inputLog?: (req: IHttpServerComponent.DefaultContext<object>['request']) => string
+  /** A customizable function that defines how the output log will be outputted. Defaults to outputting [$method: $path][$status]. */
+  outputLog?: (req: IHttpServerComponent.DefaultContext<object>['request'], res: IHttpServerComponent.IResponse) => string
+  /** A flag to disable the outputting of the input log. */
+  skipInput?: boolean
+  /** A flag to disable the outputting of the output log. */
+  skipOutput?: boolean
+  /** A flexible parameter to define how to skip the logging of endpoints. Defaults to skipping the /health/live endpoint. */
+  skip?: ((req: IHttpServerComponent.DefaultContext<object>['request']) => boolean) | string[] | string | RegExp
+}

--- a/components/http-requests-logger/tests/component.spec.ts
+++ b/components/http-requests-logger/tests/component.spec.ts
@@ -108,7 +108,7 @@ describe('when the skip output configuration is set', () => {
       response = await storedMiddleware(mockedContext, mockedNext)
     })
 
-    it('should log the request output and log the request input', () => {
+    it('should log the request input and not log the request output', () => {
       expect(loggers[0]?.info).toHaveBeenCalled()
       expect(loggers[1]?.info).not.toHaveBeenCalled()
     })

--- a/components/http-requests-logger/tests/component.spec.ts
+++ b/components/http-requests-logger/tests/component.spec.ts
@@ -298,10 +298,10 @@ describe('when any of the following middlewares fail', () => {
       mockedNext = jest.fn().mockRejectedValueOnce(error)
     })
 
-    it('should log the output correctly using the status code as 200', async () => {
+    it('should log the output correctly using the status code as 500', async () => {
       await expect(storedMiddleware(mockedContext, mockedNext)).rejects.toEqual(error)
       expect(loggers[1]?.info).toHaveBeenCalledWith(
-        `[${mockedContext.request.method}: ${mockedContext.url.pathname}${mockedContext.url.search}${mockedContext.url.hash}][200]`
+        `[${mockedContext.request.method}: ${mockedContext.url.pathname}${mockedContext.url.search}${mockedContext.url.hash}][500]`
       )
     })
   })

--- a/components/http-requests-logger/tests/component.spec.ts
+++ b/components/http-requests-logger/tests/component.spec.ts
@@ -283,9 +283,9 @@ describe('when any of the following middlewares fail', () => {
       mockedNext = jest.fn().mockRejectedValueOnce(error)
     })
 
-    it('should log the output correctly based on the status code of the exception and propagate the error', async () => {
+    it('should log the output at error level based on the status code of the exception and propagate the error', async () => {
       await expect(storedMiddleware(mockedContext, mockedNext)).rejects.toEqual(error)
-      expect(loggers[1]?.info).toHaveBeenCalledWith(
+      expect(loggers[1]?.error).toHaveBeenCalledWith(
         `[${mockedContext.request.method}: ${mockedContext.url.pathname}${mockedContext.url.search}${mockedContext.url.hash}][400]`
       )
     })
@@ -298,9 +298,9 @@ describe('when any of the following middlewares fail', () => {
       mockedNext = jest.fn().mockRejectedValueOnce(error)
     })
 
-    it('should log the output correctly using the status code as 500', async () => {
+    it('should log the output at error level using the status code as 500', async () => {
       await expect(storedMiddleware(mockedContext, mockedNext)).rejects.toEqual(error)
-      expect(loggers[1]?.info).toHaveBeenCalledWith(
+      expect(loggers[1]?.error).toHaveBeenCalledWith(
         `[${mockedContext.request.method}: ${mockedContext.url.pathname}${mockedContext.url.search}${mockedContext.url.hash}][500]`
       )
     })

--- a/components/http-requests-logger/tests/component.spec.ts
+++ b/components/http-requests-logger/tests/component.spec.ts
@@ -1,0 +1,308 @@
+import { ILoggerComponent } from '@well-known-components/interfaces'
+import { IHttpServerComponent } from '@dcl/core-commons'
+import { instrumentHttpServerWithRequestLogger } from '../src/component'
+import { RequestLoggerConfigurations, Verbosity } from '../src/types'
+
+let options: RequestLoggerConfigurations
+let loggerMock: ILoggerComponent
+let serverMock: IHttpServerComponent<IHttpServerComponent.DefaultContext<object>>
+let mockedContext: IHttpServerComponent.DefaultContext<object>
+let storedMiddleware: (
+  ctx: IHttpServerComponent.DefaultContext<object>,
+  next: () => Promise<IHttpServerComponent.IResponse>
+) => Promise<IHttpServerComponent.IResponse>
+let mockedNext: () => Promise<IHttpServerComponent.IResponse>
+let mockedResponse: IHttpServerComponent.IResponse
+let loggers: (ILoggerComponent.ILogger & { name: string })[]
+
+beforeEach(() => {
+  options = {}
+  loggers = []
+  loggerMock = {
+    getLogger: (name: string) => {
+      const aLogger = {
+        name,
+        info: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+        log: jest.fn(),
+        debug: jest.fn()
+      }
+      loggers.push(aLogger)
+      return aLogger
+    }
+  }
+  serverMock = {
+    use: jest.fn().mockImplementation(middleware => (storedMiddleware = middleware)),
+    setContext: jest.fn()
+  }
+  mockedContext = {
+    request: {
+      method: 'GET',
+      url: 'http://localhost/some-endpoint?someParameter=1'
+    } as any,
+    url: new URL('http://localhost/some-endpoint?someParameter=1')
+  }
+  mockedResponse = {
+    headers: {
+      aHeader: 'aValue'
+    }
+  }
+  mockedNext = jest.fn().mockResolvedValue(mockedResponse)
+})
+
+let response: IHttpServerComponent.IResponse
+
+describe('when initializing the component', () => {
+  beforeEach(() => {
+    instrumentHttpServerWithRequestLogger({ server: serverMock, logger: loggerMock }, options)
+  })
+
+  it('should instantiate the output and the input loggers', () => {
+    expect(loggers[0]?.name).toEqual('http-in')
+    expect(loggers[1]?.name).toEqual('http-out')
+  })
+})
+
+describe('when the verbosity configuration is set', () => {
+  beforeEach(async () => {
+    options.verbosity = Verbosity.DEBUG
+    instrumentHttpServerWithRequestLogger({ server: serverMock, logger: loggerMock }, options)
+    response = await storedMiddleware(mockedContext, mockedNext)
+  })
+
+  it('should log the requests using the verbosity', () => {
+    expect(loggers[0]?.debug).toHaveBeenCalled()
+    expect(loggers[1]?.debug).toHaveBeenCalled()
+  })
+
+  it('should resolve the request by continuing with the middleware execution chain', () => {
+    expect(mockedNext).toHaveBeenCalled()
+    expect(response).toEqual(mockedResponse)
+  })
+})
+
+describe('when the verbosity configuration is not set', () => {
+  beforeEach(async () => {
+    options.verbosity = undefined
+    instrumentHttpServerWithRequestLogger({ server: serverMock, logger: loggerMock }, options)
+    response = await storedMiddleware(mockedContext, mockedNext)
+  })
+
+  it('should log the requests using INFO as the default verbosity', () => {
+    expect(loggers[0]?.info).toHaveBeenCalled()
+    expect(loggers[1]?.info).toHaveBeenCalled()
+  })
+
+  it('should resolve the request by continuing with the middleware execution chain', () => {
+    expect(mockedNext).toHaveBeenCalled()
+    expect(response).toEqual(mockedResponse)
+  })
+})
+
+describe('when the skip output configuration is set', () => {
+  describe('and is set to true', () => {
+    beforeEach(async () => {
+      options.skipOutput = true
+      instrumentHttpServerWithRequestLogger({ server: serverMock, logger: loggerMock }, options)
+      response = await storedMiddleware(mockedContext, mockedNext)
+    })
+
+    it('should log the request output and log the request input', () => {
+      expect(loggers[0]?.info).toHaveBeenCalled()
+      expect(loggers[1]?.info).not.toHaveBeenCalled()
+    })
+
+    it('should resolve the request by continuing with the middleware execution chain', () => {
+      expect(mockedNext).toHaveBeenCalled()
+      expect(response).toEqual(mockedResponse)
+    })
+  })
+
+  describe('and is set to false', () => {
+    beforeEach(async () => {
+      options.skipOutput = false
+      instrumentHttpServerWithRequestLogger({ server: serverMock, logger: loggerMock }, options)
+      response = await storedMiddleware(mockedContext, mockedNext)
+    })
+
+    it("should log both the request's input and output", () => {
+      expect(loggers[0]?.info).toHaveBeenCalled()
+      expect(loggers[1]?.info).toHaveBeenCalled()
+    })
+
+    it('should resolve the request by continuing with the middleware execution chain', () => {
+      expect(mockedNext).toHaveBeenCalled()
+      expect(response).toEqual(mockedResponse)
+    })
+  })
+})
+
+describe('when the skip output configuration is not set', () => {
+  beforeEach(async () => {
+    options.skipOutput = undefined
+    instrumentHttpServerWithRequestLogger({ server: serverMock, logger: loggerMock }, options)
+    response = await storedMiddleware(mockedContext, mockedNext)
+  })
+
+  it("should log both the request's input and output", () => {
+    expect(loggers[0]?.info).toHaveBeenCalled()
+    expect(loggers[1]?.info).toHaveBeenCalled()
+  })
+
+  it('should resolve the request by continuing with the middleware execution chain', () => {
+    expect(mockedNext).toHaveBeenCalled()
+    expect(response).toEqual(mockedResponse)
+  })
+})
+
+describe('when the skip input configuration is set', () => {
+  describe('and is set to true', () => {
+    beforeEach(async () => {
+      options.skipInput = true
+      instrumentHttpServerWithRequestLogger({ server: serverMock, logger: loggerMock }, options)
+      response = await storedMiddleware(mockedContext, mockedNext)
+    })
+
+    it('should not log the request input and log the request output', () => {
+      expect(loggers[0]?.info).not.toHaveBeenCalled()
+      expect(loggers[1]?.info).toHaveBeenCalled()
+    })
+
+    it('should resolve the request by continuing with the middleware execution chain', () => {
+      expect(mockedNext).toHaveBeenCalled()
+      expect(response).toEqual(mockedResponse)
+    })
+  })
+
+  describe('and is set to false', () => {
+    beforeEach(async () => {
+      options.skipInput = false
+      instrumentHttpServerWithRequestLogger({ server: serverMock, logger: loggerMock }, options)
+      response = await storedMiddleware(mockedContext, mockedNext)
+    })
+
+    it("should log both the request's input and output", () => {
+      expect(loggers[0]?.info).toHaveBeenCalled()
+      expect(loggers[1]?.info).toHaveBeenCalled()
+    })
+
+    it('should resolve the request by continuing with the middleware execution chain', () => {
+      expect(mockedNext).toHaveBeenCalled()
+      expect(response).toEqual(mockedResponse)
+    })
+  })
+})
+
+describe('when the skip input configuration is not set', () => {
+  beforeEach(async () => {
+    options.skipInput = undefined
+    instrumentHttpServerWithRequestLogger({ server: serverMock, logger: loggerMock }, options)
+    response = await storedMiddleware(mockedContext, mockedNext)
+  })
+
+  it("should log both the request's input and output", () => {
+    expect(loggers[0]?.info).toHaveBeenCalled()
+    expect(loggers[1]?.info).toHaveBeenCalled()
+  })
+
+  it('should resolve the request by continuing with the middleware execution chain', () => {
+    expect(mockedNext).toHaveBeenCalled()
+    expect(response).toEqual(mockedResponse)
+  })
+})
+
+describe('when the skip parameter is set', () => {
+  beforeEach(() => {
+    options.skip = '/v1/endpoint'
+    instrumentHttpServerWithRequestLogger({ server: serverMock, logger: loggerMock }, options)
+  })
+
+  describe('and the log should be skipped', () => {
+    beforeEach(async () => {
+      mockedContext.url = new URL('http://localhost/v1/endpoint')
+      response = await storedMiddleware(mockedContext, mockedNext)
+    })
+
+    it('should not log the requests', () => {
+      expect(loggers[0]?.info).not.toHaveBeenCalled()
+      expect(loggers[1]?.info).not.toHaveBeenCalled()
+    })
+
+    it('should resolve the request by continuing with the middleware execution chain', () => {
+      expect(mockedNext).toHaveBeenCalled()
+      expect(response).toEqual(mockedResponse)
+    })
+  })
+
+  describe('and the log should not be skipped', () => {
+    beforeEach(async () => {
+      mockedContext.url = new URL('http://localhost/v1/another-endpoint')
+      response = await storedMiddleware(mockedContext, mockedNext)
+    })
+
+    it('should log the requests', () => {
+      expect(loggers[0]?.info).toHaveBeenCalled()
+      expect(loggers[1]?.info).toHaveBeenCalled()
+    })
+
+    it('should resolve the request by continuing with the middleware execution chain', () => {
+      expect(mockedNext).toHaveBeenCalled()
+      expect(response).toEqual(mockedResponse)
+    })
+  })
+})
+
+describe('when the skip parameter is not set', () => {
+  beforeEach(async () => {
+    options.skip = undefined
+    mockedContext.request = { method: 'GET', url: 'http://localhost/health/live' } as any
+    mockedContext.url = new URL('http://localhost/health/live')
+    instrumentHttpServerWithRequestLogger({ server: serverMock, logger: loggerMock }, options)
+    response = await storedMiddleware(mockedContext, mockedNext)
+  })
+
+  it('should not log the health requests', () => {
+    expect(loggers[0]?.info).not.toHaveBeenCalled()
+    expect(loggers[1]?.info).not.toHaveBeenCalled()
+  })
+
+  it('should resolve the request by continuing with the middleware execution chain', () => {
+    expect(mockedNext).toHaveBeenCalled()
+    expect(response).toEqual(mockedResponse)
+  })
+})
+
+describe('when any of the following middlewares fail', () => {
+  let error: object
+
+  describe('and the failure is caused with an error containing an status code', () => {
+    beforeEach(() => {
+      error = { status: 400, statusCode: 400 }
+      instrumentHttpServerWithRequestLogger({ server: serverMock, logger: loggerMock }, options)
+      mockedNext = jest.fn().mockRejectedValueOnce(error)
+    })
+
+    it('should log the output correctly based on the status code of the exception and propagate the error', async () => {
+      await expect(storedMiddleware(mockedContext, mockedNext)).rejects.toEqual(error)
+      expect(loggers[1]?.info).toHaveBeenCalledWith(
+        `[${mockedContext.request.method}: ${mockedContext.url.pathname}${mockedContext.url.search}${mockedContext.url.hash}][400]`
+      )
+    })
+  })
+
+  describe('and the failure is caused without an http error', () => {
+    beforeEach(() => {
+      error = { message: 'An error occurred' }
+      instrumentHttpServerWithRequestLogger({ server: serverMock, logger: loggerMock }, options)
+      mockedNext = jest.fn().mockRejectedValueOnce(error)
+    })
+
+    it('should log the output correctly using the status code as 200', async () => {
+      await expect(storedMiddleware(mockedContext, mockedNext)).rejects.toEqual(error)
+      expect(loggers[1]?.info).toHaveBeenCalledWith(
+        `[${mockedContext.request.method}: ${mockedContext.url.pathname}${mockedContext.url.search}${mockedContext.url.hash}][200]`
+      )
+    })
+  })
+})

--- a/components/http-requests-logger/tests/logic.spec.ts
+++ b/components/http-requests-logger/tests/logic.spec.ts
@@ -1,0 +1,111 @@
+import { IHttpServerComponent } from '@dcl/core-commons'
+import { shouldSkip } from '../src/logic'
+
+let context: IHttpServerComponent.DefaultContext<object>
+
+beforeEach(() => {
+  context = {
+    request: {
+      url: 'http://localhost/health/live'
+    } as any,
+    url: new URL('http://localhost/health/live')
+  }
+})
+
+describe('when checking if a request should be skipped according to a string', () => {
+  let stringToMatch: string
+
+  describe('and the url matches the provided string', () => {
+    beforeEach(() => {
+      stringToMatch = context.url.pathname
+    })
+
+    it('should return true', () => {
+      expect(shouldSkip(context, stringToMatch)).toBe(true)
+    })
+  })
+
+  describe("and the url doesn't match the provided string", () => {
+    describe('and the url matches the provided string', () => {
+      beforeEach(() => {
+        stringToMatch = '/v1/endpoint'
+      })
+
+      it('should return false', () => {
+        expect(shouldSkip(context, stringToMatch)).toBe(false)
+      })
+    })
+  })
+})
+
+describe('when checking if a request should be skipped according to a an array of strings', () => {
+  let stringsToMatch: string[]
+
+  describe('and the url matches one of the provided string', () => {
+    beforeEach(() => {
+      stringsToMatch = [context.url.pathname, '/v1/endpoint']
+    })
+
+    it('should return true', () => {
+      expect(shouldSkip(context, stringsToMatch)).toBe(true)
+    })
+  })
+
+  describe("and the url doesn't match any the provided string", () => {
+    beforeEach(() => {
+      stringsToMatch = ['/v1/endpoint']
+    })
+
+    it('should return false', () => {
+      expect(shouldSkip(context, stringsToMatch)).toBe(false)
+    })
+  })
+})
+
+describe('when checking if a request should be skipped according to a regex', () => {
+  let regexToMatch: RegExp
+
+  describe('and the url matches the provided regex', () => {
+    beforeEach(() => {
+      regexToMatch = /^\/health/
+    })
+
+    it('should return true', () => {
+      expect(shouldSkip(context, regexToMatch)).toBe(true)
+    })
+  })
+
+  describe("and the url doesn't match the provided regex", () => {
+    beforeEach(() => {
+      regexToMatch = /^\/another/
+    })
+
+    it('should return false', () => {
+      expect(shouldSkip(context, regexToMatch)).toBe(false)
+    })
+  })
+})
+
+describe('when checking if a request should be skipped according to a skip function', () => {
+  let checkingFunction: (req: IHttpServerComponent.DefaultContext<object>['request']) => boolean
+
+  describe('and the called function returns true', () => {
+    beforeEach(() => {
+      checkingFunction = req => req.url === 'http://localhost/health/live'
+    })
+
+    it('should return true', () => {
+      expect(shouldSkip(context, checkingFunction)).toBe(true)
+    })
+  })
+
+  describe("and the url doesn't match the provided regex", () => {
+    beforeEach(() => {
+      checkingFunction = req => req.url === 'http://localhost/v1/another'
+    })
+
+    it('should return false', () => {
+      expect(shouldSkip(context, checkingFunction)).toBe(false)
+    })
+  })
+})

--- a/components/http-requests-logger/tests/logic.spec.ts
+++ b/components/http-requests-logger/tests/logic.spec.ts
@@ -84,6 +84,18 @@ describe('when checking if a request should be skipped according to a regex', ()
       expect(shouldSkip(context, regexToMatch)).toBe(false)
     })
   })
+
+  describe('and the provided regex has the global flag', () => {
+    beforeEach(() => {
+      regexToMatch = /^\/health/g
+    })
+
+    it('should match consistently across repeated calls', () => {
+      expect(shouldSkip(context, regexToMatch)).toBe(true)
+      expect(shouldSkip(context, regexToMatch)).toBe(true)
+      expect(shouldSkip(context, regexToMatch)).toBe(true)
+    })
+  })
 })
 
 describe('when checking if a request should be skipped according to a skip function', () => {

--- a/components/http-requests-logger/tests/logic.spec.ts
+++ b/components/http-requests-logger/tests/logic.spec.ts
@@ -26,14 +26,12 @@ describe('when checking if a request should be skipped according to a string', (
   })
 
   describe("and the url doesn't match the provided string", () => {
-    describe('and the url matches the provided string', () => {
-      beforeEach(() => {
-        stringToMatch = '/v1/endpoint'
-      })
+    beforeEach(() => {
+      stringToMatch = '/v1/endpoint'
+    })
 
-      it('should return false', () => {
-        expect(shouldSkip(context, stringToMatch)).toBe(false)
-      })
+    it('should return false', () => {
+      expect(shouldSkip(context, stringToMatch)).toBe(false)
     })
   })
 })

--- a/components/http-requests-logger/tsconfig.json
+++ b/components/http-requests-logger/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/components/tracer/CHANGELOG.md
+++ b/components/tracer/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @dcl/tracer-component

--- a/components/tracer/README.md
+++ b/components/tracer/README.md
@@ -1,0 +1,51 @@
+# @dcl/tracer-component
+
+Creates trace spans over an execution, providing context to the code being run
+so it can be traced and the W3C Trace Context (`traceparent` / `tracestate`)
+propagated.
+
+## Installation
+
+```bash
+npm install @dcl/tracer-component
+```
+
+## Usage
+
+Import the component, initialize it and wrap your traceable code into a trace span:
+
+```typescript
+import { createTracerComponent } from '@dcl/tracer-component'
+
+const tracer = createTracerComponent()
+tracer.span('my span', () => {
+  // Do some work here
+})
+```
+
+While inside the span, the traced code is able to access the trace context.
+This is especially useful for adding traced logs:
+
+```typescript
+const tracer = createTracerComponent()
+tracer.span('my span', () => {
+  console.log(`[${tracer.getTraceString()}] Starting some work`)
+  // Do some work here
+  console.log(`[${tracer.getTraceString()}] Finishing some work`)
+})
+```
+
+The logs output a trace alongside the message using the
+[traceparent format](https://www.w3.org/TR/trace-context/#traceparent-header)
+(`version-traceId-parentId-flags`):
+
+```bash
+  [00-7970d1a8361cc811ee59dc3ee1c8134e-0000000000000000-00] Starting some work
+  [00-7970d1a8361cc811ee59dc3ee1c8134e-0000000000000000-00] Finishing some work
+```
+
+The `traceId` is unique throughout the span execution and makes it easy to track
+which run of the span a log belongs to. The `parentId` identifies the span the
+current span was created from, making it possible to follow the chain of spans.
+See the [W3C Trace Context](https://www.w3.org/TR/trace-context/) spec for the
+meaning of the `version` and `flags` values.

--- a/components/tracer/jest.config.js
+++ b/components/tracer/jest.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>'],
+  testMatch: [
+    '**/tests/**/*.spec.ts',
+    '**/tests/**/*.test.ts',
+    '**/?(*.)+(spec|test).ts'
+  ],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/dist/'
+  ],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!**/*.d.ts',
+  ],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+}

--- a/components/tracer/package.json
+++ b/components/tracer/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@dcl/tracer-component",
+  "version": "0.0.0",
+  "description": "Trace execution spans all across your application for core components library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decentraland/core-components",
+    "directory": "components/tracer"
+  },
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "test": "jest",
+    "lint": "echo \"No linting configured\""
+  },
+  "dependencies": {
+    "@well-known-components/interfaces": "^1.5.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/components/tracer/src/component.ts
+++ b/components/tracer/src/component.ts
@@ -1,0 +1,246 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { ITracerComponent, TraceContext, Trace, TraceState } from '@well-known-components/interfaces'
+import { buildTraceString, buildTraceContext, generateTraceId } from './logic'
+import { INVALID_SPAN_ID } from './constants'
+import { NotInSpanError } from './errors'
+
+export function createTracerComponent(): ITracerComponent {
+  const asyncLocalStorage = new AsyncLocalStorage<TraceContext>()
+
+  /**
+   * Create a new tracing span over a specified function.
+   * @param name - The name of the tracing span.
+   * @param tracedFunction - The function to be traced.
+   * @param traceContext - The initial trace context to initialize the new context with. Usually used to set the information about the trace parent.
+   * @returns The result of the execution of the tracedFunction.
+   */
+  function span<T>(name: string, tracedFunction: () => T, traceContext?: Omit<TraceContext, 'id' | 'name'>): T {
+    const parentTraceContext = asyncLocalStorage.getStore()
+    let newContext: TraceContext
+    if (traceContext) {
+      newContext = buildTraceContext({
+        name,
+        parentId: traceContext.parentId,
+        traceId: traceContext.traceId,
+        version: Number(traceContext.version),
+        traceFlags: Number(traceContext.traceFlags),
+        traceState: traceContext.traceState,
+        data: traceContext.data
+      })
+    } else if (parentTraceContext) {
+      newContext = buildTraceContext({
+        name,
+        parentId: parentTraceContext.traceId,
+        traceId: parentTraceContext.traceId,
+        version: parentTraceContext.version,
+        traceFlags: parentTraceContext.traceFlags,
+        traceState: parentTraceContext.traceState
+      })
+    } else {
+      // Set up default values
+      newContext = buildTraceContext({
+        name,
+        parentId: INVALID_SPAN_ID,
+        traceId: generateTraceId(),
+        version: 0,
+        traceFlags: 0
+      })
+    }
+    return asyncLocalStorage.run(newContext, tracedFunction)
+  }
+
+  /**
+   * Gets if the execution context is inside of a trace span or not.
+   * @returns true if it is inside of a trace span, false otherwise.
+   */
+  function isInsideOfTraceSpan(): boolean {
+    const currentContext = asyncLocalStorage.getStore()
+    return (
+      currentContext !== undefined &&
+      currentContext.parentId !== undefined &&
+      currentContext.traceId !== undefined &&
+      currentContext.traceFlags !== undefined &&
+      currentContext.version !== undefined
+    )
+  }
+
+  /**
+   * Gets the current span id.
+   * @returns The current span id if the function is executed inside of a trace span.
+   * @throws NotInSpanError if executed outside of a scope.
+   */
+  function getSpanId(): string {
+    const currentContext = asyncLocalStorage.getStore()
+    if (!currentContext) {
+      throw new NotInSpanError()
+    }
+
+    return currentContext?.id
+  }
+
+  /**
+   * Gets the information of the current trace.
+   * @returns The current trace if the function is executed inside of a trace span.
+   * @throws NotInSpanError if executed outside of a scope.
+   */
+  function getTrace(): Trace {
+    const currentContext = asyncLocalStorage.getStore()
+    if (!currentContext) {
+      throw new NotInSpanError()
+    }
+
+    return {
+      traceId: currentContext.traceId,
+      version: currentContext.version,
+      parentId: currentContext.parentId,
+      traceFlags: currentContext.traceFlags
+    }
+  }
+
+  /**
+   * Gets the string representation of the information of the current trace.
+   * The value is crafted using the traceparent header format.
+   * @returns The string representation of the current trace.
+   * @throws NotInSpanError if executed outside of a scope.
+   */
+  function getTraceString(): string {
+    const traceParent = getTrace()
+    return buildTraceString(traceParent)
+  }
+
+  /**
+   * Gets the information of the trace to be propagated where the parent id is the current trace span id.
+   * @returns The trace child of the current trace.
+   * @throws NotInSpanError if executed outside of a scope.
+   */
+  function getTraceChild(): Trace {
+    const currentContext = asyncLocalStorage.getStore()
+    if (!currentContext) {
+      throw new NotInSpanError()
+    }
+
+    return {
+      traceId: currentContext.traceId,
+      version: currentContext.version,
+      parentId: currentContext.id,
+      traceFlags: currentContext.traceFlags
+    }
+  }
+
+  /**
+   * Gets the string representation of the trace to be propagated where the parent id is the current trace span id.
+   * The value is crafted using the traceparent header format.
+   * @returns The string representation of the trace child of the current trace.
+   * @throws NotInSpanError if executed outside of a scope.
+   */
+  function getTraceChildString(): string {
+    const traceChild = getTraceChild()
+    return buildTraceString(traceChild)
+  }
+
+  /**
+   * Gets the properties of the trace state.
+   * @returns The current trace state.
+   * @throws NotInSpanError if executed outside of a scope.
+   */
+  function getTraceState(): Readonly<TraceState | null> {
+    const currentContext = asyncLocalStorage.getStore()
+    if (!currentContext) {
+      throw new NotInSpanError()
+    }
+
+    return Object.freeze(currentContext?.traceState ?? null)
+  }
+
+  /**
+   * Gets the string representation of the the properties of the trace state.
+   * The value is crafted using the tracestate header format.
+   * @returns The current trace state or null if there's no trace state.
+   * @throws NotInSpanError if executed outside of a scope.
+   */
+  function getTraceStateString(): string | undefined {
+    const traceState = getTraceState()
+    return traceState && Object.keys(traceState).length > 0
+      ? Object.entries(traceState).reduce((acc, curr, index, arr) => `${acc}=${curr}${index !== arr.length - 1 ? ',' : ''}`, '')
+      : undefined
+  }
+
+  /**
+   * Gets the current trace context data.
+   * @returns The current trace context data.
+   * @throws NotInSpanError if executed outside of a scope.
+   */
+  function getContextData<T>(): Readonly<T | null> {
+    const currentContext = asyncLocalStorage.getStore()
+    if (!currentContext) {
+      throw new NotInSpanError()
+    }
+
+    return Object.freeze(currentContext?.data ?? null)
+  }
+
+  /**
+   * Sets the trace context data if executed inside a trace span.
+   * @param key - The key of the property to be set.
+   * @param value - The value of the property to be set.
+   * @throws NotInSpanError if executed outside of a scope.
+   */
+  function setContextData<T = any>(data: T): void {
+    const currentContext = asyncLocalStorage.getStore()
+    if (!currentContext) {
+      throw new NotInSpanError()
+    }
+
+    currentContext.data = data
+  }
+
+  /**
+   * Sets a property of the trace state if executed inside a trace span.
+   * @param key - The key of the property to be set.
+   * @param value - The value of the property to be set.
+   * @throws NotInSpanError if executed outside of a scope.
+   */
+  function setTraceStateProperty(key: string, value: string): void {
+    const currentContext = asyncLocalStorage.getStore()
+    if (!currentContext) {
+      throw new NotInSpanError()
+    }
+
+    if (!currentContext.traceState) {
+      currentContext.traceState = {}
+    }
+    currentContext.traceState[key] = value
+  }
+
+  /**
+   * Deletes a property of the trace state if executed inside a trace span.
+   * @param key - The key of the property to be deleted.
+   * @throws NotInSpanError if executed outside of a scope.
+   */
+  function deleteTraceStateProperty(key: string): void {
+    const currentContext = asyncLocalStorage.getStore()
+    if (!currentContext) {
+      throw new NotInSpanError()
+    }
+
+    if (currentContext.traceState) {
+      delete currentContext.traceState[key]
+    }
+  }
+
+  return {
+    span,
+    isInsideOfTraceSpan,
+    getSpanId,
+    getTrace,
+    getTraceString,
+    getTraceChild,
+    getTraceChildString,
+    getContextData,
+    setContextData,
+    getTraceState,
+    getTraceStateString,
+    setTraceStateProperty,
+    deleteTraceStateProperty
+  }
+}

--- a/components/tracer/src/component.ts
+++ b/components/tracer/src/component.ts
@@ -30,7 +30,7 @@ export function createTracerComponent(): ITracerComponent {
     } else if (parentTraceContext) {
       newContext = buildTraceContext({
         name,
-        parentId: parentTraceContext.traceId,
+        parentId: parentTraceContext.id,
         traceId: parentTraceContext.traceId,
         version: parentTraceContext.version,
         traceFlags: parentTraceContext.traceFlags,
@@ -149,7 +149,9 @@ export function createTracerComponent(): ITracerComponent {
       throw new NotInSpanError()
     }
 
-    return Object.freeze(currentContext?.traceState ?? null)
+    // Freeze a shallow copy rather than the live trace state, so reading it
+    // doesn't make later setTraceStateProperty/deleteTraceStateProperty calls throw.
+    return Object.freeze(currentContext.traceState ? { ...currentContext.traceState } : null)
   }
 
   /**
@@ -161,7 +163,9 @@ export function createTracerComponent(): ITracerComponent {
   function getTraceStateString(): string | undefined {
     const traceState = getTraceState()
     return traceState && Object.keys(traceState).length > 0
-      ? Object.entries(traceState).reduce((acc, curr, index, arr) => `${acc}=${curr}${index !== arr.length - 1 ? ',' : ''}`, '')
+      ? Object.entries(traceState)
+          .map(([key, value]) => `${key}=${value}`)
+          .join(',')
       : undefined
   }
 
@@ -176,13 +180,16 @@ export function createTracerComponent(): ITracerComponent {
       throw new NotInSpanError()
     }
 
-    return Object.freeze(currentContext?.data ?? null)
+    // Freeze a shallow copy of object data rather than the live value, so reading it
+    // doesn't make the stored data (or the caller's original object) non-extensible.
+    const data = currentContext.data ?? null
+    const copy = data && typeof data === 'object' ? (Array.isArray(data) ? [...data] : { ...data }) : data
+    return Object.freeze(copy) as Readonly<T | null>
   }
 
   /**
    * Sets the trace context data if executed inside a trace span.
-   * @param key - The key of the property to be set.
-   * @param value - The value of the property to be set.
+   * @param data - The data to store in the current trace context.
    * @throws NotInSpanError if executed outside of a scope.
    */
   function setContextData<T = any>(data: T): void {

--- a/components/tracer/src/component.ts
+++ b/components/tracer/src/component.ts
@@ -22,8 +22,8 @@ export function createTracerComponent(): ITracerComponent {
         name,
         parentId: traceContext.parentId,
         traceId: traceContext.traceId,
-        version: Number(traceContext.version),
-        traceFlags: Number(traceContext.traceFlags),
+        version: traceContext.version,
+        traceFlags: traceContext.traceFlags,
         traceState: traceContext.traceState,
         data: traceContext.data
       })

--- a/components/tracer/src/constants.ts
+++ b/components/tracer/src/constants.ts
@@ -1,0 +1,2 @@
+/** A zero valued 16 bytes hex string representing the null or invalid span id */
+export const INVALID_SPAN_ID = '0000000000000000'

--- a/components/tracer/src/errors.ts
+++ b/components/tracer/src/errors.ts
@@ -1,0 +1,5 @@
+export class NotInSpanError extends Error {
+  constructor() {
+    super("Can't perform this operation out of an span")
+  }
+}

--- a/components/tracer/src/index.ts
+++ b/components/tracer/src/index.ts
@@ -1,0 +1,2 @@
+export * from './component'
+export * from './logic'

--- a/components/tracer/src/index.ts
+++ b/components/tracer/src/index.ts
@@ -1,2 +1,4 @@
 export * from './component'
 export * from './logic'
+export * from './errors'
+export * from './constants'

--- a/components/tracer/src/logic.ts
+++ b/components/tracer/src/logic.ts
@@ -63,7 +63,9 @@ export function buildTraceContext<T>({
     traceId,
     version,
     traceFlags,
-    traceState,
+    // Copy the trace state so a span doesn't share the object with the context it inherited from
+    // (otherwise a child span's mutations would leak back into its parent and siblings).
+    traceState: traceState ? { ...traceState } : undefined,
     data
   }
 }

--- a/components/tracer/src/logic.ts
+++ b/components/tracer/src/logic.ts
@@ -7,7 +7,10 @@ import { INVALID_SPAN_ID } from './constants'
  * @param traceParent - The trace parent.
  */
 export function buildTraceString(traceParent: Trace): string {
-  return `${traceParent.version.toString(16)}-${traceParent.traceId}-${traceParent.parentId}-${traceParent.traceFlags.toString(16)}`
+  // version and trace-flags are 2 hex digits each per the W3C traceparent format.
+  const version = traceParent.version.toString(16).padStart(2, '0')
+  const traceFlags = traceParent.traceFlags.toString(16).padStart(2, '0')
+  return `${version}-${traceParent.traceId}-${traceParent.parentId}-${traceFlags}`
 }
 
 /**

--- a/components/tracer/src/logic.ts
+++ b/components/tracer/src/logic.ts
@@ -1,0 +1,66 @@
+import { randomBytes } from 'node:crypto'
+import type { Trace, TraceContext } from '@well-known-components/interfaces'
+import { INVALID_SPAN_ID } from './constants'
+
+/**
+ * Builds a trace parent string representation based on its properties.
+ * @param traceParent - The trace parent.
+ */
+export function buildTraceString(traceParent: Trace): string {
+  return `${traceParent.version.toString(16)}-${traceParent.traceId}-${traceParent.parentId}-${traceParent.traceFlags.toString(16)}`
+}
+
+/**
+ * Generates a random set of bytes and then converts them into a lowercased hex string.
+ * @param length - The length in bytes from where to generate the hex string.
+ */
+function generateRandomBytesHexString(length: number): string {
+  return randomBytes(length).toString('hex').toLowerCase()
+}
+
+/**
+ * Generates a random trace id represented as an hex string.
+ */
+export function generateTraceId(): string {
+  return generateRandomBytesHexString(16)
+}
+
+/**
+ * Generates a random parent id represented as an hex string.
+ */
+export function generateSpanId(): string {
+  return generateRandomBytesHexString(8)
+}
+
+/**
+ * Builds a trace context using the provided trace information.
+ * If no parent id is provided, a null parent id will be set for the trace context.
+ */
+export function buildTraceContext<T>({
+  name,
+  parentId,
+  traceId,
+  version,
+  traceFlags,
+  traceState,
+  data
+}: {
+  name: string
+  parentId?: string
+  traceId: string
+  version: number
+  traceFlags: number
+  traceState?: Record<string, string>
+  data?: T
+}): TraceContext {
+  return {
+    name,
+    id: generateSpanId(),
+    parentId: parentId ?? INVALID_SPAN_ID,
+    traceId,
+    version,
+    traceFlags,
+    traceState,
+    data
+  }
+}

--- a/components/tracer/tests/component.spec.ts
+++ b/components/tracer/tests/component.spec.ts
@@ -44,6 +44,20 @@ describe('when recursively executing an span', () => {
   })
 })
 
+describe('when executing a nested span', () => {
+  it('should set the child span parent id to the parent span id and share the trace id', () => {
+    return tracerComponent.span('parent', () => {
+      const parentSpanId = tracerComponent.getSpanId()
+      const parentTraceId = tracerComponent.getTrace().traceId
+      return tracerComponent.span('child', () => {
+        const childTrace = tracerComponent.getTrace()
+        expect(childTrace.parentId).toBe(parentSpanId)
+        expect(childTrace.traceId).toBe(parentTraceId)
+      })
+    })
+  })
+})
+
 describe('when getting if an execution is inside of a trace span', () => {
   describe('and it is inside of a trace span', () => {
     it('should return true', () => {
@@ -193,25 +207,38 @@ describe('when getting the trace state', () => {
 describe('when getting the trace state string', () => {
   describe('when inside of a span', () => {
     describe("and there's no trace state", () => {
-      it('should return null', () => {
-        return tracerComponent.span('test span', () => expect(tracerComponent.getTraceState()).toBeNull(), defaultContext)
+      it('should return undefined', () => {
+        return tracerComponent.span(
+          'test span',
+          () => expect(tracerComponent.getTraceStateString()).toBeUndefined(),
+          defaultContext
+        )
       })
     })
 
-    describe("and there's trace state", () => {
+    describe("and there's a single trace state property", () => {
       beforeEach(() => {
-        defaultContext.traceState = {
-          aStateKey: 'aStateValue'
-        }
+        defaultContext.traceState = { aStateKey: 'aStateValue' }
       })
 
-      it('should return the trace state', () => {
+      it('should return the property formatted as key=value', () => {
         return tracerComponent.span(
           'test span',
-          () =>
-            expect(tracerComponent.getTraceState()).toEqual({
-              aStateKey: 'aStateValue'
-            }),
+          () => expect(tracerComponent.getTraceStateString()).toBe('aStateKey=aStateValue'),
+          defaultContext
+        )
+      })
+    })
+
+    describe('and there are multiple trace state properties', () => {
+      beforeEach(() => {
+        defaultContext.traceState = { aStateKey: 'aStateValue', anotherStateKey: 'anotherStateValue' }
+      })
+
+      it('should return the properties as comma-separated key=value pairs', () => {
+        return tracerComponent.span(
+          'test span',
+          () => expect(tracerComponent.getTraceStateString()).toBe('aStateKey=aStateValue,anotherStateKey=anotherStateValue'),
           defaultContext
         )
       })
@@ -220,7 +247,7 @@ describe('when getting the trace state string', () => {
 
   describe('when outside of a span', () => {
     it('should throw a not in span error', () => {
-      expect(() => tracerComponent.getTraceState()).toThrow(NotInSpanError)
+      expect(() => tracerComponent.getTraceStateString()).toThrow(NotInSpanError)
     })
   })
 })
@@ -243,6 +270,28 @@ describe('when getting the span trace context data', () => {
           'test span',
           () => {
             return expect(tracerComponent.getContextData()).toEqual({ aKey: 'aValue' })
+          },
+          defaultContext
+        )
+      })
+    })
+
+    describe('and the context data is read', () => {
+      let data: { aKey: string }
+      beforeEach(() => {
+        data = { aKey: 'aValue' }
+        defaultContext.data = data
+      })
+
+      it('should not freeze the data object stored in the span', () => {
+        return tracerComponent.span(
+          'test span',
+          () => {
+            tracerComponent.getContextData()
+            expect(() => {
+              data.aKey = 'anotherValue'
+            }).not.toThrow()
+            expect(tracerComponent.getContextData()).toEqual({ aKey: 'anotherValue' })
           },
           defaultContext
         )
@@ -394,5 +443,38 @@ describe('when deleting the trace state data', () => {
     it('should throw a not in span error', () => {
       expect(() => tracerComponent.deleteTraceStateProperty('aKey')).toThrow(NotInSpanError)
     })
+  })
+})
+
+describe('when reading the trace state and then mutating it', () => {
+  beforeEach(() => {
+    defaultContext.traceState = { aStateKey: 'aStateValue' }
+  })
+
+  it('should allow setting a new property after the trace state has been read', () => {
+    return tracerComponent.span(
+      'test span',
+      () => {
+        tracerComponent.getTraceState()
+        expect(() => tracerComponent.setTraceStateProperty('anotherStateKey', 'anotherStateValue')).not.toThrow()
+        expect(tracerComponent.getTraceState()).toEqual({
+          aStateKey: 'aStateValue',
+          anotherStateKey: 'anotherStateValue'
+        })
+      },
+      defaultContext
+    )
+  })
+
+  it('should allow deleting a property after the trace state has been read', () => {
+    return tracerComponent.span(
+      'test span',
+      () => {
+        tracerComponent.getTraceState()
+        expect(() => tracerComponent.deleteTraceStateProperty('aStateKey')).not.toThrow()
+        expect(tracerComponent.getTraceState()).toEqual({})
+      },
+      defaultContext
+    )
   })
 })

--- a/components/tracer/tests/component.spec.ts
+++ b/components/tracer/tests/component.spec.ts
@@ -1,0 +1,398 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import type { ITracerComponent, TraceContext } from '@well-known-components/interfaces'
+import { buildTraceString, createTracerComponent, generateSpanId, generateTraceId } from '../src'
+import { NotInSpanError } from '../src/errors'
+
+let tracerComponent: ITracerComponent
+let defaultContext: Omit<TraceContext, 'id' | 'data' | 'name'> & { data?: any }
+
+beforeEach(() => {
+  tracerComponent = createTracerComponent()
+  defaultContext = {
+    version: 0,
+    traceId: generateTraceId(),
+    parentId: generateSpanId(),
+    traceFlags: 0
+  }
+})
+
+describe('when executing a span', () => {
+  it('should return the same result as the given function', () => {
+    expect(tracerComponent.span('test span', () => 1)).toBe(1)
+  })
+})
+
+describe('when recursively executing an span', () => {
+  let spanIds: Set<string>
+  beforeEach(() => {
+    spanIds = new Set()
+  })
+
+  const recursiveFibonacci = (i: number): number =>
+    tracerComponent.span(`recursive-fibo ${i}`, () => {
+      spanIds.add(tracerComponent.getSpanId())
+      return i === 0 || i === 1 ? i : recursiveFibonacci(i - 1) + recursiveFibonacci(i - 2)
+    })
+
+  it('should return the recursive result', () => {
+    expect(recursiveFibonacci(6)).toBe(8)
+  })
+
+  it('should create an individual and different trace span on each recursion', () => {
+    recursiveFibonacci(2)
+    expect(spanIds.size).toBe(3)
+  })
+})
+
+describe('when getting if an execution is inside of a trace span', () => {
+  describe('and it is inside of a trace span', () => {
+    it('should return true', () => {
+      return tracerComponent.span('test span', () => expect(tracerComponent.isInsideOfTraceSpan()).toBe(true), defaultContext)
+    })
+  })
+
+  describe('and it is not inside of a trace span', () => {
+    it('should return false', () => {
+      expect(tracerComponent.isInsideOfTraceSpan()).toBe(false)
+    })
+  })
+
+  describe('and it is inside of a async local storage run but not inside of a span', () => {
+    const asyncLocalStorage = new AsyncLocalStorage<any>()
+
+    it('should return false', () => {
+      expect(asyncLocalStorage.run({}, () => tracerComponent.isInsideOfTraceSpan())).toBe(false)
+    })
+  })
+})
+
+describe('when getting the trace object', () => {
+  describe('when inside of a span', () => {
+    it('should return the trace object', () => {
+      return tracerComponent.span(
+        'test span',
+        () =>
+          expect(tracerComponent.getTrace()).toEqual({
+            version: defaultContext.version,
+            traceId: defaultContext.traceId,
+            parentId: defaultContext.parentId,
+            traceFlags: defaultContext.traceFlags
+          }),
+        defaultContext
+      )
+    })
+  })
+
+  describe('when outside of a span', () => {
+    it('should throw a not in span error', () => {
+      expect(() => tracerComponent.getTrace()).toThrow(NotInSpanError)
+    })
+  })
+})
+
+describe('when getting the trace string', () => {
+  describe('when inside of a span', () => {
+    it('should return a string representing the tracestate header of the current trace', () => {
+      return tracerComponent.span(
+        'test span',
+        () => expect(tracerComponent.getTraceString()).toBe(buildTraceString(defaultContext)),
+        defaultContext
+      )
+    })
+  })
+
+  describe('when outside of a span', () => {
+    it('should throw a not in span error', () => {
+      expect(() => tracerComponent.getTraceString()).toThrow(NotInSpanError)
+    })
+  })
+})
+
+describe('when getting the trace child', () => {
+  describe('when inside of a span', () => {
+    it('should return the trace child object where the parent id is the current span id', () => {
+      return tracerComponent.span(
+        'test span',
+        () =>
+          expect(tracerComponent.getTraceChild()).toEqual({
+            version: defaultContext.version,
+            traceId: defaultContext.traceId,
+            parentId: tracerComponent.getSpanId(),
+            traceFlags: defaultContext.traceFlags
+          }),
+        defaultContext
+      )
+    })
+  })
+
+  describe('when outside of a span', () => {
+    it('should throw a not in span error', () => {
+      expect(() => tracerComponent.getTraceChild()).toThrow(NotInSpanError)
+    })
+  })
+})
+
+describe('when getting the trace child string', () => {
+  describe('when inside of a span', () => {
+    it('should return a string representing the tracestate header where the parent id is the current span id', () => {
+      return tracerComponent.span(
+        'test span',
+        () =>
+          expect(tracerComponent.getTraceChildString()).toBe(
+            buildTraceString({
+              version: defaultContext.version,
+              traceId: defaultContext.traceId,
+              parentId: tracerComponent.getSpanId(),
+              traceFlags: defaultContext.traceFlags
+            })
+          ),
+        defaultContext
+      )
+    })
+  })
+
+  describe('when outside of a span', () => {
+    it('should throw a not in span error', () => {
+      expect(() => tracerComponent.getTraceChildString()).toThrow(NotInSpanError)
+    })
+  })
+})
+
+describe('when getting the trace state', () => {
+  describe('when inside of a span', () => {
+    describe("and there's no trace state", () => {
+      it('should return null', () => {
+        return tracerComponent.span('test span', () => expect(tracerComponent.getTraceState()).toBeNull(), defaultContext)
+      })
+    })
+
+    describe("and there's trace state", () => {
+      beforeEach(() => {
+        defaultContext.traceState = {
+          aStateKey: 'aStateValue'
+        }
+      })
+
+      it('should return the trace state', () => {
+        return tracerComponent.span(
+          'test span',
+          () => expect(tracerComponent.getTraceState()).toEqual({ aStateKey: 'aStateValue' }),
+          defaultContext
+        )
+      })
+    })
+  })
+
+  describe('when outside of a span', () => {
+    it('should throw a not in span error', () => {
+      expect(() => tracerComponent.getTraceState()).toThrow(NotInSpanError)
+    })
+  })
+})
+
+describe('when getting the trace state string', () => {
+  describe('when inside of a span', () => {
+    describe("and there's no trace state", () => {
+      it('should return null', () => {
+        return tracerComponent.span('test span', () => expect(tracerComponent.getTraceState()).toBeNull(), defaultContext)
+      })
+    })
+
+    describe("and there's trace state", () => {
+      beforeEach(() => {
+        defaultContext.traceState = {
+          aStateKey: 'aStateValue'
+        }
+      })
+
+      it('should return the trace state', () => {
+        return tracerComponent.span(
+          'test span',
+          () =>
+            expect(tracerComponent.getTraceState()).toEqual({
+              aStateKey: 'aStateValue'
+            }),
+          defaultContext
+        )
+      })
+    })
+  })
+
+  describe('when outside of a span', () => {
+    it('should throw a not in span error', () => {
+      expect(() => tracerComponent.getTraceState()).toThrow(NotInSpanError)
+    })
+  })
+})
+
+describe('when getting the span trace context data', () => {
+  describe('when inside of a span', () => {
+    describe("and there's no trace context data", () => {
+      it('should return null', () => {
+        return tracerComponent.span('test span', () => expect(tracerComponent.getContextData()).toBeNull(), defaultContext)
+      })
+    })
+
+    describe("and there's context data", () => {
+      beforeEach(() => {
+        defaultContext.data = { aKey: 'aValue' }
+      })
+
+      it('should return the context data', () => {
+        return tracerComponent.span(
+          'test span',
+          () => {
+            return expect(tracerComponent.getContextData()).toEqual({ aKey: 'aValue' })
+          },
+          defaultContext
+        )
+      })
+    })
+  })
+
+  describe('when outside of a span', () => {
+    it('should throw a not in span error', () => {
+      expect(() => tracerComponent.getContextData()).toThrow(NotInSpanError)
+    })
+  })
+})
+
+describe('when setting the trace span context data', () => {
+  describe('when inside of a span', () => {
+    it('should set the trace span context data with the provided key and value', () => {
+      return tracerComponent.span('test span', () => {
+        tracerComponent.setContextData({
+          aKey: 'aValue',
+          anotherKey: 'anotherValue'
+        })
+
+        expect(tracerComponent.getContextData()).toEqual({
+          aKey: 'aValue',
+          anotherKey: 'anotherValue'
+        })
+      })
+    })
+  })
+
+  describe('when outside of a span', () => {
+    it('should throw a not in span error', () => {
+      expect(() => tracerComponent.setContextData({ aKey: 'aValue' })).toThrow(NotInSpanError)
+    })
+  })
+})
+
+describe('when setting the trace state data', () => {
+  describe('when inside of a span', () => {
+    describe("when there's no trace state", () => {
+      it('should create the trace state with the new key and value', () => {
+        return tracerComponent.span(
+          'test span',
+          () => {
+            tracerComponent.setTraceStateProperty('aKey', 'aValue')
+            return expect(tracerComponent.getTraceState()).toEqual({ aKey: 'aValue' })
+          },
+          defaultContext
+        )
+      })
+    })
+
+    describe("and there's a trace state without the new key", () => {
+      beforeEach(() => {
+        defaultContext.traceState = { anotherKey: 'anotherValue' }
+      })
+
+      it('should add the new key and value to the trace state', () => {
+        return tracerComponent.span(
+          'test span',
+          () => {
+            tracerComponent.setTraceStateProperty('aKey', 'aValue')
+            return expect(tracerComponent.getTraceState()).toEqual({ aKey: 'aValue', anotherKey: 'anotherValue' })
+          },
+          defaultContext
+        )
+      })
+    })
+
+    describe("and there's a trace state with the given key", () => {
+      beforeEach(() => {
+        defaultContext.traceState = { aKey: 'aValue' }
+      })
+
+      it('should overwrite the key and value of the trace state', () => {
+        return tracerComponent.span(
+          'test span',
+          () => {
+            tracerComponent.setTraceStateProperty('aKey', 'anotherValue')
+            return expect(tracerComponent.getTraceState()).toEqual({ aKey: 'anotherValue' })
+          },
+          defaultContext
+        )
+      })
+    })
+  })
+
+  describe('when outside of a span', () => {
+    it('should throw a not in span error', () => {
+      expect(() => tracerComponent.setTraceStateProperty('aKey', 'aValue')).toThrow(NotInSpanError)
+    })
+  })
+})
+
+describe('when deleting the trace state data', () => {
+  describe('when inside of a span', () => {
+    describe("when there's no trace state", () => {
+      it('should do nothing and return', () => {
+        return tracerComponent.span(
+          'test span',
+          () => expect(() => tracerComponent.deleteTraceStateProperty('aKey')).not.toThrow(),
+          defaultContext
+        )
+      })
+    })
+
+    describe("when there's a trace state without the key to be deleted", () => {
+      beforeEach(() => {
+        defaultContext.traceState = {
+          anotherKey: 'aValue'
+        }
+      })
+
+      it('should do nothing and return', () => {
+        return tracerComponent.span(
+          'test span',
+          () => {
+            tracerComponent.deleteTraceStateProperty('aKey')
+            return expect(tracerComponent.getTraceState()).toEqual(defaultContext.traceState)
+          },
+          defaultContext
+        )
+      })
+    })
+
+    describe("when there's a trace state with the key to be deleted", () => {
+      beforeEach(() => {
+        defaultContext.traceState = {
+          aKey: 'aValue',
+          anotherKey: 'anotherValue'
+        }
+      })
+
+      it('should delete the property with the given key', () => {
+        return tracerComponent.span(
+          'test span',
+          () => {
+            tracerComponent.deleteTraceStateProperty('aKey')
+            return expect(tracerComponent.getTraceState()).toEqual({ anotherKey: 'anotherValue' })
+          },
+          defaultContext
+        )
+      })
+    })
+  })
+
+  describe('when outside of a span', () => {
+    it('should throw a not in span error', () => {
+      expect(() => tracerComponent.deleteTraceStateProperty('aKey')).toThrow(NotInSpanError)
+    })
+  })
+})

--- a/components/tracer/tests/component.spec.ts
+++ b/components/tracer/tests/component.spec.ts
@@ -56,6 +56,18 @@ describe('when executing a nested span', () => {
       })
     })
   })
+
+  it('should inherit the parent trace state without leaking the child mutations back into the parent', () => {
+    return tracerComponent.span('parent', () => {
+      tracerComponent.setTraceStateProperty('a', '1')
+      tracerComponent.span('child', () => {
+        expect(tracerComponent.getTraceState()).toEqual({ a: '1' })
+        tracerComponent.setTraceStateProperty('b', '2')
+        expect(tracerComponent.getTraceState()).toEqual({ a: '1', b: '2' })
+      })
+      expect(tracerComponent.getTraceState()).toEqual({ a: '1' })
+    })
+  })
 })
 
 describe('when getting if an execution is inside of a trace span', () => {

--- a/components/tracer/tests/logic.spec.ts
+++ b/components/tracer/tests/logic.spec.ts
@@ -1,0 +1,64 @@
+import { INVALID_SPAN_ID } from '../src/constants'
+import type { TraceContext } from '@well-known-components/interfaces'
+import { buildTraceContext, buildTraceString, generateSpanId, generateTraceId } from '../src/logic'
+
+describe('when building a trace string', () => {
+  const version = 0
+  const traceId = 'aTraceId'
+  const parentId = 'aParentId'
+  const traceFlags = 1
+
+  it('should create a string based in the traceparent header', () => {
+    expect(buildTraceString({ version, traceId, parentId, traceFlags })).toBe(`${version}-${traceId}-${parentId}-${traceFlags}`)
+  })
+})
+
+describe('when generating a traceId', () => {
+  it('should generate a random hex string of 16 bytes', () => {
+    expect(generateTraceId().length).toBe(32)
+  })
+})
+
+describe('when generating a span id', () => {
+  it('should generate a random hex string of 8 bytes', () => {
+    expect(generateSpanId().length).toBe(16)
+  })
+})
+
+describe('when building a trace context', () => {
+  let traceContextBuilderInput: Omit<TraceContext, 'id' | 'parentId'> & Partial<Pick<TraceContext, 'parentId'>>
+
+  beforeEach(() => {
+    traceContextBuilderInput = {
+      name: 'aName',
+      traceId: 'aTraceId',
+      version: 0,
+      traceFlags: 0,
+      traceState: { aTraceState: 'aTraceStateValue' },
+      data: {}
+    }
+  })
+
+  describe("and there's no parent id", () => {
+    it('should return a Trace with a randomly generated span id and an invalid parent id', () => {
+      expect(buildTraceContext(traceContextBuilderInput)).toEqual({
+        ...traceContextBuilderInput,
+        parentId: INVALID_SPAN_ID,
+        id: expect.any(String)
+      })
+    })
+  })
+
+  describe("and there's a parent id", () => {
+    beforeEach(() => {
+      traceContextBuilderInput.parentId = 'aParentId'
+    })
+
+    it('should return a Trace with a randomly generated span id and the given parent id', () => {
+      expect(buildTraceContext(traceContextBuilderInput)).toEqual({
+        ...traceContextBuilderInput,
+        id: expect.any(String)
+      })
+    })
+  })
+})

--- a/components/tracer/tests/logic.spec.ts
+++ b/components/tracer/tests/logic.spec.ts
@@ -3,13 +3,19 @@ import type { TraceContext } from '@well-known-components/interfaces'
 import { buildTraceContext, buildTraceString, generateSpanId, generateTraceId } from '../src/logic'
 
 describe('when building a trace string', () => {
-  const version = 0
   const traceId = 'aTraceId'
   const parentId = 'aParentId'
-  const traceFlags = 1
 
-  it('should create a string based in the traceparent header', () => {
-    expect(buildTraceString({ version, traceId, parentId, traceFlags })).toBe(`${version}-${traceId}-${parentId}-${traceFlags}`)
+  describe('and the version and trace flags are single hex digit values', () => {
+    it('should zero-pad the version and trace flags to two hex digits', () => {
+      expect(buildTraceString({ version: 0, traceId, parentId, traceFlags: 1 })).toBe(`00-${traceId}-${parentId}-01`)
+    })
+  })
+
+  describe('and the version and trace flags already span two hex digits', () => {
+    it('should hex encode them without further padding', () => {
+      expect(buildTraceString({ version: 2, traceId, parentId, traceFlags: 255 })).toBe(`02-${traceId}-${parentId}-ff`)
+    })
   })
 })
 

--- a/components/tracer/tsconfig.json
+++ b/components/tracer/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,19 @@ importers:
         specifier: ^5.8.3
         version: 5.9.3
 
+  components/http-requests-logger:
+    dependencies:
+      '@dcl/core-commons':
+        specifier: workspace:*
+        version: link:../../shared/commons
+      '@well-known-components/interfaces':
+        specifier: ^1.5.2
+        version: 1.5.2
+    devDependencies:
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+
   components/http-server:
     dependencies:
       '@dcl/core-commons':
@@ -448,6 +461,16 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+
+  components/tracer:
+    dependencies:
+      '@well-known-components/interfaces':
+        specifier: ^1.5.2
+        version: 1.5.2
+    devDependencies:
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
 
   components/uws-http-server:
     dependencies:


### PR DESCRIPTION
## What

moves two more `@well-known-components/*` components into core-components, following the same pattern used for `@dcl/http-tracer-component` (#100):

- **`@dcl/tracer-component`** (`components/tracer`) — creates trace spans over an execution and exposes the w3c trace context (`traceparent` / `tracestate`) to the traced code. pure component, only depends on `@well-known-components/interfaces`.
- **`@dcl/http-requests-logger-component`** (`components/http-requests-logger`) — logs each http request and response with configurable verbosity, custom log formats, and endpoint skipping (health checks skipped by default).

## Notes

- both packages ship as `0.0.0` with a `major` initial-release changeset, so the first publish lands them at `1.0.0` (same as how http-tracer was introduced).
- `http-requests-logger` sources `IHttpServerComponent` from `@dcl/core-commons` (native-fetch request/response types) instead of `@well-known-components/interfaces`, so it pairs with `@dcl/http-server` v2 without a cast at the call site. `ILoggerComponent` stays on `@well-known-components/interfaces` (no core equivalent).
- the tests forced two small adaptations for the logger because the native `Request.url`/`.method` are `readonly`: request mocks are cast loosely, and the one spot that wrote `request.url` directly now reassigns the whole `request` object. behavior is unchanged.
- `README.md` updated in all three spots (structure tree, components list, publishing list) for both packages.

## Fixes applied in review

bugs inherited from the original WKC components, corrected here before the first publish (documented in the changesets).

**2nd commit**

- **tracer:** `getTraceStateString()` now emits `key=value` pairs (was malformed `=a,1,=b,2`, and would have polluted the `tracestate` response header via http-tracer).
- **tracer:** `getTraceState()` / `getContextData()` freeze a shallow copy instead of the live value, so a read no longer makes later `setTraceStateProperty` / `deleteTraceStateProperty` calls throw.
- **tracer:** nested spans link `parentId` to the parent span id, not the trace id (the hierarchy was being lost).
- **tracer:** `buildTraceString()` zero-pads version/flags to two hex digits per the w3c `traceparent` format.
- **tracer:** export `NotInSpanError` / `INVALID_SPAN_ID`; fix the `setContextData` jsdoc; repair the `getTraceStateString` test (it was asserting `getTraceState`).
- **http-requests-logger:** an error escaping the handler chain without a status is logged as `500` instead of `200`.

**3rd commit**

- **tracer:** nested spans copy the inherited trace state, so a child span's mutations no longer leak back into its parent/siblings; dropped a redundant `Number(...)` coercion.
- **http-requests-logger:** `skip` regexes with the global/sticky flag now match consistently across requests (the reused regex's `lastIndex` made matches alternate); a custom `inputLog` callback is no longer invoked for skipped requests; errors are logged at `error` level; corrected the `skip` jsdoc default.

## Test plan

- [x] `pnpm --filter @dcl/tracer-component build` + `test` → 45/45 passing
- [x] `pnpm --filter @dcl/http-requests-logger-component build` + `test` → 34/34 passing
- [x] each fix verified against the built output (state-string format, read-then-mutate, padding, span linkage, trace-state isolation, public exports, stateful regex, lazy inputLog)
- [x] built entrypoints resolve (`dist/src/index.js` exports the public surface for both)
