### PR TITLE
fix: stop leaking the ws types into the published @dcl/http-server surface

### DIFF
--- a/.changeset/http-server-drop-ws-types-leak.md
+++ b/.changeset/http-server-drop-ws-types-leak.md
@@ -1,0 +1,7 @@
+---
+"@dcl/http-server": patch
+---
+
+Stop the published types from importing `ws`, so consumers no longer need `@types/ws` (or `skipLibCheck: true`) to typecheck against `@dcl/http-server`.
+
+`ws` is only a dev/type dependency, but `WebSocketCallback`, `IWebSocketComponent` and `TestServerWithWs` referenced its `WebSocket` type, leaking `import type { WebSocket } from 'ws'` into `dist/ws.d.ts` and `dist/test-component.d.ts`. Consumers that don't install `@types/ws` then failed with `TS2307: Cannot find module 'ws'` whenever `skipLibCheck` was off, which forced them to enable it. These (deprecated/alpha) WebSocket types are now generic with an `any` default, so the published `.d.ts` no longer references `ws`; consumers that use them can still opt into precise typing via `WebSocketCallback<import('ws').WebSocket>`.

--- a/components/http-server/src/test-component.ts
+++ b/components/http-server/src/test-component.ts
@@ -2,7 +2,6 @@ import type { IFetchComponent, IHttpServerComponent } from '@dcl/core-commons'
 import { createServerHandler } from './server-handler'
 import { NormalizedResponse } from './logic'
 import { PassThrough, pipeline, Readable } from 'stream'
-import type { WebSocket as WS } from 'ws'
 
 /**
  * Converts the server's internal {@link NormalizedResponse} into a native `Response` for test callers.
@@ -38,7 +37,7 @@ function toFetchResponse(res: NormalizedResponse): Response {
 }
 
 /** @alpha */
-export type IWebSocketComponent<W = WS> = {
+export type IWebSocketComponent<W = any> = {
   createWebSocket(url: string, protocols?: string | string[]): W
 }
 
@@ -51,8 +50,8 @@ export type ITestHttpServerComponent<Context extends object> = IHttpServerCompon
 /**
  * @alpha
  */
-export type TestServerWithWs = {
-  ws(path: string, protocols: string | string[]): WS
+export type TestServerWithWs<W = any> = {
+  ws(path: string, protocols: string | string[]): W
 }
 
 /**

--- a/components/http-server/src/ws.ts
+++ b/components/http-server/src/ws.ts
@@ -1,9 +1,15 @@
 import { IHttpServerComponent } from '@dcl/core-commons'
-import type { WebSocket as WS } from 'ws'
 
 const wsSymbol = Symbol('WebSocketResponse')
 
-export type WebSocketCallback = (ws: WS) => Promise<void> | void
+/**
+ * Callback invoked with the upgraded WebSocket. The socket type is generic (defaulting to
+ * `any`) so the published types don't depend on `@types/ws` — which would otherwise force
+ * every consumer to install it or enable `skipLibCheck`. Consumers that use this (unstable)
+ * API can parameterize it with their own socket type, e.g.
+ * `WebSocketCallback<import('ws').WebSocket>`.
+ */
+export type WebSocketCallback<W = any> = (ws: W) => Promise<void> | void
 
 /**
  * @alpha


### PR DESCRIPTION
## What

`@dcl/http-server`'s published types leak an import of the optional `ws` package, forcing every consumer to install `@types/ws` or enable `skipLibCheck: true`.

`WebSocketCallback` (`src/ws.ts`), `IWebSocketComponent` and `TestServerWithWs` (`src/test-component.ts`) referenced `ws`'s `WebSocket` type, so `tsc` emitted `import type { WebSocket as WS } from 'ws'` into `dist/ws.d.ts` and `dist/test-component.d.ts`. `ws` is only a **dev/type** dependency (used by the test harness), so consumers that don't install `@types/ws` get:

```
node_modules/@dcl/http-server/dist/test-component.d.ts:2:38 - error TS2307: Cannot find module 'ws'
```

whenever `skipLibCheck` is off — which is exactly what was keeping `skipLibCheck: true` pinned in several downstream services (signatures-server, marketplace-server, worlds-content-server, …).

## Change

Make the three (already `@deprecated` / `@alpha`) WebSocket types generic with an `any` default and drop the `ws` imports:

- `WebSocketCallback` → `WebSocketCallback<W = any>`
- `IWebSocketComponent<W = WS>` → `IWebSocketComponent<W = any>`
- `TestServerWithWs` → `TestServerWithWs<W = any>`

The published `.d.ts` no longer references `ws`. This is non-breaking (an `any` default is assignable everywhere `ws.WebSocket` was), and consumers that use these APIs can still opt into precise typing via `WebSocketCallback<import('ws').WebSocket>`. `ws` / `@types/ws` remain devDependencies for the test harness.

This mirrors the express/koa removal from `@dcl/crypto-middleware` (core-libs #46) — stop forcing optional-peer types onto every consumer.

## Verification

- `pnpm -r build` → `@dcl/http-server` builds clean.
- `grep "from 'ws'" dist/*.d.ts` → **no matches** (leak gone).
- `pnpm --filter @dcl/http-server test` → **12 suites / 402 passed** (incl. `test/ws.spec.ts`).
