### PR TITLE
fix: serialize concurrent pg-component migrations instead of failing

### DIFF
--- a/.changeset/pg-component-serialize-concurrent-migrations.md
+++ b/.changeset/pg-component-serialize-concurrent-migrations.md
@@ -1,0 +1,7 @@
+---
+"@dcl/pg-component": patch
+---
+
+Serialize concurrent migrations instead of failing with "Another migration is already running".
+
+node-pg-migrate guards migrations with a non-blocking advisory lock (`pg_try_advisory_lock`) and throws immediately when it loses the race. When several pg-components migrate the same database around the same time (e.g. multiple components started together on boot), the losers would fail outright — and a caller that does not fail fast (such as a components lifecycle) can hang on that error rather than surface it. `start()` now retries the migration with a short backoff while another migration holds the lock, so concurrent migrations serialize behind whichever one currently holds it.

--- a/.changeset/pg-component-serialize-concurrent-migrations.md
+++ b/.changeset/pg-component-serialize-concurrent-migrations.md
@@ -4,4 +4,6 @@
 
 Serialize concurrent migrations instead of failing with "Another migration is already running".
 
-node-pg-migrate guards migrations with a non-blocking advisory lock (`pg_try_advisory_lock`) and throws immediately when it loses the race. When several pg-components migrate the same database around the same time (e.g. multiple components started together on boot), the losers would fail outright — and a caller that does not fail fast (such as a components lifecycle) can hang on that error rather than surface it. `start()` now retries the migration with a short backoff while another migration holds the lock, so concurrent migrations serialize behind whichever one currently holds it.
+node-pg-migrate guards migrations with a non-blocking advisory lock (`pg_try_advisory_lock`) and throws immediately when it loses the race. When several pg-components migrate the same database around the same time (e.g. multiple components started together on boot), the losers would fail outright — and a caller that does not fail fast (such as a components lifecycle) can hang on that error rather than surface it. `start()` now retries the migration with a short, jittered backoff while another migration holds the lock, so concurrent migrations serialize behind whichever one currently holds it.
+
+The retry behavior is configurable via `PG_COMPONENT_MIGRATION_RETRY_ATTEMPTS` (default `30`) and `PG_COMPONENT_MIGRATION_RETRY_DELAY` in milliseconds (default `1000`).

--- a/components/pg/src/component.ts
+++ b/components/pg/src/component.ts
@@ -83,6 +83,8 @@ export async function createPgComponent(
   const STREAM_QUERY_TIMEOUT = await config.getNumber('PG_COMPONENT_STREAM_QUERY_TIMEOUT')
   const GRACE_PERIODS = (await config.getNumber('PG_COMPONENT_GRACE_PERIODS')) ?? 10
   const STOP_TIMEOUT = (await config.getNumber('PG_COMPONENT_STOP_TIMEOUT')) ?? 30_000
+  const MIGRATION_RETRY_ATTEMPTS = (await config.getNumber('PG_COMPONENT_MIGRATION_RETRY_ATTEMPTS')) ?? 30
+  const MIGRATION_RETRY_DELAY = (await config.getNumber('PG_COMPONENT_MIGRATION_RETRY_DELAY')) ?? 1000
 
   const finalOptions: PoolConfig = { ...defaultOptions, ...options.pool }
 
@@ -112,22 +114,24 @@ export async function createPgComponent(
   // Retry with a short backoff so they serialize behind whichever migration currently holds the
   // lock instead of erroring.
   async function runMigrations(opt: RunnerOption) {
-    const MAX_ATTEMPTS = 30
-    const RETRY_DELAY_MS = 1000
-
-    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    for (let attempt = 1; attempt <= MIGRATION_RETRY_ATTEMPTS; attempt++) {
       try {
         await runner(opt)
         return
       } catch (err: any) {
+        // node-pg-migrate does not export a typed error for this, so we match the message it throws
+        // from its lock() helper. This is coupled to node-pg-migrate's wording (verified against
+        // node-pg-migrate@7.x); if the message changes upstream, this matcher must be updated.
         const isAnotherMigrationRunning = /Another migration is already running/i.test(err?.message ?? String(err))
 
-        if (!isAnotherMigrationRunning || attempt === MAX_ATTEMPTS) {
+        if (!isAnotherMigrationRunning || attempt === MIGRATION_RETRY_ATTEMPTS) {
           throw err
         }
 
-        logger.warn(`Another migration is already running, retrying (attempt ${attempt}/${MAX_ATTEMPTS})`)
-        await setTimeout(RETRY_DELAY_MS)
+        // Jitter the backoff so concurrent retriers don't retry in lockstep and keep colliding.
+        const delay = MIGRATION_RETRY_DELAY + Math.floor(Math.random() * (MIGRATION_RETRY_DELAY / 2))
+        logger.warn(`Another migration is already running, retrying (attempt ${attempt}/${MIGRATION_RETRY_ATTEMPTS})`)
+        await setTimeout(delay)
       }
     }
   }

--- a/components/pg/src/component.ts
+++ b/components/pg/src/component.ts
@@ -104,6 +104,34 @@ export async function createPgComponent(
 
   let didStart = false
 
+  // node-pg-migrate guards against concurrent migrations with a non-blocking advisory lock
+  // (pg_try_advisory_lock) and throws "Another migration is already running" when it cannot acquire
+  // it. When several pg-components migrate the same database around the same time (e.g. multiple
+  // components started together on boot), the ones that lose the race would otherwise fail outright
+  // — and a caller that does not fail fast (such as a components lifecycle) can hang on that error.
+  // Retry with a short backoff so they serialize behind whichever migration currently holds the
+  // lock instead of erroring.
+  async function runMigrations(opt: RunnerOption) {
+    const MAX_ATTEMPTS = 30
+    const RETRY_DELAY_MS = 1000
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        await runner(opt)
+        return
+      } catch (err: any) {
+        const isAnotherMigrationRunning = /Another migration is already running/i.test(err?.message ?? String(err))
+
+        if (!isAnotherMigrationRunning || attempt === MAX_ATTEMPTS) {
+          throw err
+        }
+
+        logger.warn(`Another migration is already running, retrying (attempt ${attempt}/${MAX_ATTEMPTS})`)
+        await setTimeout(RETRY_DELAY_MS)
+      }
+    }
+  }
+
   // Methods
   async function start() {
     if (didStart) {
@@ -127,7 +155,7 @@ export async function createPgComponent(
           if (!opt.logger) {
             opt.logger = logger
           }
-          await runner(opt)
+          await runMigrations(opt)
         }
       } catch (err: any) {
         logger.error('Migration failed', {

--- a/components/pg/tests/fixtures/migrations/1700000000000_create-lock-test-table.js
+++ b/components/pg/tests/fixtures/migrations/1700000000000_create-lock-test-table.js
@@ -1,0 +1,13 @@
+/* eslint-disable */
+// Fixture migration used by the "two components migrating the same database" test.
+exports.shorthands = undefined
+
+exports.up = (pgm) => {
+  pgm.createTable('pg_component_migration_lock_test', {
+    id: { type: 'serial', primaryKey: true }
+  })
+}
+
+exports.down = (pgm) => {
+  pgm.dropTable('pg_component_migration_lock_test')
+}

--- a/components/pg/tests/pg-component.spec.ts
+++ b/components/pg/tests/pg-component.spec.ts
@@ -3,6 +3,7 @@ import { PostgreSqlContainer, StartedPostgreSqlContainer } from '@testcontainers
 import { createPgComponent } from '../src/component'
 import { IPgComponent } from '../src/types'
 import SQL from 'sql-template-strings'
+import { resolve } from 'path'
 
 describe('PgComponent', () => {
   let container: StartedPostgreSqlContainer
@@ -93,6 +94,40 @@ describe('PgComponent', () => {
 
     it('should connect to the database successfully', async () => {
       await expect(pg.start()).resolves.not.toThrow()
+    })
+  })
+
+  describe('when two components run migrations against the same database', () => {
+    let pgA: IPgComponent
+    let pgB: IPgComponent
+    let config: IConfigComponent
+    let logs: ILoggerComponent
+
+    beforeEach(() => {
+      config = createMockConfig()
+      logs = createMockLogs()
+    })
+
+    afterEach(async () => {
+      await pgA?.stop()
+      await pgB?.stop()
+    })
+
+    it('should serialize concurrent migrations instead of throwing "Another migration is already running"', async () => {
+      const migration = {
+        dir: resolve(__dirname, 'fixtures/migrations'),
+        migrationsTable: 'pgmigrations',
+        direction: 'up' as const
+      }
+
+      pgA = await createPgComponent({ config, logs }, { migration })
+      pgB = await createPgComponent({ config, logs }, { migration })
+
+      // node-pg-migrate uses a non-blocking advisory lock and throws "Another migration is already
+      // running" when a second migration races it. Starting both components at once must not throw:
+      // the loser retries with backoff until the first releases the lock, then runs (a no-op here,
+      // since the migration is already applied).
+      await expect(Promise.all([pgA.start(), pgB.start()])).resolves.toHaveLength(2)
     })
   })
 

--- a/components/pg/tests/pg-migration-retry.spec.ts
+++ b/components/pg/tests/pg-migration-retry.spec.ts
@@ -1,0 +1,96 @@
+import { IConfigComponent, ILoggerComponent } from '@well-known-components/interfaces'
+import runner from 'node-pg-migrate'
+import { createPgComponent } from '../src/component'
+
+// Unit tests for the migration retry loop. node-pg-migrate's runner and the pg Pool are mocked so
+// the retry behavior can be exercised without a database.
+jest.mock('node-pg-migrate')
+jest.mock('pg', () => ({
+  Pool: jest.fn().mockImplementation(() => ({
+    connect: jest.fn().mockResolvedValue({ release: jest.fn() }),
+    on: jest.fn(),
+    end: jest.fn(),
+    query: jest.fn()
+  })),
+  Client: jest.fn()
+}))
+
+const mockedRunner = runner as jest.MockedFunction<typeof runner>
+
+describe('PgComponent migration retries', () => {
+  let config: IConfigComponent
+  let logs: ILoggerComponent
+
+  const migration = { dir: '/tmp/migrations', migrationsTable: 'pgmigrations', direction: 'up' as const }
+
+  function createMockConfig(overrides: Record<string, string | number | undefined> = {}): IConfigComponent {
+    const values: Record<string, string | number | undefined> = {
+      PG_COMPONENT_PSQL_CONNECTION_STRING: 'postgres://user:pass@localhost/db',
+      // No delay between retries so the tests run instantly.
+      PG_COMPONENT_MIGRATION_RETRY_DELAY: 0,
+      ...overrides
+    }
+
+    return {
+      getString: jest.fn().mockImplementation((key: string) => Promise.resolve(values[key] as string | undefined)),
+      getNumber: jest.fn().mockImplementation((key: string) => Promise.resolve(values[key] as number | undefined)),
+      requireString: jest.fn().mockImplementation((key: string) => Promise.resolve(values[key] as string)),
+      requireNumber: jest.fn().mockImplementation((key: string) => Promise.resolve(values[key] as number))
+    }
+  }
+
+  function createMockLogs(): ILoggerComponent {
+    return {
+      getLogger: jest.fn().mockReturnValue({
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        log: jest.fn()
+      })
+    }
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    config = createMockConfig()
+    logs = createMockLogs()
+  })
+
+  describe('when the lock is released after a few attempts', () => {
+    it('should retry and resolve', async () => {
+      mockedRunner
+        .mockRejectedValueOnce(new Error('Another migration is already running'))
+        .mockRejectedValueOnce(new Error('Another migration is already running'))
+        .mockResolvedValueOnce(undefined as never)
+
+      const pg = await createPgComponent({ config, logs }, { migration })
+
+      await expect(pg.start()).resolves.not.toThrow()
+      expect(mockedRunner).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('when the migration fails with an error other than a concurrent migration', () => {
+    it('should rethrow immediately without retrying', async () => {
+      mockedRunner.mockRejectedValue(new Error('relation "credits" does not exist'))
+
+      const pg = await createPgComponent({ config, logs }, { migration })
+
+      await expect(pg.start()).rejects.toThrow('relation "credits" does not exist')
+      expect(mockedRunner).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('and another migration keeps holding the lock past the configured attempts', () => {
+    it('should give up and rethrow the original error', async () => {
+      mockedRunner.mockRejectedValue(new Error('Another migration is already running'))
+      config = createMockConfig({ PG_COMPONENT_MIGRATION_RETRY_ATTEMPTS: 3 })
+
+      const pg = await createPgComponent({ config, logs }, { migration })
+
+      await expect(pg.start()).rejects.toThrow('Another migration is already running')
+      expect(mockedRunner).toHaveBeenCalledTimes(3)
+    })
+  })
+})


### PR DESCRIPTION
## What

`@dcl/pg-component` fails when two components migrate the same database around the same time.

node-pg-migrate guards migrations with a **non-blocking** advisory lock (`pg_try_advisory_lock`) and throws **"Another migration is already running"** the instant it loses the race (it does *not* wait). So when several pg-components run migrations against the same database on startup — and they overlap — the loser throws. If the caller doesn't fail fast (e.g. a `@well-known-components` lifecycle starting components together), it can **hang** on that rejection instead of surfacing it.

This is timing-dependent: on a fast machine the migrations often serialize naturally and it passes, but on a slower/constrained CI runner they overlap and it breaks — which is exactly what was seen in a downstream service whose tests start two migrating pg-components against one database.

## Change

`start()` now wraps the migration in a small retry loop: on **"Another migration is already running"** it waits briefly and retries (up to 30× / ~30s), so concurrent migrations serialize behind whichever one currently holds the lock instead of erroring. Any other error is rethrown immediately, unchanged.

## What this is NOT

The advisory lock is *not* leaked — node-pg-migrate releases it (`pg_advisory_unlock`) at the end, so **sequential** migrations already worked. The only gap was truly-concurrent attempts, which this serializes.

## Verification

- New regression test: two components migrating the same database **concurrently** must not throw (`Promise.all([pgA.start(), pgB.start()])`). It **fails without this change** (`Another migration is already running`) and passes with it.
- Full pg-component suite (testcontainers, real Postgres): **21/21 pass**.

Patch changeset included.
