### PR TITLE
feat(http-server): abort requests on client disconnect

### DIFF
--- a/.changeset/soft-pandas-signal.md
+++ b/.changeset/soft-pandas-signal.md
@@ -2,4 +2,4 @@
 '@dcl/http-server': minor
 ---
 
-Abort each HTTP and upgrade handler's Fetch `Request.signal` when its client disconnects, and avoid logging or writing an error response after the HTTP connection is already gone.
+Abort each HTTP and upgrade handler's Fetch `Request.signal` when its client disconnects, including while an HTTP response is streaming or a pending WebSocket upgrade is half-closed, and avoid logging or writing an error response after the connection is already gone.

--- a/.changeset/soft-pandas-signal.md
+++ b/.changeset/soft-pandas-signal.md
@@ -1,0 +1,5 @@
+---
+'@dcl/http-server': minor
+---
+
+Abort each HTTP and upgrade handler's Fetch `Request.signal` when its client disconnects, and avoid logging or writing an error response after the HTTP connection is already gone.

--- a/components/http-server/src/logic.ts
+++ b/components/http-server/src/logic.ts
@@ -184,11 +184,22 @@ export function getDefaultMiddlewares(): Middleware<any>[] {
 // disappears together with its request.
 const parsedUrlByRequest = new WeakMap<IHttpServerComponent.IRequest, URL>()
 
+/**
+ * Adapts a Node request to the Fetch API request used by HTTP-server handlers.
+ *
+ * @param request Incoming Node request.
+ * @param host Fallback host used to build the absolute URL.
+ * @param maxBodySize Optional streaming body limit.
+ * @param onBodyExceeded Optional callback invoked when the streaming body limit is exceeded.
+ * @param signal Optional signal tied to the underlying client connection.
+ * @returns A Fetch request whose body, headers, URL, and cancellation follow the Node request.
+ */
 export const getRequestFromNodeMessage = <T extends http.IncomingMessage & { originalUrl?: string }>(
   request: T,
   host: string,
   maxBodySize?: number,
-  onBodyExceeded?: () => void
+  onBodyExceeded?: () => void,
+  signal?: AbortSignal
 ): IHttpServerComponent.IRequest => {
   const headers = new Headers()
 
@@ -206,7 +217,8 @@ export const getRequestFromNodeMessage = <T extends http.IncomingMessage & { ori
   const method = request.method!.toUpperCase()
   const requestInit: RequestInit & { duplex?: 'half' } = {
     headers,
-    method
+    method,
+    signal
   }
 
   // Only stream a body when the incoming Node message hasn't been consumed yet.

--- a/components/http-server/src/server.ts
+++ b/components/http-server/src/server.ts
@@ -10,6 +10,7 @@ import { getServer, success, getRequestFromNodeMessage, exceedsContentLength, as
 import type { ServerComponents, IHttpServerOptions } from './types'
 import { createServerHandler } from './server-handler'
 import * as http from 'http'
+import { Readable } from 'stream'
 import { createServerTerminator } from './terminator'
 import { Socket } from 'net'
 import { getWebSocketCallback } from './ws'
@@ -182,6 +183,16 @@ export async function createServerComponent<Context extends object>(
     )
     const response = await serverHandler.processRequest(configuredContext, request)
 
+    // Middleware may handle cancellation and still return a response. Do not start writing that
+    // response to a connection which disappeared while the middleware was cleaning up, and dispose
+    // a returned stream which otherwise has no consumer.
+    if (res.destroyed) {
+      if (response.body instanceof Readable) {
+        destroy(response.body)
+      }
+      return
+    }
+
     if (bodyExceeded) {
       res.setHeader('connection', 'close')
     }
@@ -220,6 +231,12 @@ export async function createServerComponent<Context extends object>(
     } finally {
       socket.removeListener('end', abortOnDisconnect)
       socket.removeListener('close', abortOnDisconnect)
+    }
+
+    // Middleware may observe the abort, finish cleanup, and return normally. In that case the
+    // transport is still gone and must not be handed to the WebSocket server or written to.
+    if (disconnectController.signal.aborted || socket.destroyed) {
+      return
     }
 
     const websocketConnect = getWebSocketCallback(response)

--- a/components/http-server/src/server.ts
+++ b/components/http-server/src/server.ts
@@ -10,7 +10,7 @@ import { getServer, success, getRequestFromNodeMessage, exceedsContentLength, as
 import type { ServerComponents, IHttpServerOptions } from './types'
 import { createServerHandler } from './server-handler'
 import * as http from 'http'
-import { Readable } from 'stream'
+import { Stream } from 'stream'
 import { createServerTerminator } from './terminator'
 import { Socket } from 'net'
 import { getWebSocketCallback } from './ws'
@@ -187,7 +187,12 @@ export async function createServerComponent<Context extends object>(
     // response to a connection which disappeared while the middleware was cleaning up, and dispose
     // a returned stream which otherwise has no consumer.
     if (res.destroyed) {
-      if (response.body instanceof Readable) {
+      if (response.body instanceof Stream) {
+        // The response is already abandoned, so no consumer remains for cleanup errors. Replace
+        // stale error listeners with a no-op before disposal, matching `destroy(stream, true)` while
+        // supporting every Node Stream accepted by response normalization.
+        response.body.removeAllListeners('error')
+        response.body.on('error', () => {})
         destroy(response.body)
       }
       return

--- a/components/http-server/src/server.ts
+++ b/components/http-server/src/server.ts
@@ -163,16 +163,34 @@ export async function createServerComponent<Context extends object>(
     // normal response path, which wouldn't close the connection. Flag it here so we can add
     // `Connection: close` and stop the client from continuing to stream into a doomed request.
     let bodyExceeded = false
-    const request = getRequestFromNodeMessage(req, host, maxBodySize, () => {
-      bodyExceeded = true
-    })
-    const response = await serverHandler.processRequest(configuredContext, request)
-
-    if (bodyExceeded) {
-      res.setHeader('connection', 'close')
+    const disconnectController = new AbortController()
+    const abortOnDisconnect = (): void => {
+      if (!res.writableEnded) {
+        disconnectController.abort(new DOMException('Client disconnected.', 'AbortError'))
+      }
     }
+    res.once('close', abortOnDisconnect)
 
-    success(response, res)
+    try {
+      const request = getRequestFromNodeMessage(
+        req,
+        host,
+        maxBodySize,
+        () => {
+          bodyExceeded = true
+        },
+        disconnectController.signal
+      )
+      const response = await serverHandler.processRequest(configuredContext, request)
+
+      if (bodyExceeded) {
+        res.setHeader('connection', 'close')
+      }
+
+      success(response, res)
+    } finally {
+      res.removeListener('close', abortOnDisconnect)
+    }
   }
 
   async function handleUpgrade(req: http.IncomingMessage, socket: Socket, head: Buffer) {
@@ -180,8 +198,18 @@ export async function createServerComponent<Context extends object>(
       throw new Error('No WebSocketServer present')
     }
 
-    const request = getRequestFromNodeMessage(req, host)
-    const response = await serverHandler.processRequest(configuredContext, request)
+    const disconnectController = new AbortController()
+    const abortOnDisconnect = (): void => {
+      disconnectController.abort(new DOMException('Client disconnected.', 'AbortError'))
+    }
+    socket.once('close', abortOnDisconnect)
+    const request = getRequestFromNodeMessage(req, host, undefined, undefined, disconnectController.signal)
+    let response: IHttpServerComponent.IResponse
+    try {
+      response = await serverHandler.processRequest(configuredContext, request)
+    } finally {
+      socket.removeListener('close', abortOnDisconnect)
+    }
 
     const websocketConnect = getWebSocketCallback(response)
 
@@ -216,6 +244,9 @@ export async function createServerComponent<Context extends object>(
 
   function handler(request: http.IncomingMessage, response: http.ServerResponse) {
     asyncHandle(request, response).catch((error) => {
+      if (response.destroyed) {
+        return
+      }
       logger.error(error)
 
       if (error.code == 'ERR_INVALID_URL') {

--- a/components/http-server/src/server.ts
+++ b/components/http-server/src/server.ts
@@ -171,26 +171,25 @@ export async function createServerComponent<Context extends object>(
     }
     res.once('close', abortOnDisconnect)
 
-    try {
-      const request = getRequestFromNodeMessage(
-        req,
-        host,
-        maxBodySize,
-        () => {
-          bodyExceeded = true
-        },
-        disconnectController.signal
-      )
-      const response = await serverHandler.processRequest(configuredContext, request)
+    const request = getRequestFromNodeMessage(
+      req,
+      host,
+      maxBodySize,
+      () => {
+        bodyExceeded = true
+      },
+      disconnectController.signal
+    )
+    const response = await serverHandler.processRequest(configuredContext, request)
 
-      if (bodyExceeded) {
-        res.setHeader('connection', 'close')
-      }
-
-      success(response, res)
-    } finally {
-      res.removeListener('close', abortOnDisconnect)
+    if (bodyExceeded) {
+      res.setHeader('connection', 'close')
     }
+
+    // Keep the one-shot close listener installed while a returned Readable is still piping. A
+    // normal response has already set writableEnded when close fires, whereas a premature close
+    // must continue to abort request-scoped stream/proxy work after the middleware has returned.
+    success(response, res)
   }
 
   async function handleUpgrade(req: http.IncomingMessage, socket: Socket, head: Buffer) {
@@ -202,12 +201,24 @@ export async function createServerComponent<Context extends object>(
     const abortOnDisconnect = (): void => {
       disconnectController.abort(new DOMException('Client disconnected.', 'AbortError'))
     }
+    // A client can half-close a pending upgrade, emitting `end` while the server side remains open
+    // waiting for middleware. Listen for both that case and a full transport close.
+    socket.once('end', abortOnDisconnect)
     socket.once('close', abortOnDisconnect)
     const request = getRequestFromNodeMessage(req, host, undefined, undefined, disconnectController.signal)
     let response: IHttpServerComponent.IResponse
     try {
       response = await serverHandler.processRequest(configuredContext, request)
+    } catch (error) {
+      // A client abandoning a pending upgrade is expected transport cancellation, not an
+      // application failure. Only consume the exact reason emitted by this connection's signal;
+      // unrelated middleware errors must still reach the outer error logger.
+      if (disconnectController.signal.aborted && error === disconnectController.signal.reason) {
+        return
+      }
+      throw error
     } finally {
+      socket.removeListener('end', abortOnDisconnect)
       socket.removeListener('close', abortOnDisconnect)
     }
 

--- a/components/http-server/src/server.ts
+++ b/components/http-server/src/server.ts
@@ -188,10 +188,8 @@ export async function createServerComponent<Context extends object>(
     // a returned stream which otherwise has no consumer.
     if (res.destroyed) {
       if (response.body instanceof Stream) {
-        // The response is already abandoned, so no consumer remains for cleanup errors. Replace
-        // stale error listeners with a no-op before disposal, matching `destroy(stream, true)` while
-        // supporting every Node Stream accepted by response normalization.
-        response.body.removeAllListeners('error')
+        // Ensure a cleanup error is handled even when the stream has no listener of its own, while
+        // preserving application-owned listeners which may perform metrics or resource cleanup.
         response.body.on('error', () => {})
         destroy(response.body)
       }

--- a/components/http-server/test/logic.spec.ts
+++ b/components/http-server/test/logic.spec.ts
@@ -92,6 +92,34 @@ describe('when writing a successful response with multiple Set-Cookie headers', 
 })
 
 describe('when building a request from a Node message', () => {
+  describe('and an abort signal is provided', () => {
+    let controller: AbortController
+    let request: ReturnType<typeof getRequestFromNodeMessage>
+
+    beforeEach(() => {
+      controller = new AbortController()
+      request = getRequestFromNodeMessage(
+        { method: 'GET', url: '/resource', headers: {} } as any,
+        '0.0.0.0',
+        undefined,
+        undefined,
+        controller.signal
+      )
+      controller.abort(new DOMException('Client disconnected.', 'AbortError'))
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    it('should propagate cancellation to the Fetch request', () => {
+      expect({ aborted: request.signal.aborted, reason: request.signal.reason }).toEqual({
+        aborted: true,
+        reason: new DOMException('Client disconnected.', 'AbortError')
+      })
+    })
+  })
+
   describe('and a header carries multiple values', () => {
     let nodeMessage: any
 

--- a/components/http-server/test/requestSignal.spec.ts
+++ b/components/http-server/test/requestSignal.spec.ts
@@ -1,6 +1,6 @@
 import { createConfigComponent } from '@well-known-components/env-config-provider'
 import type { Server } from 'http'
-import { PassThrough } from 'stream'
+import { PassThrough, Readable } from 'stream'
 import WebSocket from 'ws'
 import { createServerComponent, getUnderlyingServer, Router } from '../src'
 import { FullHttpServerComponent } from '../src/server'
@@ -151,15 +151,23 @@ describeE2E('request disconnect signal', ({ components }: { components: TestComp
     let clientController: AbortController
     let clientRequest: Promise<unknown>
     let handlerStarted: Promise<void>
-    let responseBody: PassThrough
+    let responseBody: Readable
     let responseBodyClosed: Promise<void>
     let responseBodyPipe: jest.SpyInstance
     let resolveHandlerStarted: () => void
+    let streamError: jest.Mock
 
     beforeEach(async () => {
       clientController = new AbortController()
-      responseBody = new PassThrough()
+      streamError = jest.fn()
+      responseBody = new Readable({
+        read() {},
+        destroy(_error, callback) {
+          callback(new Error('cleanup failed'))
+        }
+      })
       responseBodyClosed = new Promise<void>((resolve) => responseBody.once('close', resolve))
+      responseBody.on('error', streamError)
       responseBodyPipe = jest.spyOn(responseBody, 'pipe')
       handlerStarted = new Promise<void>((resolve) => {
         resolveHandlerStarted = resolve
@@ -187,8 +195,13 @@ describeE2E('request disconnect signal', ({ components }: { components: TestComp
     })
 
     it('should discard the response stream without starting it', () => {
-      expect({ destroyed: responseBody.destroyed, pipeCalls: responseBodyPipe.mock.calls.length }).toEqual({
+      expect({
+        destroyed: responseBody.destroyed,
+        errorCalls: streamError.mock.calls.length,
+        pipeCalls: responseBodyPipe.mock.calls.length
+      }).toEqual({
         destroyed: true,
+        errorCalls: 0,
         pipeCalls: 0
       })
     })

--- a/components/http-server/test/requestSignal.spec.ts
+++ b/components/http-server/test/requestSignal.spec.ts
@@ -1,14 +1,30 @@
+import { PassThrough } from 'stream'
+import WebSocket from 'ws'
+import { Router } from '../src'
 import { describeE2E } from './test-e2e-harness'
 import { TestComponents } from './test-helpers'
+
+function abortDetails(reason: unknown): unknown {
+  return typeof reason === 'object' && reason !== null && 'name' in reason && 'message' in reason
+    ? { message: (reason as Error).message, name: (reason as Error).name }
+    : reason
+}
+
+function rejectAfter(message: string): Promise<never> {
+  return new Promise((_, reject) => setTimeout(() => reject(new Error(message)), 1500).unref())
+}
 
 describeE2E('request disconnect signal', ({ components }: { components: TestComponents }) => {
   describe('when the client disconnects while a handler is running', () => {
     let clientController: AbortController
+    let clientError: unknown
+    let clientRequest: Promise<Response | unknown>
     let handlerStarted: Promise<void>
+    let reason: unknown
     let resolveHandlerStarted: () => void
     let serverAbortReason!: Promise<unknown>
 
-    beforeEach(() => {
+    beforeEach(async () => {
       clientController = new AbortController()
       handlerStarted = new Promise<void>((resolve) => {
         resolveHandlerStarted = resolve
@@ -22,31 +38,147 @@ describeE2E('request disconnect signal', ({ components }: { components: TestComp
         await serverAbortReason
         throw context.request.signal.reason
       })
+
+      clientRequest = components.fetch.fetch('/', { signal: clientController.signal }).catch((error) => error)
+      await handlerStarted
+      clientController.abort()
+      ;[clientError, reason] = await Promise.all([clientRequest, serverAbortReason])
+    })
+
+    afterEach(() => {
+      clientController.abort()
+      jest.resetAllMocks()
+    })
+
+    it('should abort the handler request signal', () => {
+      expect({
+        clientRequestAborted:
+          typeof clientError === 'object' && clientError !== null && 'name' in clientError
+            ? (clientError as Error).name
+            : clientError,
+        serverReason: abortDetails(reason)
+      }).toEqual({
+        clientRequestAborted: 'AbortError',
+        serverReason: { message: 'Client disconnected.', name: 'AbortError' }
+      })
+    })
+  })
+
+  describe('when the client disconnects while a response is streaming', () => {
+    let clientController: AbortController
+    let reason: unknown
+    let response: Response
+    let responseBody: PassThrough
+    let serverAbortReason!: Promise<unknown>
+
+    beforeEach(async () => {
+      clientController = new AbortController()
+      responseBody = new PassThrough()
+      components.server.resetMiddlewares()
+      components.server.use(async (context) => {
+        serverAbortReason = new Promise((resolve) => {
+          context.request.signal.addEventListener('abort', () => resolve(context.request.signal.reason), { once: true })
+        })
+        responseBody.write('stream started')
+        return { body: responseBody }
+      })
+
+      response = await components.fetch.fetch('/', { signal: clientController.signal })
+      clientController.abort()
+      reason = await serverAbortReason
+    })
+
+    afterEach(() => {
+      clientController.abort()
+      responseBody.destroy()
+      jest.resetAllMocks()
+    })
+
+    it('should keep the request signal connected until the response stream closes', () => {
+      expect({ responseStatus: response.status, serverReason: abortDetails(reason) }).toEqual({
+        responseStatus: 200,
+        serverReason: { message: 'Client disconnected.', name: 'AbortError' }
+      })
+    })
+  })
+
+  describe('when the response completes normally', () => {
+    let requestSignal: AbortSignal
+    let response: Response
+
+    beforeEach(async () => {
+      requestSignal = new AbortController().signal
+      components.server.resetMiddlewares()
+      components.server.use(async (context) => {
+        requestSignal = context.request.signal
+        return { status: 204 }
+      })
+
+      response = await components.fetch.fetch('/')
+      await response.arrayBuffer()
+      await new Promise<void>((resolve) => setImmediate(resolve))
     })
 
     afterEach(() => {
       jest.resetAllMocks()
     })
 
-    it('should abort the handler request signal', async () => {
-      const clientRequest = components.fetch.fetch('/', { signal: clientController.signal }).catch((error) => error)
-      await handlerStarted
-      clientController.abort()
+    it('should leave the request signal un-aborted', () => {
+      expect(requestSignal.aborted).toEqual(false)
+    })
+  })
 
-      const [clientError, reason] = await Promise.all([clientRequest, serverAbortReason])
-      expect({
-        clientRequestAborted:
-          typeof clientError === 'object' && clientError !== null && 'name' in clientError
-            ? (clientError as Error).name
-            : clientError,
-        serverReason:
-          typeof reason === 'object' && reason !== null && 'name' in reason && 'message' in reason
-            ? { message: (reason as Error).message, name: (reason as Error).name }
-            : reason
-      }).toEqual({
-        clientRequestAborted: 'AbortError',
-        serverReason: { message: 'Client disconnected.', name: 'AbortError' }
+  describe('when the client disconnects while WebSocket upgrade middleware is running', () => {
+    let clientSocket: WebSocket
+    let clientSocketError: Promise<never>
+    let handlerStarted: Promise<void>
+    let httpServerErrors: string[]
+    let reason: unknown
+    let resolveHandlerStarted: () => void
+    let serverAbortReason!: Promise<unknown>
+    let stderrWrite: jest.SpyInstance
+
+    beforeEach(async () => {
+      handlerStarted = new Promise<void>((resolve) => {
+        resolveHandlerStarted = resolve
       })
+      stderrWrite = jest.spyOn(process.stderr, 'write').mockImplementation(() => true)
+      components.server.resetMiddlewares()
+      const router = new Router()
+      router.get('/ws', async (context) => {
+        serverAbortReason = new Promise((resolve) => {
+          context.request.signal.addEventListener('abort', () => resolve(context.request.signal.reason), { once: true })
+        })
+        resolveHandlerStarted()
+        await serverAbortReason
+        throw context.request.signal.reason
+      })
+      components.server.use(router.middleware())
+      components.server.use(router.allowedMethods())
+
+      clientSocket = components.ws.createWebSocket('/ws')
+      clientSocketError = new Promise((_, reject) => clientSocket.once('error', reject))
+      await Promise.race([handlerStarted, clientSocketError, rejectAfter('Upgrade middleware did not start')])
+      clientSocket.terminate()
+      reason = await Promise.race([serverAbortReason, rejectAfter('Upgrade request signal did not abort')])
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      httpServerErrors = stderrWrite.mock.calls
+        .map(([message]) => String(message))
+        .filter((message) => message.includes('[ERROR] (http-server)'))
+    })
+
+    afterEach(() => {
+      clientSocket.terminate()
+      stderrWrite.mockRestore()
+      jest.resetAllMocks()
+    })
+
+    it('should abort the upgrade request signal', () => {
+      expect(abortDetails(reason)).toEqual({ message: 'Client disconnected.', name: 'AbortError' })
+    })
+
+    it('should not log the expected disconnect as an application error', () => {
+      expect(httpServerErrors).toEqual([])
     })
   })
 })

--- a/components/http-server/test/requestSignal.spec.ts
+++ b/components/http-server/test/requestSignal.spec.ts
@@ -1,6 +1,10 @@
+import { createConfigComponent } from '@well-known-components/env-config-provider'
+import type { Server } from 'http'
 import { PassThrough } from 'stream'
 import WebSocket from 'ws'
-import { Router } from '../src'
+import { createServerComponent, getUnderlyingServer, Router } from '../src'
+import { FullHttpServerComponent } from '../src/server'
+import { upgradeWebSocketResponse } from '../src/ws'
 import { describeE2E } from './test-e2e-harness'
 import { TestComponents } from './test-helpers'
 
@@ -10,8 +14,43 @@ function abortDetails(reason: unknown): unknown {
     : reason
 }
 
-function rejectAfter(message: string): Promise<never> {
-  return new Promise((_, reject) => setTimeout(() => reject(new Error(message)), 1500).unref())
+async function withTimeout<T>(promise: Promise<T>, message: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), 1500)
+        timer.unref()
+      })
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+type RunningUpgradeServer = {
+  server: FullHttpServerComponent<{}>
+  url: string
+}
+
+async function startUpgradeServer(loggerError: jest.Mock, handleUpgrade: jest.Mock): Promise<RunningUpgradeServer> {
+  const logs = {
+    getLogger: () => ({
+      log: jest.fn(),
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: loggerError
+    })
+  } as any
+  const config = createConfigComponent({ HTTP_SERVER_PORT: '0', HTTP_SERVER_HOST: '127.0.0.1' })
+  const server = await createServerComponent<{}>({ logs, config, ws: { handleUpgrade } }, {})
+  await (server.start as () => Promise<void>)()
+  const underlying = await getUnderlyingServer<Server>(server)
+  const address = underlying.address()
+  const port = typeof address === 'object' && address !== null ? address.port : 0
+  return { server, url: `ws://127.0.0.1:${port}` }
 }
 
 describeE2E('request disconnect signal', ({ components }: { components: TestComponents }) => {
@@ -40,9 +79,12 @@ describeE2E('request disconnect signal', ({ components }: { components: TestComp
       })
 
       clientRequest = components.fetch.fetch('/', { signal: clientController.signal }).catch((error) => error)
-      await handlerStarted
+      await withTimeout(handlerStarted, 'Handler did not start')
       clientController.abort()
-      ;[clientError, reason] = await Promise.all([clientRequest, serverAbortReason])
+      ;[clientError, reason] = await withTimeout(
+        Promise.all([clientRequest, serverAbortReason]),
+        'Handler request signal did not abort'
+      )
     })
 
     afterEach(() => {
@@ -83,9 +125,12 @@ describeE2E('request disconnect signal', ({ components }: { components: TestComp
         return { body: responseBody }
       })
 
-      response = await components.fetch.fetch('/', { signal: clientController.signal })
+      response = await withTimeout(
+        components.fetch.fetch('/', { signal: clientController.signal }),
+        'Streaming response did not start'
+      )
       clientController.abort()
-      reason = await serverAbortReason
+      reason = await withTimeout(serverAbortReason, 'Streaming request signal did not abort')
     })
 
     afterEach(() => {
@@ -98,6 +143,53 @@ describeE2E('request disconnect signal', ({ components }: { components: TestComp
       expect({ responseStatus: response.status, serverReason: abortDetails(reason) }).toEqual({
         responseStatus: 200,
         serverReason: { message: 'Client disconnected.', name: 'AbortError' }
+      })
+    })
+  })
+
+  describe('when a disconnected HTTP handler returns a streamed response after cleanup', () => {
+    let clientController: AbortController
+    let clientRequest: Promise<unknown>
+    let handlerStarted: Promise<void>
+    let responseBody: PassThrough
+    let responseBodyClosed: Promise<void>
+    let responseBodyPipe: jest.SpyInstance
+    let resolveHandlerStarted: () => void
+
+    beforeEach(async () => {
+      clientController = new AbortController()
+      responseBody = new PassThrough()
+      responseBodyClosed = new Promise<void>((resolve) => responseBody.once('close', resolve))
+      responseBodyPipe = jest.spyOn(responseBody, 'pipe')
+      handlerStarted = new Promise<void>((resolve) => {
+        resolveHandlerStarted = resolve
+      })
+      components.server.resetMiddlewares()
+      components.server.use(async (context) => {
+        resolveHandlerStarted()
+        await new Promise<void>((resolve) => {
+          context.request.signal.addEventListener('abort', () => resolve(), { once: true })
+        })
+        return { body: responseBody }
+      })
+
+      clientRequest = components.fetch.fetch('/', { signal: clientController.signal }).catch((error) => error)
+      await withTimeout(handlerStarted, 'Handler did not start')
+      clientController.abort()
+      await withTimeout(clientRequest, 'Disconnected client request did not settle')
+      await withTimeout(responseBodyClosed, 'Discarded response stream did not close')
+    })
+
+    afterEach(() => {
+      clientController.abort()
+      responseBody.destroy()
+      jest.resetAllMocks()
+    })
+
+    it('should discard the response stream without starting it', () => {
+      expect({ destroyed: responseBody.destroyed, pipeCalls: responseBodyPipe.mock.calls.length }).toEqual({
+        destroyed: true,
+        pipeCalls: 0
       })
     })
   })
@@ -127,23 +219,28 @@ describeE2E('request disconnect signal', ({ components }: { components: TestComp
       expect(requestSignal.aborted).toEqual(false)
     })
   })
+})
 
-  describe('when the client disconnects while WebSocket upgrade middleware is running', () => {
+describe('when the client disconnects while WebSocket upgrade middleware is running', () => {
+  describe('and middleware throws the request signal reason', () => {
     let clientSocket: WebSocket
     let clientSocketError: Promise<never>
     let handlerStarted: Promise<void>
-    let httpServerErrors: string[]
+    let loggerError: jest.Mock
     let reason: unknown
     let resolveHandlerStarted: () => void
+    let running: RunningUpgradeServer
     let serverAbortReason!: Promise<unknown>
-    let stderrWrite: jest.SpyInstance
+    let webSocketUpgrade: jest.Mock
 
     beforeEach(async () => {
+      loggerError = jest.fn()
+      webSocketUpgrade = jest.fn()
+      running = await startUpgradeServer(loggerError, webSocketUpgrade)
       handlerStarted = new Promise<void>((resolve) => {
         resolveHandlerStarted = resolve
       })
-      stderrWrite = jest.spyOn(process.stderr, 'write').mockImplementation(() => true)
-      components.server.resetMiddlewares()
+      running.server.resetMiddlewares()
       const router = new Router()
       router.get('/ws', async (context) => {
         serverAbortReason = new Promise((resolve) => {
@@ -153,23 +250,20 @@ describeE2E('request disconnect signal', ({ components }: { components: TestComp
         await serverAbortReason
         throw context.request.signal.reason
       })
-      components.server.use(router.middleware())
-      components.server.use(router.allowedMethods())
+      running.server.use(router.middleware())
+      running.server.use(router.allowedMethods())
 
-      clientSocket = components.ws.createWebSocket('/ws')
+      clientSocket = new WebSocket(`${running.url}/ws`)
       clientSocketError = new Promise((_, reject) => clientSocket.once('error', reject))
-      await Promise.race([handlerStarted, clientSocketError, rejectAfter('Upgrade middleware did not start')])
+      await withTimeout(Promise.race([handlerStarted, clientSocketError]), 'Upgrade middleware did not start')
       clientSocket.terminate()
-      reason = await Promise.race([serverAbortReason, rejectAfter('Upgrade request signal did not abort')])
+      reason = await withTimeout(serverAbortReason, 'Upgrade request signal did not abort')
       await new Promise<void>((resolve) => setImmediate(resolve))
-      httpServerErrors = stderrWrite.mock.calls
-        .map(([message]) => String(message))
-        .filter((message) => message.includes('[ERROR] (http-server)'))
     })
 
-    afterEach(() => {
+    afterEach(async () => {
       clientSocket.terminate()
-      stderrWrite.mockRestore()
+      await (running.server.stop as () => Promise<void>)()
       jest.resetAllMocks()
     })
 
@@ -178,7 +272,65 @@ describeE2E('request disconnect signal', ({ components }: { components: TestComp
     })
 
     it('should not log the expected disconnect as an application error', () => {
-      expect(httpServerErrors).toEqual([])
+      expect(loggerError).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and middleware returns an upgrade response after cleanup', () => {
+    let clientSocket: WebSocket
+    let clientSocketError: Promise<never>
+    let handlerStarted: Promise<void>
+    let loggerError: jest.Mock
+    let middlewareFinished: Promise<void>
+    let resolveHandlerStarted: () => void
+    let resolveMiddlewareFinished: () => void
+    let running: RunningUpgradeServer
+    let webSocketConnect: jest.Mock
+    let webSocketUpgrade: jest.Mock
+
+    beforeEach(async () => {
+      loggerError = jest.fn()
+      webSocketConnect = jest.fn()
+      webSocketUpgrade = jest.fn()
+      running = await startUpgradeServer(loggerError, webSocketUpgrade)
+      handlerStarted = new Promise<void>((resolve) => {
+        resolveHandlerStarted = resolve
+      })
+      middlewareFinished = new Promise<void>((resolve) => {
+        resolveMiddlewareFinished = resolve
+      })
+      running.server.resetMiddlewares()
+      const router = new Router()
+      router.get('/ws', async (context) => {
+        resolveHandlerStarted()
+        await new Promise<void>((resolve) => {
+          context.request.signal.addEventListener('abort', () => resolve(), { once: true })
+        })
+        resolveMiddlewareFinished()
+        return upgradeWebSocketResponse(webSocketConnect)
+      })
+      running.server.use(router.middleware())
+      running.server.use(router.allowedMethods())
+
+      clientSocket = new WebSocket(`${running.url}/ws`)
+      clientSocketError = new Promise((_, reject) => clientSocket.once('error', reject))
+      await withTimeout(Promise.race([handlerStarted, clientSocketError]), 'Upgrade middleware did not start')
+      clientSocket.terminate()
+      await withTimeout(middlewareFinished, 'Upgrade middleware did not finish cleanup')
+      await new Promise<void>((resolve) => setImmediate(resolve))
+    })
+
+    afterEach(async () => {
+      clientSocket.terminate()
+      await (running.server.stop as () => Promise<void>)()
+      jest.resetAllMocks()
+    })
+
+    it('should not pass the abandoned connection to the WebSocket server', () => {
+      expect({ connectCalls: webSocketConnect.mock.calls.length, upgradeCalls: webSocketUpgrade.mock.calls.length }).toEqual({
+        connectCalls: 0,
+        upgradeCalls: 0
+      })
     })
   })
 })

--- a/components/http-server/test/requestSignal.spec.ts
+++ b/components/http-server/test/requestSignal.spec.ts
@@ -155,11 +155,10 @@ describeE2E('request disconnect signal', ({ components }: { components: TestComp
     let responseBodyClosed: Promise<void>
     let responseBodyPipe: jest.SpyInstance
     let resolveHandlerStarted: () => void
-    let streamError: jest.Mock
+    let runDisconnectedRequest: () => Promise<void>
 
-    beforeEach(async () => {
+    beforeEach(() => {
       clientController = new AbortController()
-      streamError = jest.fn()
       responseBody = new Readable({
         read() {},
         destroy(_error, callback) {
@@ -167,7 +166,6 @@ describeE2E('request disconnect signal', ({ components }: { components: TestComp
         }
       })
       responseBodyClosed = new Promise<void>((resolve) => responseBody.once('close', resolve))
-      responseBody.on('error', streamError)
       responseBodyPipe = jest.spyOn(responseBody, 'pipe')
       handlerStarted = new Promise<void>((resolve) => {
         resolveHandlerStarted = resolve
@@ -181,11 +179,13 @@ describeE2E('request disconnect signal', ({ components }: { components: TestComp
         return { body: responseBody }
       })
 
-      clientRequest = components.fetch.fetch('/', { signal: clientController.signal }).catch((error) => error)
-      await withTimeout(handlerStarted, 'Handler did not start')
-      clientController.abort()
-      await withTimeout(clientRequest, 'Disconnected client request did not settle')
-      await withTimeout(responseBodyClosed, 'Discarded response stream did not close')
+      runDisconnectedRequest = async () => {
+        clientRequest = components.fetch.fetch('/', { signal: clientController.signal }).catch((error) => error)
+        await withTimeout(handlerStarted, 'Handler did not start')
+        clientController.abort()
+        await withTimeout(clientRequest, 'Disconnected client request did not settle')
+        await withTimeout(responseBodyClosed, 'Discarded response stream did not close')
+      }
     })
 
     afterEach(() => {
@@ -194,15 +194,30 @@ describeE2E('request disconnect signal', ({ components }: { components: TestComp
       jest.resetAllMocks()
     })
 
-    it('should discard the response stream without starting it', () => {
-      expect({
-        destroyed: responseBody.destroyed,
-        errorCalls: streamError.mock.calls.length,
-        pipeCalls: responseBodyPipe.mock.calls.length
-      }).toEqual({
-        destroyed: true,
-        errorCalls: 0,
-        pipeCalls: 0
+    describe('and the response stream has no error listener', () => {
+      beforeEach(async () => {
+        await runDisconnectedRequest()
+      })
+
+      it('should handle the cleanup error while discarding the stream without starting it', () => {
+        expect({ destroyed: responseBody.destroyed, pipeCalls: responseBodyPipe.mock.calls.length }).toEqual({
+          destroyed: true,
+          pipeCalls: 0
+        })
+      })
+    })
+
+    describe('and the response stream has an application error listener', () => {
+      let streamError: jest.Mock
+
+      beforeEach(async () => {
+        streamError = jest.fn()
+        responseBody.on('error', streamError)
+        await runDisconnectedRequest()
+      })
+
+      it('should preserve and notify the application error listener', () => {
+        expect(streamError).toHaveBeenCalledWith(expect.objectContaining({ message: 'cleanup failed' }))
       })
     })
   })

--- a/components/http-server/test/requestSignal.spec.ts
+++ b/components/http-server/test/requestSignal.spec.ts
@@ -1,0 +1,52 @@
+import { describeE2E } from './test-e2e-harness'
+import { TestComponents } from './test-helpers'
+
+describeE2E('request disconnect signal', ({ components }: { components: TestComponents }) => {
+  describe('when the client disconnects while a handler is running', () => {
+    let clientController: AbortController
+    let handlerStarted: Promise<void>
+    let resolveHandlerStarted: () => void
+    let serverAbortReason!: Promise<unknown>
+
+    beforeEach(() => {
+      clientController = new AbortController()
+      handlerStarted = new Promise<void>((resolve) => {
+        resolveHandlerStarted = resolve
+      })
+      components.server.resetMiddlewares()
+      components.server.use(async (context) => {
+        resolveHandlerStarted()
+        serverAbortReason = new Promise((resolve) => {
+          context.request.signal.addEventListener('abort', () => resolve(context.request.signal.reason), { once: true })
+        })
+        await serverAbortReason
+        throw context.request.signal.reason
+      })
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    it('should abort the handler request signal', async () => {
+      const clientRequest = components.fetch.fetch('/', { signal: clientController.signal }).catch((error) => error)
+      await handlerStarted
+      clientController.abort()
+
+      const [clientError, reason] = await Promise.all([clientRequest, serverAbortReason])
+      expect({
+        clientRequestAborted:
+          typeof clientError === 'object' && clientError !== null && 'name' in clientError
+            ? (clientError as Error).name
+            : clientError,
+        serverReason:
+          typeof reason === 'object' && reason !== null && 'name' in reason && 'message' in reason
+            ? { message: (reason as Error).message, name: (reason as Error).name }
+            : reason
+      }).toEqual({
+        clientRequestAborted: 'AbortError',
+        serverReason: { message: 'Client disconnected.', name: 'AbortError' }
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Why

`@dcl/http-server` adapts Node `IncomingMessage` objects into Fetch `Request` objects, but the adapted request currently uses the Fetch API's default signal. That signal never aborts when the underlying HTTP client disconnects.

Long-running handlers therefore cannot stop request-scoped validation, storage, streaming, or other external work after the caller has gone away. This was found while hardening large scene deployments in [worlds-content-server#512](https://github.com/decentraland/worlds-content-server/pull/512), where the handler correctly consumes `ctx.request.signal` but the HTTP server never changes it.

## How

- create a request-scoped `AbortController` for every HTTP request
- abort it with an `AbortError` when the `ServerResponse` closes before it has ended
- pass that signal through `getRequestFromNodeMessage` into the Fetch `Request`
- keep the one-shot disconnect listener active through streamed response completion, so proxy/SSE-style work is cancelled if the client leaves after middleware returns
- apply the same behavior while upgrade middleware is deciding whether to accept a WebSocket
- handle both `end` and `close` for pending upgrades because a client may half-close while the server is still waiting on middleware
- remove upgrade listeners after middleware processing finishes
- if middleware handles cancellation and returns normally, safely discard any unconsumed Node response stream, handle errors raised during its destruction without removing application-owned listeners, and do not write or pass an abandoned socket to the WebSocket server
- suppress only the exact expected disconnect reason after an abandoned upgrade while continuing to log unrelated middleware errors
- avoid logging or attempting to write a 500 after an HTTP response connection is already destroyed
- add a minor changeset for `@dcl/http-server`

Normal HTTP response completion does not abort the request signal. HTTP close listeners are one-shot and remain attached until the response lifecycle actually ends, while upgrade listeners are removed once the handshake middleware finishes.

## Verification

- `corepack pnpm --filter @dcl/core-commons build`
- `corepack pnpm --filter @dcl/http-server build`
- `corepack pnpm --filter @dcl/http-server lint`
- complete HTTP-server suite: 421 passed, 4 skipped across 13 suites
- real-server coverage for native Fetch, status-enabled server, and Undici client disconnects
- regression coverage for active handlers, streamed responses, normal completion, handlers returning after cancellation, erroring stream disposal with and without application listeners, pending WebSocket upgrades, half-closed upgrade transports, and directly mocked expected-disconnect logging
