### PR TITLE
refactor(test-helpers): drop @dcl/crypto-middleware in favour of @dcl/crypto

### DIFF
--- a/.changeset/test-helpers-drop-crypto-middleware.md
+++ b/.changeset/test-helpers-drop-crypto-middleware.md
@@ -1,0 +1,5 @@
+---
+'@dcl/test-helpers': minor
+---
+
+Drop the `@dcl/crypto-middleware` dependency and read the three signed-fetch header names from `@dcl/crypto` instead, raising the `@dcl/crypto` range to `^3.7.0` (the version that first exports them). This package only ever imported `AUTH_CHAIN_HEADER_PREFIX`, `AUTH_TIMESTAMP_HEADER` and `AUTH_METADATA_HEADER` from the middleware and never called `verify`, and the middleware marks its own re-exports of those constants `@deprecated Import from '@dcl/crypto' directly`. Consumers that hold their own direct `@dcl/crypto-middleware` dependency no longer get a second, unrelated major of it installed nested under this package. No behaviour or public API change.

--- a/components/test-helpers/package.json
+++ b/components/test-helpers/package.json
@@ -21,8 +21,7 @@
   },
   "dependencies": {
     "@dcl/core-commons": "workspace:*",
-    "@dcl/crypto": "^3.4.5",
-    "@dcl/crypto-middleware": "^4.0.0",
+    "@dcl/crypto": "^3.7.0",
     "@well-known-components/interfaces": "^1.5.2"
   },
   "peerDependencies": {

--- a/components/test-helpers/src/auth.ts
+++ b/components/test-helpers/src/auth.ts
@@ -1,11 +1,6 @@
-import { Authenticator } from '@dcl/crypto'
+import { AUTH_CHAIN_HEADER_PREFIX, AUTH_METADATA_HEADER, AUTH_TIMESTAMP_HEADER, Authenticator } from '@dcl/crypto'
 import type { AuthIdentity, AuthLink, IdentityType } from '@dcl/crypto'
 import { createUnsafeIdentity } from '@dcl/crypto/dist/crypto'
-import {
-  AUTH_CHAIN_HEADER_PREFIX,
-  AUTH_METADATA_HEADER,
-  AUTH_TIMESTAMP_HEADER
-} from '@dcl/crypto-middleware'
 
 /**
  * A test identity: an ephemeral key, the real account that authorized it, and

--- a/components/test-helpers/tests/auth-fetch.spec.ts
+++ b/components/test-helpers/tests/auth-fetch.spec.ts
@@ -1,6 +1,6 @@
 import * as http from 'http'
 import { IConfigComponent } from '@well-known-components/interfaces'
-import { AUTH_CHAIN_HEADER_PREFIX, AUTH_METADATA_HEADER, AUTH_TIMESTAMP_HEADER } from '@dcl/crypto-middleware'
+import { AUTH_CHAIN_HEADER_PREFIX, AUTH_METADATA_HEADER, AUTH_TIMESTAMP_HEADER } from '@dcl/crypto'
 import { createLocalFetchComponent, defaultServerConfig, getIdentity } from '../src'
 import type { Identity } from '../src'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,11 +439,8 @@ importers:
         specifier: workspace:*
         version: link:../../shared/commons
       '@dcl/crypto':
-        specifier: ^3.4.5
+        specifier: ^3.7.0
         version: 3.7.0
-      '@dcl/crypto-middleware':
-        specifier: ^4.0.0
-        version: 4.0.0
       '@types/jest':
         specifier: '>=29'
         version: 30.0.0
@@ -1108,21 +1105,6 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
-
-  '@dcl/core-commons@0.10.0':
-    resolution: {integrity: sha512-lcCgnwxkq/MoTbU59wKnspmVaQyEIP8SRRDUCd3Werrwj+nsH6T7xGuVo17cLVEd8D/Hi3NLFtBiq+N7kZAt/A==}
-
-  '@dcl/crypto-middleware@4.0.0':
-    resolution: {integrity: sha512-j12R22lMBYk5zwXRzoKxGvU+F8IER+iV9buehbriHPkxVQdBOBqS0EoWtREpanGW1MLhHqoAijsOft1hXzc/rA==}
-    engines: {node: '>=22.0.0'}
-    peerDependencies:
-      express: ^4.0.0 || ^5.0.0
-      koa: ^2.0.0
-    peerDependenciesMeta:
-      express:
-        optional: true
-      koa:
-        optional: true
 
   '@dcl/crypto@3.7.0':
     resolution: {integrity: sha512-8HSFLxnIHDeA8I/6yGAUwbCin2TX2oPn2uBLj5UmR0NFAyN5wYJCqbeolaJaIdmqN9RFjdb9ixKOY4uKF5Q2XA==}
@@ -6210,15 +6192,6 @@ snapshots:
       human-id: 4.1.1
       prettier: 2.8.8
 
-  '@dcl/core-commons@0.10.0':
-    dependencies:
-      '@well-known-components/interfaces': 1.5.2
-
-  '@dcl/crypto-middleware@4.0.0':
-    dependencies:
-      '@dcl/core-commons': 0.10.0
-      '@dcl/crypto': 3.7.0
-
   '@dcl/crypto@3.7.0':
     dependencies:
       '@dcl/schemas': 25.3.0
@@ -6287,7 +6260,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1
+      debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -6324,7 +6297,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.1
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7922,7 +7895,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.3)
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.8.3)
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.57.1
       ts-api-utils: 1.4.3(typescript@5.8.3)
     optionalDependencies:
@@ -7936,11 +7909,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.1
+      debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
-      semver: 7.7.2
+      semver: 7.7.3
       ts-api-utils: 1.4.3(typescript@5.8.3)
     optionalDependencies:
       typescript: 5.8.3
@@ -7956,7 +7929,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.3)
       eslint: 8.57.1
-      semver: 7.7.2
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
## Description

`@dcl/test-helpers` declared `@dcl/crypto-middleware` but only ever imported three signed-fetch header names from it — `AUTH_CHAIN_HEADER_PREFIX`, `AUTH_TIMESTAMP_HEADER`, `AUTH_METADATA_HEADER` — and never called `verify`. All three already live in `@dcl/crypto`, which is already a dependency of this package, and the middleware marks its own re-exports of them `@deprecated Import from '@dcl/crypto' directly`. This PR drops the dependency.

**Why this matters beyond tidiness.** A test-only package pulling in a server middleware meant consumers with their own direct `@dcl/crypto-middleware` dependency got a *second, unrelated major* installed nested underneath this one. During the ongoing `@dcl/crypto-middleware@5.1.0` rollout that surfaced in ~10 Decentraland services as a stale `@dcl/test-helpers/node_modules/@dcl/crypto-middleware@4.x` sitting next to the 5.1.0 they had just installed. It is inert — this package never calls `verify`, so no request is ever verified by the old copy — but it broke the one-copy check (`find node_modules -path '*@dcl/crypto-middleware/package.json'`) that the rollout used to confirm the upgrade had actually landed. Fixing it here fixes it in every consumer at once.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Infrastructure / CI/CD
- [ ] Performance improvement

## Changes Made

- `components/test-helpers/src/auth.ts`: the three header constants now come from `@dcl/crypto`, folded into the existing `@dcl/crypto` import.
- `components/test-helpers/tests/auth-fetch.spec.ts`: same import repointed.
- `components/test-helpers/package.json`: `@dcl/crypto-middleware` removed; `@dcl/crypto` `^3.4.5` → `^3.7.0`.
- `.changeset/test-helpers-drop-crypto-middleware.md`: `minor` for `@dcl/test-helpers`.

### Why the `@dcl/crypto` floor has to move

`3.7.0` is the **first** version to export these constants — `dist/headers.js` does not exist in 3.4.5, 3.5.0 or 3.6.0 (checked by unpacking each from the registry). Resolution happened to land on 3.7.0 already via the caret, so tests would have passed either way, but leaving the floor at `^3.4.5` would declare a range that cannot satisfy the new imports. A consumer pinning `@dcl/crypto` to 3.4.x is the case that would have broken.

## How to Test

1. `pnpm install`
2. `pnpm build` — required before testing `test-helpers` in isolation, since `@dcl/core-commons` is a `workspace:*` sibling and `tsc` needs its `dist/`. Running `pnpm --filter @dcl/test-helpers build` on a clean checkout fails with `TS2307: Cannot find module '@dcl/core-commons'`, which looks like a missing dependency but is just build order.
3. `pnpm test`
4. Confirm the dependency is genuinely gone, not just unimported:
   ```sh
   grep -rn "crypto-middleware" components/test-helpers/dist/   # no output
   grep -n "crypto-middleware" pnpm-lock.yaml                   # no test-helpers importer entry
   ```
   The lockfile drops both `@dcl/crypto-middleware@4.0.0` and the `@dcl/core-commons@0.10.0` copy it dragged in.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code for obvious errors
- [x] Added or updated tests where applicable — no new tests; this is an import-source change with no behaviour to cover, and the existing `auth-fetch.spec.ts` already exercises the constants end to end through a real signed request
- [x] Existing tests pass locally — full monorepo suite green, including `test-helpers` 3 suites / 23 tests
- [x] Updated documentation if needed — changeset added
- [x] No new warnings or console errors introduced

`pnpm build` and `pnpm lint` are both clean across the workspace.

## Related Issues

Part of the `@dcl/crypto-middleware@5.1.0` rollout across Decentraland services. Item 4 of the rollout's open decisions: `@dcl/test-helpers` should drop the middleware dependency entirely rather than widen its range.

## Screenshots

Not applicable.
