### PR TITLE
fix: don't attach an already-consumed request stream as the native Request body

### DIFF
--- a/.changeset/http-server-consumed-request-body.md
+++ b/.changeset/http-server-consumed-request-body.md
@@ -1,0 +1,5 @@
+---
+"@dcl/http-server": patch
+---
+
+`getRequestFromNodeMessage`: don't attach an already-consumed request stream as the native `Request` body. When an upstream consumer (e.g. an Express `body-parser`) has already read the incoming message, wrapping the drained stream made the native `Request` constructor throw `Response body object should not be disturbed or locked`. The body is now only streamed when the incoming stream hasn't been read yet (`readableEnded` / `readableDidRead`); the WKC server path is unaffected since it builds the request before reading the body.

--- a/components/http-server/src/logic.ts
+++ b/components/http-server/src/logic.ts
@@ -125,7 +125,14 @@ export const getRequestFromNodeMessage = <T extends http.IncomingMessage & { ori
     method
   }
 
-  if (method != 'GET' && method != 'HEAD') {
+  // Only stream a body when the incoming Node message hasn't been consumed yet.
+  // If something already read it (e.g. an Express body-parser running before this
+  // is called), `Readable.toWeb` yields a disturbed stream and the native
+  // `Request` constructor throws "Response body object should not be disturbed or
+  // locked". In that case the parsed body is exposed by the caller through other
+  // means, so skipping it here is safe.
+  const bodyAlreadyConsumed = request.readableEnded || request.readableDidRead
+  if (method != 'GET' && method != 'HEAD' && !bodyAlreadyConsumed) {
     // The native `Request` body must be a web `ReadableStream`. Adapt the incoming Node message
     // stream; `duplex: 'half'` is required by the fetch spec when streaming a request body.
     requestInit.body = Readable.toWeb(request) as unknown as ReadableStream

--- a/components/http-server/test/logic.spec.ts
+++ b/components/http-server/test/logic.spec.ts
@@ -98,4 +98,29 @@ describe('when building a request from a Node message', () => {
       expect(request.body).not.toBeNull()
     })
   })
+
+  describe('and the request body has already been consumed', () => {
+    let nodeMessage: any
+
+    beforeEach(async () => {
+      nodeMessage = Object.assign(Readable.from([Buffer.from('payload')]), {
+        method: 'POST',
+        url: '/resource',
+        headers: {}
+      })
+      // Simulate an upstream consumer (e.g. an Express body-parser) that drains
+      // the incoming stream before the request is built.
+      for await (const _chunk of nodeMessage) {
+        // drain
+      }
+    })
+
+    it('should not throw and should not attach a body', () => {
+      let request!: ReturnType<typeof getRequestFromNodeMessage>
+      expect(() => {
+        request = getRequestFromNodeMessage(nodeMessage, '0.0.0.0')
+      }).not.toThrow()
+      expect(request.body).toBeNull()
+    })
+  })
 })


### PR DESCRIPTION
## what

`@dcl/http-server`'s `getRequestFromNodeMessage` no longer attaches an already-consumed incoming stream as the native `Request` body.

## why

For any non-GET/HEAD method it did:
```ts
requestInit.body = Readable.toWeb(request)
requestInit.duplex = 'half'
new Request(url, requestInit)
```
When an upstream consumer has **already drained** the incoming Node message — e.g. an Express app whose `body-parser` runs before the request is built, which is exactly what `decentraland-gatsby`'s wkc `ExpressContext` does — wrapping the drained stream makes the native `Request` constructor throw:

```
TypeError: Response body object should not be disturbed or locked
```

This broke **every POST route** that went through gatsby's wkc Router (surfaced by failing places integration tests on `POST /destinations`, `/places`, `/report`, …). The WKC server path was fine because it builds the request *before* the handler reads the body.

## fix

Only stream the body when the incoming message hasn't been read yet:
```ts
const bodyAlreadyConsumed = request.readableEnded || request.readableDidRead
if (method !== 'GET' && method !== 'HEAD' && !bodyAlreadyConsumed) { ... }
```
- WKC server path: unaffected (stream not yet read → body still attached).
- Express + body-parser: body skipped → no crash; the parsed body is read through the consumer's usual channel.

## tests

- New regression test in `logic.spec.ts` for an already-consumed stream (verified it throws the exact error without the guard, passes with it).
- Full `logic.spec.ts` suite passes. (Note: 4 unrelated suites fail to *load* locally with `ReferenceError: File is not defined` — an undici/Node-env issue present on `main` too, not from this change.)

## release

Includes a changeset (`@dcl/http-server` patch). Once released, downstreams pick it up via gatsby's `^2.0.1` range on reinstall — no gatsby re-release needed.